### PR TITLE
Feature/multi date select

### DIFF
--- a/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.md
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.md
@@ -1,0 +1,51 @@
+# DateRangeCalendar
+
+DateRangeCalendar is a controlled component, just like all other form inputs.
+
+It requires a bit more state than the usual `value`:
+
+* startDate
+* endDate
+* focusedInput
+
+These must be provided as props, as well as their setters.
+`value` is not used.
+
+```
+<DateRangeCalendar
+  startDate={startDate}
+  endDate={endDate}
+  focusedInput={focusedInput}
+  setStartDate={setStartDate}
+  setEndDate={setEndDate}
+  setFocusedInput={setFocusedInput}
+  onChange={onChangeHandler}
+/>
+```
+
+## onChange
+
+The `onChange` props works as usual, but will provide an object with `{ startDate, endDate }`.
+
+## The hook
+
+You can simplify this by using the provided hook `useDateRangeCalendarState`.
+
+Creating a wrapper component can look like this:
+
+```
+  const dateRangeStateProps = useDateRangeCalendarState();
+
+  return <DateRangeCalendar {...dateRangeStateProps} onChange={onChange} />;
+```
+
+The hook will provide the required state props, and the user only provides `onChange`.
+
+The component is no longer controlled.  This means that the component controls 
+what dates are selected, and you can use `onChange` to listen to changes in the 
+selected dates.
+
+### Preselecting dates
+
+If you need to preselect dates, you will have to call the `setStartDate` 
+and `setEndDate` methods provided by the hook.

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.stories.tsx
@@ -7,6 +7,9 @@ import {
 import { storiesOf } from "@storybook/react";
 import { addDays } from "date-fns";
 import * as React from "react";
+import { DateRangeCalendarProps } from "./DateRangeCalendar";
+import markdown from "./DateRangeCalendar.md";
+import { useDateRangeCalendarState } from "./hooks/UseDateRangeCalendarState";
 
 let statePerMonthWithTwoWeeksEnabled = {};
 for (let i = 1; i < 7; i++) {
@@ -34,6 +37,13 @@ interface State {
   focusedInput: DateRangeFocusedInput;
 }
 
+function DateRangeCalendarWithState<T>({
+  onChange
+}: Pick<DateRangeCalendarProps<T>, "onChange">) {
+  const calendarProps = useDateRangeCalendarState();
+  return <DateRangeCalendar {...calendarProps} onChange={onChange} />;
+}
+
 storiesOf("calendar/Calendar/DateRangeCalendar", module)
   .add(
     "standard",
@@ -50,8 +60,12 @@ storiesOf("calendar/Calendar/DateRangeCalendar", module)
         setEndDate={endDate => store.set({ endDate })}
         setFocusedInput={focusedInput => store.set({ focusedInput })}
       />
-    ))
+    )),
+    {
+      notes: { markdown }
+    }
   )
