### PR TITLE
Increase allowed inputs for entering grid edition mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next release
 
-* Coming soon...
+* Allow inputs `-+*<>` in grid when `allowedInputType='all'`.
 
 ## 0.0.42
 

--- a/packages/grid/src/hooks/UseEditableCell.ts
+++ b/packages/grid/src/hooks/UseEditableCell.ts
@@ -196,21 +196,11 @@ const createKeyDownHandler = <TValue>(
   } else if (!e.ctrlKey && !e.metaKey && !e.shiftKey && isEditable) {
     // TODO Find nice way to allow full user control, while also providing simplicity.
     const lastKeyEvent = createKeyDownEvent(e);
-    if (isNumeric(e.key) && allowsNumerics(allowedInputType)) {
-      startEditing(lastKeyEvent);
-      setLastKeyEvent(lastKeyEvent);
-      revertableValue.commit();
-      revertableValue.setValue(transformEnteredValue(lastKeyEvent.key));
-      e.preventDefault();
-      e.stopPropagation();
-    } else if (isLetter(e.key) && allowsLetters(allowedInputType)) {
-      startEditing(lastKeyEvent);
-      setLastKeyEvent(lastKeyEvent);
-      revertableValue.commit();
-      revertableValue.setValue(transformEnteredValue(lastKeyEvent.key));
-      e.preventDefault();
-      e.stopPropagation();
-    } else if (isCharacter(e.key)) {
+    if (
+      (isNumeric(e.key) && allowsNumerics(allowedInputType)) ||
+      (isLetter(e.key) && allowsLetters(allowedInputType)) ||
+      isCharacter(e.key)
+    ) {
       startEditing(lastKeyEvent);
       setLastKeyEvent(lastKeyEvent);
       revertableValue.commit();

--- a/packages/grid/src/hooks/UseEditableCell.ts
+++ b/packages/grid/src/hooks/UseEditableCell.ts
@@ -164,6 +164,20 @@ export const useEditableCell = <TValue>(
   };
 };
 
+const allowsNumerics = (allowedInputType: AllowedInputType): boolean =>
+  allowedInputType === "all" ||
+  allowedInputType === "numeric" ||
+  allowedInputType === "alphanumeric";
+const allowsLetters = (allowedInputType: AllowedInputType): boolean =>
+  allowedInputType === "all" ||
+  allowedInputType === "alphanumeric" ||
+  allowedInputType === "letters";
+
+const isCharacter = (key: string): boolean =>
+  isLetter(key) || !!key.match(/^[-+*<>]$/);
+const isLetter = (key: string): boolean => !!key.match(/^[a-zA-Z0-9]$/);
+const isNumeric = (key: string): boolean => !isNaN(parseInt(key, 10));
+
 const createKeyDownHandler = <TValue>(
   _: boolean, // isEditing
   isEditable: boolean,
@@ -179,33 +193,24 @@ const createKeyDownHandler = <TValue>(
     revertableValue.commit();
     e.preventDefault();
     e.stopPropagation();
-  } else if (
-    !e.ctrlKey &&
-    !e.metaKey &&
-    e.key.match(/^[a-zA-Z0-9]$/) &&
-    isEditable
-  ) {
+  } else if (!e.ctrlKey && !e.metaKey && !e.shiftKey && isEditable) {
     // TODO Find nice way to allow full user control, while also providing simplicity.
-    const num = parseInt(e.key, 10);
     const lastKeyEvent = createKeyDownEvent(e);
-    if (!isNaN(num)) {
-      if (
-        allowedInputType === "all" ||
-        allowedInputType === "numeric" ||
-        allowedInputType === "alphanumeric"
-      ) {
-        startEditing(lastKeyEvent);
-        setLastKeyEvent(lastKeyEvent);
-        revertableValue.commit();
-        revertableValue.setValue(transformEnteredValue(lastKeyEvent.key));
-        e.preventDefault();
-        e.stopPropagation();
-      }
-    } else if (
-      allowedInputType === "all" ||
-      allowedInputType === "alphanumeric" ||
-      allowedInputType === "letters"
-    ) {
+    if (isNumeric(e.key) && allowsNumerics(allowedInputType)) {
+      startEditing(lastKeyEvent);
+      setLastKeyEvent(lastKeyEvent);
+      revertableValue.commit();
+      revertableValue.setValue(transformEnteredValue(lastKeyEvent.key));
+      e.preventDefault();
+      e.stopPropagation();
+    } else if (isLetter(e.key) && allowsLetters(allowedInputType)) {
+      startEditing(lastKeyEvent);
+      setLastKeyEvent(lastKeyEvent);
+      revertableValue.commit();
+      revertableValue.setValue(transformEnteredValue(lastKeyEvent.key));
+      e.preventDefault();
+      e.stopPropagation();
+    } else if (isCharacter(e.key)) {
       startEditing(lastKeyEvent);
       setLastKeyEvent(lastKeyEvent);
       revertableValue.commit();


### PR DESCRIPTION
We had a case in FP where we wanted to enter edit mode when pressing `-` or `+`. As it is now, it is not allowed since the only valid input is `[a-zA-Z0-9]`. This PR increases the flexibility for `allowedInputType: 'all'` to also allow inputs `[-+*<>]`.

I don't know how to handle when user presses `shift + "other key"` so I only chose these ones for now on.

Did some rewriting of logic so please watch 2 times! =)