### PR TITLE
Proposal for a new way to do Clickable.

### DIFF
--- a/packages/core/src/components/interaction/Clickable.stories.tsx
+++ b/packages/core/src/components/interaction/Clickable.stories.tsx
@@ -1,6 +1,20 @@
-import { Clickable, StandardText } from "@stenajs-webui/core";
+import {
+  Box,
+  Clickable,
+  StandardText,
+  useDefaultClickable
+} from "@stenajs-webui/core";
 import { storiesOf } from "@storybook/react";
 import * as React from "react";
+
+const ClickableHook = () => {
+  const boxProps = useDefaultClickable();
+  return (
+    <Box {...boxProps} onClick={() => alert("Click")}>
+      <StandardText>Click me!</StandardText>
+    </Box>
+  );
+};
 
 storiesOf("core/Interaction/Clickable", module)
   .add("default", () => (
@@ -8,6 +22,7 @@ storiesOf("core/Interaction/Clickable", module)
       <StandardText>Click me!</StandardText>
     </Clickable>
   ))
+  .add("Box with clickable hook", () => <ClickableHook />)
   .add("with DOM id and class name", () => (
     <Clickable
       onClick={() => alert("Clicked!")}

--- a/packages/core/src/components/interaction/Clickable.stories.tsx
+++ b/packages/core/src/components/interaction/Clickable.stories.tsx
@@ -10,7 +10,7 @@ import * as React from "react";
 const ClickableHook = () => {
   const boxProps = useDefaultClickable();
   return (
-    <Box {...boxProps} onClick={() => alert("Click")}>
+    <Box element={"button"} {...boxProps} onClick={() => alert("Click")}>
       <StandardText>Click me!</StandardText>
     </Box>
   );

--- a/packages/core/src/components/interaction/hooks/UseDefaultClickable.ts
+++ b/packages/core/src/components/interaction/hooks/UseDefaultClickable.ts
@@ -1,0 +1,33 @@
+import { useMemo } from "react";
+import { BoxProps } from "../../layout/box/Box";
+
+interface UseDefaultClickableOptions {
+  disableFocusHighlight?: boolean;
+  opacityOnHover?: boolean;
+}
+
+export const useDefaultClickable = (
+  options?: UseDefaultClickableOptions
+): Partial<BoxProps> => {
+  const { disableFocusHighlight = false, opacityOnHover = false } =
+    options || {};
+  return useMemo<Partial<BoxProps>>(
+    () => ({
+      display: "inline-block",
+      background: "transparent",
+      border: "0",
+      userSelect: "none",
+      spacing: 0,
+      indent: 0,
+      element: "button",
+      cursor: "pointer",
+      hoverOpacity: opacityOnHover ? 0.7 : 1,
+      activeOpacity: 0.5,
+      focusOutline: "0",
+      focusBoxShadow: disableFocusHighlight
+        ? undefined
+        : "0 0 3pt 2pt rgba(0, 0, 100, 0.3);"
+    }),
+    [disableFocusHighlight, opacityOnHover]
+  );
+};

--- a/packages/core/src/components/layout/box/Box.tsx
+++ b/packages/core/src/components/layout/box/Box.tsx
@@ -5,7 +5,9 @@ import {
   BorderColorProperty,
   BorderProperty,
   BoxShadowProperty,
-  ColorProperty
+  ColorProperty,
+  CursorProperty,
+  OutlineProperty
 } from "csstype";
 import * as React from "react";
 import {
@@ -76,6 +78,7 @@ type FlexBoxProps = BoxProps;
 type ShadowType = keyof ThemeShadows;
 
 export interface BoxProps extends StyledSystemProps, DivProps {
+  element?: "button" | "span" | "div";
   /**
    * Sets the text color of the box.
    */
@@ -98,6 +101,10 @@ export interface BoxProps extends StyledSystemProps, DivProps {
    */
   shadow?: ShadowType | BoxShadowProperty;
   /**
+   * Changes the cursor of the mouse.
+   */
+  cursor?: CursorProperty;
+  /**
    * Sets the background of the box.
    */
   background?: ThemeColorField | BackgroundProperty<TLengthStyledSystem>;
@@ -118,6 +125,26 @@ export interface BoxProps extends StyledSystemProps, DivProps {
    */
   hoverBorder?: ThemeColorField | BorderProperty<TLengthStyledSystem>;
   /**
+   * Sets the opacity of the box when hovering with mouse.
+   */
+  hoverOpacity?: number;
+  /**
+   * Sets the background of the box when active.
+   */
+  activeBackground?: ThemeColorField | BackgroundProperty<TLengthStyledSystem>;
+  /**
+   * Sets the border of the box when active.
+   */
+  activeBorder?: ThemeColorField | BorderProperty<TLengthStyledSystem>;
+  /**
+   * Sets the opacity of the box when active.
+   */
+  activeOpacity?: number;
+  /**
+   * Sets the shadow of the box when active.
+   */
+  activeBoxShadow?: ShadowType | BoxShadowProperty;
+  /**
    * Sets the background of the box when the box is in focus.
    */
   focusBackground?: ThemeColorField | BackgroundProperty<TLengthStyledSystem>;
@@ -125,6 +152,18 @@ export interface BoxProps extends StyledSystemProps, DivProps {
    * Sets the border of the box when the box is in focus.
    */
   focusBorder?: ThemeColorField | BorderProperty<TLengthStyledSystem>;
+  /**
+   * Sets the opacity of the box when the box is in focus.
+   */
+  focusOpacity?: number;
+  /**
+   * Sets the outline of the box when the box is in focus.
+   */
+  focusOutline?: OutlineProperty<TLengthStyledSystem>;
+  /**
+   * Sets the shadow of the box when active.
+   */
+  focusBoxShadow?: ShadowType | BoxShadowProperty;
   /**
    * Sets the background of the box when focus is within the box.
    */
@@ -135,6 +174,14 @@ export interface BoxProps extends StyledSystemProps, DivProps {
    * Sets the border of the box when focus is within the box.
    */
   focusWithinBorder?: ThemeColorField | BorderProperty<TLengthStyledSystem>;
+  /**
+   * Sets the border of the box when focus is within the box.
+   */
+  focusWithinOpacity?: number;
+  /**
+   * Sets the shadow of the box when focus is within the box.
+   */
+  focusWithinBoxShadow?: ShadowType | BoxShadowProperty;
 }
 
 const excludedProps = ["spacing", "indent", "width", "height", "color"];
@@ -143,10 +190,8 @@ const isExcludedWebUiProp = (propName: string) =>
   excludedProps.indexOf(propName) !== -1;
 
 const getPaddingRule = (props: InnerProps) =>
-  props.spacing || props.indent
-    ? `padding: ${numberOrZero(props.spacing) * (props.themeSpacing || 10)}px
-    ${numberOrZero(props.indent) * (props.themeIndent || 10)}px;`
-    : "";
+  `padding: ${numberOrZero(props.spacing) * (props.themeSpacing || 10)}px
+    ${numberOrZero(props.indent) * (props.themeIndent || 10)}px;`;
 
 type InnerProps = FlexBoxProps &
   BoxShadowProps &
@@ -182,26 +227,46 @@ const FlexBox = styled("div", {
   ${right};
   ${top};
   ${bottom};
+  ${({ cursor }) => (cursor ? `cursor: ${cursor};` : "")}
   :hover {
     ${({ hoverBackground }) =>
       hoverBackground ? `background: ${hoverBackground};` : ""}
     ${({ hoverBorder }) => (hoverBorder ? `border: ${hoverBorder};` : "")}
+    ${({ hoverOpacity }) => (hoverOpacity ? `opacity: ${hoverOpacity};` : "")}
+  }
+  :active {
+    ${({ activeBackground }) =>
+      activeBackground ? `background: ${activeBackground};` : ""}
+    ${({ activeBorder }) => (activeBorder ? `border: ${activeBorder};` : "")}
+    ${({ activeOpacity }) =>
+      activeOpacity ? `opacity: ${activeOpacity};` : ""}
+    ${({ activeBoxShadow }) =>
+      activeBoxShadow ? `box-shadow: ${activeBoxShadow};` : ""}
   }
   :focus {
     ${({ focusBackground }) =>
       focusBackground ? `background: ${focusBackground};` : ""}
     ${({ focusBorder }) => (focusBorder ? `border: ${focusBorder};` : "")}
+    ${({ focusOpacity }) => (focusOpacity ? `opacity: ${focusOpacity};` : "")}
+    ${({ focusOutline }) => (focusOutline ? `outline: ${focusOutline};` : "")}
+    ${({ focusBoxShadow }) =>
+      focusBoxShadow ? `box-shadow: ${focusBoxShadow};` : ""}
   }
   :focus-within {
     ${({ focusWithinBackground }) =>
       focusWithinBackground ? `background: ${focusWithinBackground};` : ""}
     ${({ focusWithinBorder }) =>
       focusWithinBorder ? `border: ${focusWithinBorder};` : ""}
+    ${({ focusWithinOpacity }) =>
+      focusWithinOpacity ? `opacity: ${focusWithinOpacity};` : ""}
+    ${({ focusWithinBoxShadow }) =>
+      focusWithinBoxShadow ? `box-shadow: ${focusWithinBoxShadow};` : ""}
   }
 `;
 
 export const Box: React.FC<BoxProps> = ({
   innerRef,
+  element,
   shadow,
   background,
   border,
@@ -221,7 +286,10 @@ export const Box: React.FC<BoxProps> = ({
     }),
     [shadow, background, border, borderColor, color]
   );
-  return <FlexBox ref={innerRef} {...boxProps} {...props} />;
+
+  const FlexBoxComponent = element ? FlexBox.withComponent(element) : FlexBox;
+
+  return <FlexBoxComponent ref={innerRef} {...boxProps} {...props} />;
 };
 
 const numberOrZero = (num: number | boolean | undefined): number => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,6 +10,7 @@ export * from "./theme/theme-types/ThemeShadows";
 export * from "./components/decorators/separatorline/SeparatorLine";
 
 export * from "./components/interaction/Clickable";
+export * from "./components/interaction/hooks/UseDefaultClickable";
 
 export * from "./components/layout/absolute/Absolute";
 export * from "./components/layout/relative/Relative";


### PR DESCRIPTION
This is more of an invitation to a discussion about the existence of Clickable than a pull request.

Clickable is quite limiting, allowing only a certain style of highlight for hover, active and focus states.

Clickable also miss a lot of things that you get with Box.

I have extended Box with new props needed for these state highlights, within reason (not every style is available, but shadow, background, etc).

I have also added a `useDefaultClickable` hook which creates Box-props object with these values set in the same way as the old Clickable. This is mainly to avoid breaking changes, but also serves as a demonstration.

Any input, thoughts or ideas are welcome!