+  .add("with state hook", () => <DateRangeCalendarWithState />)
   .add(
     "with today highlighted",
     withState<State>({

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.stories.tsx
@@ -1,15 +1,15 @@
 import { Store, withState } from "@dump247/storybook-state";
 import {
   DateRangeCalendar,
+  DateRangeCalendarProps,
   DateRangeFocusedInput,
-  setDayStateValue
+  setDayStateValue,
+  useDateRangeCalendarState
 } from "@stenajs-webui/calendar";
 import { storiesOf } from "@storybook/react";
 import { addDays } from "date-fns";
 import * as React from "react";
-import { DateRangeCalendarProps } from "./DateRangeCalendar";
 import markdown from "./DateRangeCalendar.md";
-import { useDateRangeCalendarState } from "./hooks/UseDateRangeCalendarState";
 
 let statePerMonthWithTwoWeeksEnabled = {};
 for (let i = 1; i < 7; i++) {

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.tsx
@@ -4,7 +4,7 @@ import {
   CalendarWithMonthSwitcherProps
 } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 
-import { useDateRangeSelection } from "./UseDateRangeSelection";
+import { useDateRangeSelection } from "./hooks/UseDateRangeSelection";
 
 export type DateRangeFocusedInput = "startDate" | "endDate" | undefined;
 

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/UseDateRangeSelection.ts
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/UseDateRangeSelection.ts
@@ -1,8 +1,6 @@
-import { isAfter } from "date-fns";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
+import { useDateRangeOnClickDayHandler } from "../../../features/date-range/hooks/UseDateRangeOnClickDayHandler";
 import { CalendarProps } from "../../../types/CalendarTypes";
-import { DayData } from "../../../util/calendar/CalendarDataFactory";
-import { ensureStartIsFirst } from "../../../util/calendar/CalendarIntervalValidator";
 import { DateRangeCalendarProps } from "./DateRangeCalendar";
 import { buildDayState } from "./util/DayStateFactory";
 import { toggleDatesIfEndIsEarlierThanStart } from "./util/IntervalSwitcher";
@@ -17,57 +15,14 @@ export const useDateRangeSelection = <T>({
   setFocusedInput,
   statePerMonth
 }: DateRangeCalendarProps<T>): CalendarProps<T> => {
-  const onClickDay = useCallback(
-    (day: DayData) => {
-      if (focusedInput === "startDate") {
-        if (endDate && isAfter(day.date, endDate)) {
-          setStartDate(endDate);
-          setEndDate(day.date);
-          if (onChange) {
-            onChange({ startDate: endDate, endDate: day.date });
-          }
-        } else {
-          setStartDate(day.date);
-          setFocusedInput("endDate");
-          if (onChange) {
-            onChange(
-              ensureStartIsFirst({
-                startDate: day.date,
-                endDate: endDate
-              })
-            );
-          }
-        }
-      } else if (focusedInput === "endDate") {
-        if (startDate && isAfter(startDate, day.date)) {
-          setStartDate(day.date);
-          setEndDate(startDate);
-          if (onChange) {
-            onChange({ startDate: day.date, endDate: startDate });
-          }
-        } else {
-          setEndDate(day.date);
-          setFocusedInput("startDate");
-          if (onChange) {
-            onChange(
-              ensureStartIsFirst({
-                startDate: startDate,
-                endDate: day.date
-              })
-            );
-          }
-        }
-      }
-    },
-    [
-      focusedInput,
-      endDate,
-      startDate,
-      setStartDate,
-      setEndDate,
-      onChange,
-      setFocusedInput
-    ]
+  const onClickDay = useDateRangeOnClickDayHandler(
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    focusedInput,
+    setFocusedInput,
+    onChange
   );
 
   const dates = useMemo(

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/hooks/UseDateRangeCalendarState.ts
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/hooks/UseDateRangeCalendarState.ts
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import { DateRangeFocusedInput } from "../DateRangeCalendar";
+
+export const useDateRangeCalendarState = () => {
+  const [startDate, setStartDate] = useState<Date | undefined>();
+  const [endDate, setEndDate] = useState<Date | undefined>();
+  const [focusedInput, setFocusedInput] = useState<DateRangeFocusedInput>(
+    "startDate"
+  );
+  return {
+    startDate,
+    setStartDate,
+    endDate,
+    setEndDate,
+    focusedInput,
+    setFocusedInput
+  };
+};

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/hooks/UseDateRangeSelection.ts
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/hooks/UseDateRangeSelection.ts
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
-import { useDateRangeOnClickDayHandler } from "../../../features/date-range/hooks/UseDateRangeOnClickDayHandler";
-import { CalendarProps } from "../../../types/CalendarTypes";
-import { DateRangeCalendarProps } from "./DateRangeCalendar";
-import { buildDayState } from "./util/DayStateFactory";
-import { toggleDatesIfEndIsEarlierThanStart } from "./util/IntervalSwitcher";
+import { useDateRangeOnClickDayHandler } from "../../../../features/date-range/hooks/UseDateRangeOnClickDayHandler";
+import { CalendarProps } from "../../../../types/CalendarTypes";
+import { DateRangeCalendarProps } from "../DateRangeCalendar";
+import { buildDayState } from "../util/DayStateFactory";
+import { toggleDatesIfEndIsEarlierThanStart } from "../util/IntervalSwitcher";
 
 export const useDateRangeSelection = <T>({
   focusedInput,

--- a/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.stories.tsx
@@ -1,0 +1,208 @@
+import { Store, withState } from "@dump247/storybook-state";
+import { faCoffee } from "@fortawesome/free-solid-svg-icons/faCoffee";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  CalendarTheme,
+  extranetCalendarTheme,
+  MultiDateCalendar,
+  OnClickWeek,
+  RenderWeekNumber,
+  setDayStateValue,
+  WeekData,
+  WeekNumberCell
+} from "@stenajs-webui/calendar";
+import { Box, Row, Space } from "@stenajs-webui/core";
+import { storiesOf } from "@storybook/react";
+import { addDays, getISOWeek } from "date-fns";
+import * as React from "react";
+
+interface State {
+  value: Array<Date>;
+}
+
+const disabledTomorrow = setDayStateValue(undefined, addDays(new Date(), 1), {
+  highlights: ["disabled"]
+});
+
+let statePerMonthWithTwoWeeksEnabled = {};
+for (let i = 1; i < 7; i++) {
+  statePerMonthWithTwoWeeksEnabled = setDayStateValue(
+    statePerMonthWithTwoWeeksEnabled,
+    addDays(new Date(), i),
+    {
+      highlights: ["enabled"]
+    }
+  );
+}
+for (let i = 10; i < 14; i++) {
+  statePerMonthWithTwoWeeksEnabled = setDayStateValue(
+    statePerMonthWithTwoWeeksEnabled,
+    addDays(new Date(), i),
+    {
+      highlights: ["enabled"]
+    }
+  );
+}
+
+storiesOf("calendar/Calendar/MultiDateCalendar", module)
+  .add(
+    "standard",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => (
+      <MultiDateCalendar
+        onChange={value => store.set({ value })}
+        value={store.state.value}
+      />
+    ))
+  )
+  .add(
+    "today highlighted",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => (
+      <MultiDateCalendar
+        highlightToday
+        onChange={value => store.set({ value })}
+        value={store.state.value}
+      />
+    ))
+  )
+  .add(
+    "with disabled date tomorrow",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => (
+      <MultiDateCalendar
+        onChange={value => store.set({ value })}
+        value={store.state.value}
+        statePerMonth={disabledTomorrow}
+      />
+    ))
+  )
+  .add(
+    "with disabled as default",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => (
+      <MultiDateCalendar
+        defaultHighlights={["disabled"]}
+        onChange={value => store.set({ value })}
+        value={store.state.value}
+        statePerMonth={statePerMonthWithTwoWeeksEnabled}
+      />
+    ))
+  )
+  .add(
+    "with month switcher below",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => (
+      <MultiDateCalendar
+        onChange={value => store.set({ value })}
+        value={store.state.value}
+        monthSwitcherPlacement={"below"}
+      />
+    ))
+  )
+  .add(
+    "with multiple months",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => (
+      <MultiDateCalendar
+        onChange={value => store.set({ value })}
+        numMonths={3}
+        value={store.state.value}
+      />
+    ))
+  )
+  .add(
+    "with multiple rows",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => (
+      <MultiDateCalendar
+        onChange={value => store.set({ value })}
+        numMonths={6}
+        monthsPerRow={3}
+        value={store.state.value}
+      />
+    ))
+  )
+  .add(
+    "with custom week content",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => {
+      const renderWeekNumber: RenderWeekNumber = (
+        week: WeekData,
+        theme: CalendarTheme,
+        onClick?: OnClickWeek
+      ) => {
+        const now = new Date();
+        return (
+          <WeekNumberCell
+            week={week}
+            onClickWeek={onClick}
+            theme={theme}
+            background={
+              week.startYear === now.getFullYear() &&
+              week.weekNumber === getISOWeek(now) ? (
+                <FontAwesomeIcon
+                  icon={faCoffee}
+                  color={"blue"}
+                  style={{ fontSize: 30 }}
+                />
+              ) : (
+                undefined
+              )
+            }
+          />
+        );
+      };
+
+      return (
+        <MultiDateCalendar
+          onChange={value => store.set({ value })}
+          value={store.state.value}
+          renderWeekNumber={renderWeekNumber}
+        />
+      );
+    })
+  )
+  .add(
+    "with custom content",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => (
+      <MultiDateCalendar
+        onChange={value => store.set({ value })}
+        value={store.state.value}
+        extraDayContent={() => (
+          <Box position={"absolute"} top={"-10px"} right={"-10px"}>
+            <FontAwesomeIcon icon={faCoffee} />
+          </Box>
+        )}
+      />
+    ))
+  )
+  .add(
+    "with instance custom theme",
+    withState<State>({
+      value: []
+    })(({ store }: { store: Store<State> }) => (
+      <Row>
+        <MultiDateCalendar
+          onChange={value => store.set({ value })}
+          value={store.state.value}
+          theme={extranetCalendarTheme}
+        />
+        <Space num={2} />
+        <MultiDateCalendar
+          onChange={value => store.set({ value })}
+          value={store.state.value}
+        />
+      </Row>
+    ))
+  );

