### PR TITLE
Feature/add font weight to buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update design of `Spinner`.
 * Add `InputSpinner` which is used in buttons and input fields.
 * Merge the two individual theme prop for calendar and text input into one common theme prop for `DateTextInput`.
+* Add `fontWeight` to `ButtonTheme`.
 
 #### 0.0.33
 

--- a/packages/core/src/theme/hooks/UseThemeSelector.ts
+++ b/packages/core/src/theme/hooks/UseThemeSelector.ts
@@ -1,4 +1,5 @@
 import { DependencyList, useMemo } from "react";
+import { ThemeFontWeightField, ThemeFontWeights } from "../..";
 import { Theme } from "../Theme";
 import { ThemeColorField, ThemeColors } from "../theme-types/ThemeColors";
 import { ThemeFontField, ThemeFonts } from "../theme-types/ThemeFonts";
@@ -24,10 +25,12 @@ type ThemeFieldRecord<T> = Record<string, T | string | undefined>;
 type ColorFields = ThemeFieldRecord<ThemeColorField>;
 type FontFields = ThemeFieldRecord<ThemeFontField>;
 type FontSizesFields = ThemeFieldRecord<ThemeFontSizeField>;
+type FontWeightFields = ThemeFieldRecord<ThemeFontWeightField>;
 
 export type ThemeSelectorFields = {
   colors?: ColorFields;
   fontSizes?: FontFields;
+  fontWeights?: FontWeightFields;
   fonts?: FontSizesFields;
 };
 
@@ -46,16 +49,25 @@ export const useThemeFields = <TFields extends ThemeSelectorFields>(
       theme.fontSizes,
       fields.fontSizes
     );
+    const fontWeights = getFieldsFromPartOfTheme(
+      theme.fontWeights,
+      fields.fontWeights
+    );
     return {
       colors,
       fonts,
-      fontSizes
+      fontSizes,
+      fontWeights
     } as TFields;
   }, [theme, fields]);
 };
 
 const getFieldsFromPartOfTheme = <
