### PR TITLE
Add hoverColor prop to text components

### DIFF
--- a/packages/core/src/components/text/TextBase.tsx
+++ b/packages/core/src/components/text/TextBase.tsx
@@ -6,6 +6,7 @@ import {
   UserSelectProperty,
   WhiteSpaceProperty
 } from "csstype";
+import * as React from "react";
 import {
   fontFamily,
   FontFamilyProps,
@@ -18,11 +19,13 @@ import {
   textAlign,
   TextAlignProps
 } from "styled-system";
+import { useThemeFields } from "../../theme/hooks/UseThemeSelector";
 import { ThemeFontField } from "../../theme/theme-types/ThemeFonts";
 import { ThemeFontSizeField } from "../../theme/theme-types/ThemeFontSizes";
 import { ThemeFontWeightField } from "../../theme/theme-types/ThemeFontWeights";
 import { SpanProps } from "../../types/ElementProps";
 import { Omit } from "../../types/Omit";
+import { useTextTheme } from "./hooks/UseTextTheme";
 
 export interface TextProps
   extends TextThemeProps,
@@ -44,6 +47,8 @@ export type TextBaseProps = TextBasePropsBase &
 export interface TextBasePropsBase {
   /** The color of the text. */
   color?: string;
+  /** Changes text color when mouse hovers over text. */
+  hoverColor?: string;
   whiteSpace?: WhiteSpaceProperty;
   /** Adds underline to text. */
   textDecoration?: TextDecorationProperty;
@@ -77,7 +82,7 @@ const excludedProps = [
 const isExcludedWebuiProp = (propName: string) =>
   excludedProps.indexOf(propName) !== -1;
 
-export const TextBase = styled("span", {
+const StyledText = styled("span", {
   shouldForwardProp: propName =>
     isExcludedWebuiProp(propName) ? false : isPropValid(propName)
 })<TextBaseProps>`
@@ -94,5 +99,35 @@ export const TextBase = styled("span", {
   :hover {
     ${({ hoverUnderline }) =>
       hoverUnderline ? "text-decoration: underline;" : ""};
+    ${({ hoverColor }) => (hoverColor ? `color: ${hoverColor};` : "")}
   }
 `;
+
+export const TextBase: React.FC<TextProps & { element?: "h1" }> = ({
+  fontSize = "normal",
+  fontFamily = "primary",
+  fontWeight = "standard",
+  color,
+  hoverColor,
+  element,
+  ...textProps
+}) => {
+  const themeTextProps = useTextTheme({ fontSize, fontWeight, fontFamily });
+  const { colors } = useThemeFields(
+    {
+      colors: {
+        color,
+        hoverColor
+      }
+    },
+    [color, hoverColor]
+  );
+
+  const StyledTextWithElement = element
+    ? StyledText.withComponent(element)
+    : StyledText;
+
+  return (
+    <StyledTextWithElement {...themeTextProps} {...textProps} {...colors} />
+  );
+};

--- a/packages/core/src/components/text/variants/HeaderText.stories.tsx
+++ b/packages/core/src/components/text/variants/HeaderText.stories.tsx
@@ -1,8 +1,7 @@
-import { HeaderText } from "@stenajs-webui/core";
+import { defaultTheme, HeaderText } from "@stenajs-webui/core";
 import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
-import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/HeaderText", module)
   .add("standard", () => (

--- a/packages/core/src/components/text/variants/HeaderText.stories.tsx
+++ b/packages/core/src/components/text/variants/HeaderText.stories.tsx
@@ -1,11 +1,25 @@
 import { HeaderText } from "@stenajs-webui/core";
-import { text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
+import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/HeaderText", module)
   .add("standard", () => (
-    <HeaderText>
+    <HeaderText
+      color={select("Color", Object.keys(defaultTheme.colors), "primaryText")}
+    >
+      {text("Text", "That is some nice text, right there!")}
+    </HeaderText>
+  ))
+  .add("hover color", () => (
+    <HeaderText
+      hoverColor={select(
+        "Color",
+        Object.keys(defaultTheme.colors),
+        "successGreen"
+      )}
+    >
       {text("Text", "That is some nice text, right there!")}
     </HeaderText>
   ))

--- a/packages/core/src/components/text/variants/HeaderText.tsx
+++ b/packages/core/src/components/text/variants/HeaderText.tsx
@@ -1,8 +1,5 @@
 import * as React from "react";
-import { useTextTheme } from "../hooks/UseTextTheme";
 import { TextBase, TextProps } from "../TextBase";
-
-const H1 = TextBase.withComponent("h1");
 
 export const HeaderText: React.FC<TextProps> = ({
   fontSize = "huge",
@@ -10,6 +7,13 @@ export const HeaderText: React.FC<TextProps> = ({
   fontWeight = "standard",
   ...textProps
 }) => {
-  const themeTextProps = useTextTheme({ fontSize, fontWeight, fontFamily });
-  return <H1 {...themeTextProps} {...textProps} />;
+  return (
+    <TextBase
+      {...textProps}
+      element={"h1"}
+      fontSize={fontSize}
+      fontFamily={fontFamily}
+      fontWeight={fontWeight}
+    />
+  );
 };

--- a/packages/core/src/components/text/variants/LargeText.stories.tsx
+++ b/packages/core/src/components/text/variants/LargeText.stories.tsx
@@ -1,8 +1,7 @@
-import { LargeText } from "@stenajs-webui/core";
+import { defaultTheme, LargeText } from "@stenajs-webui/core";
 import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
-import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/LargeText", module)
   .add("standard", () => (

--- a/packages/core/src/components/text/variants/LargeText.stories.tsx
+++ b/packages/core/src/components/text/variants/LargeText.stories.tsx
@@ -1,11 +1,25 @@
 import { LargeText } from "@stenajs-webui/core";
-import { text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
+import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/LargeText", module)
   .add("standard", () => (
-    <LargeText>
+    <LargeText
+      color={select("Color", Object.keys(defaultTheme.colors), "primaryText")}
+    >
+      {text("Text", "That is some nice text, right there!")}
+    </LargeText>
+  ))
+  .add("hover color", () => (
+    <LargeText
+      hoverColor={select(
+        "Color",
+        Object.keys(defaultTheme.colors),
+        "successGreen"
+      )}
+    >
       {text("Text", "That is some nice text, right there!")}
     </LargeText>
   ))

--- a/packages/core/src/components/text/variants/LargeText.tsx
+++ b/packages/core/src/components/text/variants/LargeText.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useTextTheme } from "../hooks/UseTextTheme";
 import { TextBase, TextProps } from "../TextBase";
 
 export const LargeText: React.FC<TextProps> = ({
@@ -8,6 +7,12 @@ export const LargeText: React.FC<TextProps> = ({
   fontWeight = "standard",
   ...textProps
 }) => {
-  const themeTextProps = useTextTheme({ fontSize, fontWeight, fontFamily });
-  return <TextBase {...themeTextProps} {...textProps} />;
+  return (
+    <TextBase
+      {...textProps}
+      fontSize={fontSize}
+      fontFamily={fontFamily}
+      fontWeight={fontWeight}
+    />
+  );
 };

--- a/packages/core/src/components/text/variants/SmallText.stories.tsx
+++ b/packages/core/src/components/text/variants/SmallText.stories.tsx
@@ -1,11 +1,25 @@
 import { SmallText } from "@stenajs-webui/core";
-import { text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
+import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/SmallText", module)
   .add("standard", () => (
-    <SmallText>
+    <SmallText
+      color={select("Color", Object.keys(defaultTheme.colors), "primaryText")}
+    >
+      {text("Text", "That is some nice text, right there!")}
+    </SmallText>
+  ))
+  .add("hover color", () => (
+    <SmallText
+      hoverColor={select(
+        "Color",
+        Object.keys(defaultTheme.colors),
+        "successGreen"
+      )}
+    >
       {text("Text", "That is some nice text, right there!")}
     </SmallText>
   ))

--- a/packages/core/src/components/text/variants/SmallText.stories.tsx
+++ b/packages/core/src/components/text/variants/SmallText.stories.tsx
@@ -1,8 +1,7 @@
-import { SmallText } from "@stenajs-webui/core";
+import { defaultTheme, SmallText } from "@stenajs-webui/core";
 import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
-import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/SmallText", module)
   .add("standard", () => (

--- a/packages/core/src/components/text/variants/SmallText.tsx
+++ b/packages/core/src/components/text/variants/SmallText.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useTextTheme } from "../hooks/UseTextTheme";
 import { TextBase, TextProps } from "../TextBase";
 
 export const SmallText: React.FC<TextProps> = ({
@@ -8,6 +7,12 @@ export const SmallText: React.FC<TextProps> = ({
   fontWeight = "standard",
   ...textProps
 }) => {
-  const themeTextProps = useTextTheme({ fontSize, fontWeight, fontFamily });
-  return <TextBase {...themeTextProps} {...textProps} />;
+  return (
+    <TextBase
+      {...textProps}
+      fontSize={fontSize}
+      fontFamily={fontFamily}
+      fontWeight={fontWeight}
+    />
+  );
 };

--- a/packages/core/src/components/text/variants/SmallerText.stories.tsx
+++ b/packages/core/src/components/text/variants/SmallerText.stories.tsx
@@ -1,11 +1,25 @@
 import { SmallerText } from "@stenajs-webui/core";
-import { text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
+import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/SmallerText", module)
   .add("standard", () => (
-    <SmallerText>
+    <SmallerText
+      color={select("Color", Object.keys(defaultTheme.colors), "primaryText")}
+    >
+      {text("Text", "That is some nice text, right there!")}
+    </SmallerText>
+  ))
+  .add("hover color", () => (
+    <SmallerText
+      hoverColor={select(
+        "Color",
+        Object.keys(defaultTheme.colors),
+        "successGreen"
+      )}
+    >
       {text("Text", "That is some nice text, right there!")}
     </SmallerText>
   ))

--- a/packages/core/src/components/text/variants/SmallerText.stories.tsx
+++ b/packages/core/src/components/text/variants/SmallerText.stories.tsx
@@ -1,8 +1,7 @@
-import { SmallerText } from "@stenajs-webui/core";
+import { defaultTheme, SmallerText } from "@stenajs-webui/core";
 import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
-import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/SmallerText", module)
   .add("standard", () => (

--- a/packages/core/src/components/text/variants/SmallerText.tsx
+++ b/packages/core/src/components/text/variants/SmallerText.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useTextTheme } from "../hooks/UseTextTheme";
 import { TextBase, TextProps } from "../TextBase";
 
 export const SmallerText: React.FC<TextProps> = ({
@@ -8,6 +7,12 @@ export const SmallerText: React.FC<TextProps> = ({
   fontWeight = "standard",
   ...textProps
 }) => {
-  const themeTextProps = useTextTheme({ fontSize, fontWeight, fontFamily });
-  return <TextBase {...themeTextProps} {...textProps} />;
+  return (
+    <TextBase
+      {...textProps}
+      fontSize={fontSize}
+      fontFamily={fontFamily}
+      fontWeight={fontWeight}
+    />
+  );
 };

--- a/packages/core/src/components/text/variants/StandardText.stories.tsx
+++ b/packages/core/src/components/text/variants/StandardText.stories.tsx
@@ -1,11 +1,25 @@
 import { StandardText } from "@stenajs-webui/core";
-import { text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
+import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/StandardText", module)
   .add("standard", () => (
-    <StandardText>
+    <StandardText
+      color={select("Color", Object.keys(defaultTheme.colors), "primaryText")}
+    >
+      {text("Text", "That is some nice text, right there!")}
+    </StandardText>
+  ))
+  .add("hover color", () => (
+    <StandardText
+      hoverColor={select(
+        "Color",
+        Object.keys(defaultTheme.colors),
+        "successGreen"
+      )}
+    >
       {text("Text", "That is some nice text, right there!")}
     </StandardText>
   ))

--- a/packages/core/src/components/text/variants/StandardText.stories.tsx
+++ b/packages/core/src/components/text/variants/StandardText.stories.tsx
@@ -1,8 +1,7 @@
-import { StandardText } from "@stenajs-webui/core";
+import { defaultTheme, StandardText } from "@stenajs-webui/core";
 import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
-import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/StandardText", module)
   .add("standard", () => (

--- a/packages/core/src/components/text/variants/StandardText.tsx
+++ b/packages/core/src/components/text/variants/StandardText.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useTextTheme } from "../hooks/UseTextTheme";
 import { TextBase, TextProps } from "../TextBase";
 
 export const StandardText: React.FC<TextProps> = ({
@@ -8,6 +7,12 @@ export const StandardText: React.FC<TextProps> = ({
   fontWeight = "standard",
   ...textProps
 }) => {
-  const themeTextProps = useTextTheme({ fontSize, fontWeight, fontFamily });
-  return <TextBase {...themeTextProps} {...textProps} />;
+  return (
+    <TextBase
+      {...textProps}
+      fontSize={fontSize}
+      fontFamily={fontFamily}
+      fontWeight={fontWeight}
+    />
+  );
 };

--- a/packages/core/src/components/text/variants/TinyText.stories.tsx
+++ b/packages/core/src/components/text/variants/TinyText.stories.tsx
@@ -1,11 +1,27 @@
 import { TinyText } from "@stenajs-webui/core";
-import { text } from "@storybook/addon-knobs";
+import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
+import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/TinyText", module)
   .add("standard", () => (
-    <TinyText>{text("Text", "That is some nice text, right there!")}</TinyText>
+    <TinyText
+      color={select("Color", Object.keys(defaultTheme.colors), "primaryText")}
+    >
+      {text("Text", "That is some nice text, right there!")}
+    </TinyText>
+  ))
+  .add("hover color", () => (
+    <TinyText
+      hoverColor={select(
+        "Color",
+        Object.keys(defaultTheme.colors),
+        "successGreen"
+      )}
+    >
+      {text("Text", "That is some nice text, right there!")}
+    </TinyText>
   ))
   .add("with underline", () => (
     <TinyText textDecoration={"underline"}>

--- a/packages/core/src/components/text/variants/TinyText.stories.tsx
+++ b/packages/core/src/components/text/variants/TinyText.stories.tsx
@@ -1,8 +1,7 @@
-import { TinyText } from "@stenajs-webui/core";
+import { defaultTheme, TinyText } from "@stenajs-webui/core";
 import { select, text } from "@storybook/addon-knobs";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
-import { defaultTheme } from "../../../theme/DefaultTheme";
 
 storiesOf("core/Text/TinyText", module)
   .add("standard", () => (

--- a/packages/core/src/components/text/variants/TinyText.tsx
+++ b/packages/core/src/components/text/variants/TinyText.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useTextTheme } from "../hooks/UseTextTheme";
 import { TextBase, TextProps } from "../TextBase";
 
 export const TinyText: React.FC<TextProps> = ({
@@ -8,6 +7,12 @@ export const TinyText: React.FC<TextProps> = ({
   fontWeight = "standard",
   ...textProps
 }) => {
-  const themeTextProps = useTextTheme({ fontSize, fontWeight, fontFamily });
-  return <TextBase {...themeTextProps} {...textProps} />;
+  return (
+    <TextBase
+      {...textProps}
+      fontSize={fontSize}
+      fontFamily={fontFamily}
+      fontWeight={fontWeight}
+    />
+  );
 };


### PR DESCRIPTION
Move theme resolving from text components, to `TextBase`.
Add `hoverColor` prop to text components.
Add stories for props `color` and `hoverColor`.