### PR TITLE
Cursor should be at the end in input when value is provided on mount

### DIFF
--- a/packages/forms/src/components/ui/text-input/SimpleTextInput.tsx
+++ b/packages/forms/src/components/ui/text-input/SimpleTextInput.tsx
@@ -250,6 +250,11 @@ export const SimpleTextInput: React.FC<SimpleTextInputProps> = ({
     if (refToUse.current) {
       if (selectAllOnFocus) {
         refToUse.current!.setSelectionRange(0, refToUse.current!.value.length);
+      } else {
+        refToUse.current!.setSelectionRange(
+          refToUse.current!.value.length,
+          refToUse.current!.value.length
+        );
       }
     }
     if (onFocus) {


### PR DESCRIPTION
https://stackoverflow.com/questions/35951771/react-autofocus-sets-curser-to-beginning-of-input-value