### PR TITLE
Add flex: none to `Space`

### DIFF
--- a/packages/core/src/components/layout/space/Space.tsx
+++ b/packages/core/src/components/layout/space/Space.tsx
@@ -23,7 +23,8 @@ export const Space: React.FC<SpaceProps> = ({
     <div
       style={{
         width: vertical ? "1px" : `${size * space}px`,
-        height: horizontal ? "1px" : `${size * space}px`
+        height: horizontal ? "1px" : `${size * space}px`,
+        flex: "none"
       }}
     >
       {children}


### PR DESCRIPTION
This makes it actually retain its correct size.
From
![image](https://user-images.githubusercontent.com/2521318/88296247-bd6cb900-ccfe-11ea-9e94-f0107a9aa9b5.png)
to
![image](https://user-images.githubusercontent.com/2521318/88296279-c493c700-ccfe-11ea-9e93-c0c417b4708b.png)