--- a/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.stories.tsx
@@ -11,7 +11,7 @@ import {
   WeekData,
   WeekNumberCell
 } from "@stenajs-webui/calendar";
-import { Box, Row, Space } from "@stenajs-webui/core";
+import { Box, Row, Space, StandardText } from "@stenajs-webui/core";
 import { storiesOf } from "@storybook/react";
 import { addDays, getISOWeek } from "date-fns";
 import * as React from "react";
@@ -50,10 +50,20 @@ storiesOf("calendar/Calendar/MultiDateCalendar", module)
     withState<State>({
       value: []
     })(({ store }: { store: Store<State> }) => (
-      <MultiDateCalendar
-        onChange={value => store.set({ value })}
-        value={store.state.value}
-      />
+      <>
+        <MultiDateCalendar
+          onChange={value => store.set({ value })}
+          value={store.state.value}
+        />
+        <Space />
+        <Box background={"#eee"} spacing={2} indent={2}>
+          <StandardText>Click to select date range.</StandardText>
+          <Space />
+          <StandardText>
+            Hold ctrl (or cmd) and click to toggle individual dates.
+          </StandardText>
+        </Box>
+      </>
     ))
   )
   .add(

--- a/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.tsx
@@ -9,7 +9,7 @@ import { useMultiDateSelection } from "./UseMultiDateSelection";
 export interface MultiDateCalendarProps<T>
   extends CalendarWithMonthSwitcherProps<T> {
   value: Array<Date> | undefined;
-  onChange: (value: Array<Date>) => void;
+  onChange?: (value: Array<Date>) => void;
 }
 
 export function MultiDateCalendar<T extends {}>(

--- a/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import {
+  CalendarWithMonthSwitcher,
+  CalendarWithMonthSwitcherProps
+} from "../../../features/month-switcher/CalendarWithMonthSwitcher";
+
+import { useMultiDateSelection } from "./UseMultiDateSelection";
+
+export interface MultiDateCalendarProps<T>
+  extends CalendarWithMonthSwitcherProps<T> {
+  value: Array<Date> | undefined;
+  onChange: (value: Array<Date>) => void;
+}
+
+export function MultiDateCalendar<T extends {}>(
+  props: MultiDateCalendarProps<T>
+) {
+  const singleDateSelectionProps = useMultiDateSelection(props);
+  return (
+    <CalendarWithMonthSwitcher<T> {...props} {...singleDateSelectionProps} />
+  );
+}

--- a/packages/calendar/src/components/calendar-types/multi-date-calendar/UseMultiDateSelection.ts
+++ b/packages/calendar/src/components/calendar-types/multi-date-calendar/UseMultiDateSelection.ts
@@ -1,0 +1,53 @@
+import { useCallback, useMemo } from "react";
+import {
+  CalendarProps,
+  CalendarState,
+  OnClickDay
+} from "../../../types/CalendarTypes";
+import { addDayStateHighlights } from "../../../util/calendar/StateModifier";
+import {
+  listContainsDate,
+  removeDateIfExist
+} from "../../../util/date/DateListTools";
+import { MultiDateCalendarProps } from "./MultiDateCalendar";
+
+export const useMultiDateSelection = <T>({
+  onChange,
+  value,
+  statePerMonth
+}: MultiDateCalendarProps<T>): Partial<CalendarProps<T>> => {
+  const onClickDay: OnClickDay<T> = useCallback(
+    day => {
+      if (onChange) {
+        if (!value) {
+          onChange([day.date]);
+        } else if (listContainsDate(value, day.date)) {
+          onChange(removeDateIfExist(value, day.date));
+        } else {
+          onChange([...value, day.date]);
+        }
+      }
+    },
+    [onChange]
+  );
+  const statePerMonthWithSelectedDate = useMemo(() => {
+    return addHighlighting(statePerMonth, value);
+  }, [statePerMonth, value]);
+
+  return {
+    onClickDay,
+    statePerMonth: statePerMonthWithSelectedDate
+  };
+};
+
+const addHighlighting = (
+  statePerMonth: CalendarState | undefined,
+  dateList: Array<Date> | undefined
+): CalendarState | undefined => {
+  if (!dateList) {
+    return statePerMonth;
+  }
+  return dateList.reduce((statePerMonth, date) => {
+    return addDayStateHighlights(statePerMonth, date, ["selected"]);
+  }, statePerMonth);
+};

--- a/packages/calendar/src/components/calendar/renderers/CalendarDay.tsx
+++ b/packages/calendar/src/components/calendar/renderers/CalendarDay.tsx
@@ -108,7 +108,7 @@ export const CalendarDay = <T extends {}>({
               )}
               {onClickDay && isClickable(defaultHighlights, dayState) ? (
                 <Clickable
-                  onClick={() => onClickDay(day, userData)}
+                  onClick={ev => onClickDay(day, userData, ev)}
                   style={{ width: "100%", height: "100%" }}
                 >
                   {content}

--- a/packages/calendar/src/components/calendar/renderers/WeekDayCell.tsx
+++ b/packages/calendar/src/components/calendar/renderers/WeekDayCell.tsx
@@ -1,5 +1,6 @@
 import { Box, StandardText, useThemeFields } from "@stenajs-webui/core";
 import * as React from "react";
+import { Clickable } from "@stenajs-webui/core";
 import { OnClickWeekDay } from "../../../types/CalendarTypes";
 import { DayData } from "../../../util/calendar/CalendarDataFactory";
 import { CalendarTheme } from "../CalendarTheme";
@@ -25,8 +26,11 @@ export const WeekDayCell = ({
   );
 
   return (
-    <div
-      onClick={onClickWeekDay ? () => onClickWeekDay(day.dayOfWeek) : undefined}
+    <Clickable
+      onClick={
+        onClickWeekDay ? ev => onClickWeekDay(day.dayOfWeek, ev) : undefined
+      }
+      disableFocusHighlight={!onClickWeekDay}
     >
       <Box
         width={theme.width}
@@ -36,6 +40,6 @@ export const WeekDayCell = ({
       >
         <StandardText color={colors.textColor}>{day.name}</StandardText>
       </Box>
-    </div>
+    </Clickable>
   );
 };

--- a/packages/calendar/src/components/calendar/renderers/WeekNumberCell.tsx
+++ b/packages/calendar/src/components/calendar/renderers/WeekNumberCell.tsx
@@ -37,8 +37,8 @@ export const WeekNumberCell: React.FC<WeekNumberCellProps> = ({
       position={"relative"}
     >
       <Clickable
-        onClick={onClickWeek ? () => onClickWeek(week) : undefined}
-        disableFocusHighlight
+        onClick={onClickWeek ? ev => onClickWeek(week, ev) : undefined}
+        disableFocusHighlight={!onClickWeek}
       >
         <Box
           width={theme.width}

--- a/packages/calendar/src/features/date-range/hooks/UseDateRangeOnClickDayHandler.ts
+++ b/packages/calendar/src/features/date-range/hooks/UseDateRangeOnClickDayHandler.ts
@@ -1,0 +1,74 @@
+import { isAfter } from "date-fns";
+import { useCallback } from "react";
+import { DateRangeFocusedInput } from "../../../components/calendar-types/date-range-calendar/DateRangeCalendar";
+import { OnClickDay } from "../../../types/CalendarTypes";
+import { DayData } from "../../../util/calendar/CalendarDataFactory";
+import { ensureStartIsFirst } from "../../../util/calendar/CalendarIntervalValidator";
+
+export interface DateRangeOnChangeValue {
+  startDate?: Date;
+  endDate?: Date;
+}
+
+export const useDateRangeOnClickDayHandler = <T>(
+  startDate: Date | undefined,
+  setStartDate: (startDate: Date) => void,
+  endDate: Date | undefined,
+  setEndDate: (endDate: Date) => void,
+  focusedInput: DateRangeFocusedInput,
+  setFocusedInput: (focusedInput: DateRangeFocusedInput) => void,
+  onChange?: (value: DateRangeOnChangeValue) => void
+): OnClickDay<T> => {
+  return useCallback(
+    (day: DayData) => {
+      if (focusedInput === "startDate") {
+        if (endDate && isAfter(day.date, endDate)) {
+          setStartDate(endDate);
+          setEndDate(day.date);
+          if (onChange) {
+            onChange({ startDate: endDate, endDate: day.date });
+          }
+        } else {
+          setStartDate(day.date);
+          setFocusedInput("endDate");
+          if (onChange) {
+            onChange(
+              ensureStartIsFirst({
+                startDate: day.date,
+                endDate: endDate
+              })
+            );
+          }
+        }
+      } else if (focusedInput === "endDate") {
+        if (startDate && isAfter(startDate, day.date)) {
+          setStartDate(day.date);
+          setEndDate(startDate);
+          if (onChange) {
+            onChange({ startDate: day.date, endDate: startDate });
+          }
+        } else {
+          setEndDate(day.date);
+          setFocusedInput("startDate");
+          if (onChange) {
+            onChange(
+              ensureStartIsFirst({
+                startDate: startDate,
+                endDate: day.date
+              })
+            );
+          }
+        }
+      }
+    },
+    [
+      focusedInput,
+      endDate,
+      startDate,
+      setStartDate,
+      setEndDate,
+      onChange,
+      setFocusedInput
+    ]
+  );
+};

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -4,6 +4,8 @@ export * from "./components/calendar-types/single-date-calendar/SingleDateCalend
 export * from "./components/calendar-types/single-date-calendar/UseSingleDateSelection";
 export * from "./components/calendar-types/single-week-calendar/SingleWeekCalendar";
 export * from "./components/calendar-types/single-week-calendar/UseSingleWeekSelection";
+export * from "./components/calendar-types/multi-date-calendar/MultiDateCalendar";
+export * from "./components/calendar-types/multi-date-calendar/UseMultiDateSelection";
 export * from "./components/input-types/date-input/DateInput";
 export * from "./components/input-types/date-input/DateInputTheme";
 export * from "./components/input-types/date-range-input/DateRangeInput";

--- a/packages/calendar/src/index.ts
+++ b/packages/calendar/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./components/calendar-types/date-range-calendar/DateRangeCalendar";
-export * from "./components/calendar-types/date-range-calendar/UseDateRangeSelection";
+export * from "./components/calendar-types/date-range-calendar/hooks/UseDateRangeSelection";
+export * from "./components/calendar-types/date-range-calendar/hooks/UseDateRangeCalendarState";
 export * from "./components/calendar-types/single-date-calendar/SingleDateCalendar";
 export * from "./components/calendar-types/single-date-calendar/UseSingleDateSelection";
 export * from "./components/calendar-types/single-week-calendar/SingleWeekCalendar";

--- a/packages/calendar/src/types/CalendarTypes.tsx
+++ b/packages/calendar/src/types/CalendarTypes.tsx
@@ -119,9 +119,19 @@ export interface HighlightsState {
 }
 
 export type DayState = HighlightsState;
-export type OnClickDay<T> = (day: DayData, data?: T) => void;
-export type OnClickWeekDay = (weekDay: number) => void;
-export type OnClickWeek = (week: WeekData) => void;
+export type OnClickDay<T> = (
+  day: DayData,
+  data: T | undefined,
+  ev: React.MouseEvent<HTMLButtonElement>
+) => void;
+export type OnClickWeekDay = (
+  weekDay: number,
+  ev: React.MouseEvent<HTMLButtonElement>
+) => void;
+export type OnClickWeek = (
+  week: WeekData,
+  ev: React.MouseEvent<HTMLButtonElement>
+) => void;
 export type CalendarUserData<T> = { [key: string]: CalendarUserMonthData<T> };
 export type CalendarUserMonthData<T> = {
   [key: number]: CalendarUserWeekData<T>;

--- a/packages/calendar/src/util/date/DateListTools.ts
+++ b/packages/calendar/src/util/date/DateListTools.ts
@@ -1,0 +1,17 @@
+import { isSameDay } from "date-fns";
+
+export const addDateIfNotExists = (
+  list: Array<Date>,
+  date: Date
+): Array<Date> => {
+  if (list.filter(item => isSameDay(item, date)).length >= 1) {
+    return list;
+  }
+  return [...list, date];
+};
+
+export const removeDateIfExist = (list: Array<Date>, date: Date): Array<Date> =>
+  list.filter(item => !isSameDay(item, date));
+
+export const listContainsDate = (list: Array<Date>, date: Date): boolean =>
+  !!list.find(item => isSameDay(item, date));

--- a/packages/calendar/src/util/date/__tests__/DateListTools.test.ts
+++ b/packages/calendar/src/util/date/__tests__/DateListTools.test.ts
@@ -1,0 +1,53 @@
+import { addDays } from "date-fns";
+import {
+  addDateIfNotExists,
+  listContainsDate,
+  removeDateIfExist
+} from "../DateListTools";
+
+describe("DateListTool", () => {
+  const dateList = [new Date(), addDays(new Date(), 2), addDays(new Date(), 7)];
+
+  describe("addDateIfNotExists", () => {
+    describe("when date already exists in list", () => {
+      it("it should return unmodified list", () => {
+        expect(addDateIfNotExists(dateList, new Date()).length).toBe(3);
+      });
+    });
+    describe("when date does not exists in list", () => {
+      it("it should return new list with date added", () => {
+        expect(
+          addDateIfNotExists(dateList, addDays(new Date(), 14)).length
+        ).toBe(4);
+      });
+    });
+  });
+
+  describe("removeDateIfExist", () => {
+    describe("when date already exists in list", () => {
+      it("it should return a new list with date removed", () => {
+        expect(removeDateIfExist(dateList, new Date()).length).toBe(2);
+      });
+    });
+    describe("when date does not exists in list", () => {
+      it("it should return unmodified list", () => {
+        expect(
+          removeDateIfExist(dateList, addDays(new Date(), 14)).length
+        ).toBe(3);
+      });
+    });
+  });
+
+  describe("listContainsDate", () => {
+    describe("when date exists in list", () => {
+      it("returns true", () => {
+        expect(listContainsDate(dateList, new Date())).toBe(true);
+      });
+    });
+    describe("when date does not exists in list", () => {
+      it("returns false", () => {
+        expect(listContainsDate(dateList, addDays(new Date(), 14))).toBe(false);
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add `MultiDateCalendar` which enables user to select multiple dates.
Click on days for normal date range behavior.
Ctrl/cmd + click to toggle dates on and off.

Add `useDateRangeCalendarState` hook, which replaces the old `DateRangeCalendarWithState` component.

Add markdown notes for `DateRangeCalendar`.

![Screenshot 2019-08-13 at 10 03 57](https://user-images.githubusercontent.com/1266041/62927583-1d50a500-bdb7-11e9-8179-e3327b2b1623.png)