-  TThemePart extends ThemeColors | ThemeFonts | ThemeFontSizes,
+  TThemePart extends
+    | ThemeColors
+    | ThemeFonts
+    | ThemeFontSizes
+    | ThemeFontWeights,
   TFields extends ThemeFieldRecord<keyof TThemePart>
 >(
   themePart: TThemePart,

--- a/packages/elements/src/components/ui/buttons/Button.tsx
+++ b/packages/elements/src/components/ui/buttons/Button.tsx
@@ -56,6 +56,7 @@ export interface ButtonTextProps {
   color: string;
   fontFamily: string;
   fontSize: string;
+  fontWeight: string | number;
 }
 
 export const Button: React.FC<ButtonProps> = React.memo(props => {
@@ -83,7 +84,8 @@ export const Button: React.FC<ButtonProps> = React.memo(props => {
     loadingSpinnerColor,
     loadingTextColor,
     font,
-    fontSize
+    fontSize,
+    fontWeight
   } = useButtonStateTheme(buttonTheme, props.textColor, disabled);
 
   const list = [];
@@ -102,6 +104,7 @@ export const Button: React.FC<ButtonProps> = React.memo(props => {
           color={successTextColor}
           fontSize={fontSize}
           fontFamily={font}
+          fontWeight={fontWeight}
         >
           {successLabel}
         </ButtonText>
@@ -120,6 +123,7 @@ export const Button: React.FC<ButtonProps> = React.memo(props => {
           color={loadingTextColor}
           fontSize={fontSize}
           fontFamily={font}
+          fontWeight={fontWeight}
         >
           {loadingLabel}
         </ButtonText>
@@ -138,7 +142,12 @@ export const Button: React.FC<ButtonProps> = React.memo(props => {
     }
     if (label) {
       list.push(
-        <ButtonText color={textColor} fontSize={fontSize} fontFamily={font}>
+        <ButtonText
+          color={textColor}
+          fontSize={fontSize}
+          fontFamily={font}
+          fontWeight={fontWeight}
+        >
           {label}
         </ButtonText>
       );
@@ -198,7 +207,7 @@ const ButtonText = styled.span<ButtonTextProps>`
   font-size: ${({ fontSize }) => fontSize};
   color: ${({ color }) => color};
   font-family: ${({ fontFamily }) => fontFamily};
-  font-weight: 600;
+  font-weight: ${({ fontWeight }) => fontWeight};
   letter-spacing: 1px;
   margin-top: -2px;
 `;

--- a/packages/elements/src/components/ui/buttons/ButtonTheme.ts
+++ b/packages/elements/src/components/ui/buttons/ButtonTheme.ts
@@ -1,7 +1,8 @@
 import {
   ThemeColorField,
   ThemeFontField,
-  ThemeFontSizeField
+  ThemeFontSizeField,
+  ThemeFontWeightField
 } from "@stenajs-webui/core";
 
 export interface ButtonTheme {
@@ -17,6 +18,8 @@ export interface ButtonTheme {
   font: ThemeFontField | string;
   /** The font of the button. */
   fontSize: ThemeFontSizeField | string;
+  /** The font weight of the button. */
+  fontWeight: ThemeFontWeightField | string;
   /** Border radius of the button. */
   borderRadius: string | undefined;
   /** Size of spacing between edges, icons and text. */
@@ -44,6 +47,7 @@ export const defaultButtonTheme: ButtonTheme = {
   bgColorDisabled: "disabledText",
   font: "buttons",
   fontSize: "normal",
+  fontWeight: "normal",
   borderRadius: "3px",
   numSpacing: 2,
   height: "40px",

--- a/packages/elements/src/components/ui/buttons/ButtonTheme.ts
+++ b/packages/elements/src/components/ui/buttons/ButtonTheme.ts
@@ -47,7 +47,7 @@ export const defaultButtonTheme: ButtonTheme = {
   bgColorDisabled: "disabledText",
   font: "buttons",
   fontSize: "normal",
-  fontWeight: "normal",
+  fontWeight: "600",
   borderRadius: "3px",
   numSpacing: 2,
   height: "40px",

--- a/packages/elements/src/components/ui/buttons/StandardButton.stories.tsx
+++ b/packages/elements/src/components/ui/buttons/StandardButton.stories.tsx
@@ -1,13 +1,29 @@
-import { faCoffee } from "@fortawesome/free-solid-svg-icons/faCoffee";
 import { faCheck } from "@fortawesome/free-solid-svg-icons/faCheck";
-import { StandardButton } from "@stenajs-webui/elements";
+import { faCoffee } from "@fortawesome/free-solid-svg-icons/faCoffee";
+import {
+  defaultStandardButtonTheme,
+  StandardButton
+} from "@stenajs-webui/elements";
 import { action } from "@storybook/addon-actions";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
+const customTheme = {
+  ...defaultStandardButtonTheme,
+  fontSize: "16px",
+  fontWeight: "300"
+};
+
 storiesOf("elements/Buttons/StandardButton", module)
   .add("default", () => (
     <StandardButton label={"Submit"} onClick={action("Button clicked")} />
+  ))
+  .add("custom theme", () => (
+    <StandardButton
+      label={"Submit"}
+      onClick={action("Button clicked")}
+      buttonTheme={customTheme}
+    />
   ))
   .add("disabled", () => (
     <StandardButton

--- a/packages/elements/src/components/ui/buttons/hooks/UseBottonStateTheme.ts
+++ b/packages/elements/src/components/ui/buttons/hooks/UseBottonStateTheme.ts
@@ -6,7 +6,7 @@ export const useButtonStateTheme = (
   textColor: ThemeColorField | string | undefined,
   disabled: boolean
 ) => {
-  const { colors, fontSizes, fonts } = useThemeFields(
+  const { colors, fontSizes, fontWeights, fonts } = useThemeFields(
     {
       colors: {
         textColor: textColor || buttonTheme.textColor,
@@ -23,6 +23,9 @@ export const useButtonStateTheme = (
       },
       fonts: {
         font: buttonTheme.font
+      },
+      fontWeights: {
+        fontWeight: buttonTheme.fontWeight
       }
     },
     [buttonTheme]
@@ -35,6 +38,7 @@ export const useButtonStateTheme = (
     loadingSpinnerColor: colors.loadingSpinnerColor,
     loadingTextColor: colors.loadingTextColor,
     fontSize: fontSizes.fontSize,
-    font: fonts.font
+    font: fonts.font,
+    fontWeight: fontWeights.fontWeight
   };
 };

--- a/packages/elements/src/components/ui/spinner/InputSpinner.stories.tsx
+++ b/packages/elements/src/components/ui/spinner/InputSpinner.stories.tsx
@@ -1,4 +1,3 @@
-import { Column, Space, StandardText } from "@stenajs-webui/core";
 import { InputSpinner } from "@stenajs-webui/elements";
 import { color } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";

--- a/packages/panels/src/components/nav-bar/NavBarButtonTheme.ts
+++ b/packages/panels/src/components/nav-bar/NavBarButtonTheme.ts
@@ -9,6 +9,8 @@ export interface NavBarButtonTheme extends ButtonTheme {
 export const defaultNavBarButtonTheme: NavBarButtonTheme = {
   ...defaultFlatButtonTheme,
   height: "50px",
+  fontSize: "16px",
+  fontWeight: "normal",
   textColorSelected: "navBarBgButtonText",
   textColorNotSelected: "navBarBgButtonTextFaded"
 };


### PR DESCRIPTION
Now possible to set font-weight in ButtonTheme. Added story with example:
<img width="153" alt="Screenshot 2019-08-23 at 19 18 42" src="https://user-images.githubusercontent.com/1266041/63610893-d8a8e300-c5da-11e9-97df-72a02edcdf09.png">

Also updated NavBarButton as per Ozcars design.
<img width="527" alt="Screenshot 2019-08-23 at 19 18 35" src="https://user-images.githubusercontent.com/1266041/63610922-efe7d080-c5da-11e9-8c2d-1fc032199eb6.png">

