### PR TITLE
Add easy actions for StandardTable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and can be created manually using `createStandardTableActions` function.
 
 ### Breaking changes
 
+- New actions are breaking, if the app is using them via `useLocalStateTableContext`.
 - `useLocalStateTableContext` now accepts an `initialState` parameter instead of `initialSortOrder` and `initialSortOrderDesc`.
     - Use `createStandardTableInitialState` to maintain compatibility.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,10 @@
 
 ## 1.0.5
 
-### Fixes
+### Improvements
 
 - `Select` component now has the same focused box shadow that is used in input fields.
 - `Link` component now uses an 1px outline instead of border.
-
-### Improvements
-
 - `StandardTableConfig` now infers column names from row object automatically.
 - `StandardTableConfig` now supports expand collapse button in header row (set `showHeaderExpandCollapse` to `true`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@
 - `StandardTableConfig` now infers column names from row object automatically.
 - `StandardTableConfig` now supports expand collapse button in header row (set `showHeaderExpandCollapse` to `true`)
 
+#### New actions for `StandardTable`
+
+  `StandardTable` is now using new higher order reducers, which require composing nested actions.
+  This made it harder to create actions in the apps, and these new actions help.
+
+  - selectByIds(ids)
+  - clearSelection()
+  - expandByIds(ids)
+  - collapseAll()
+  - sortBy(columnId, desc?)
+  - clearSortOrder()
+
+New actions are exposed by `useLocalStateTableContext` hook,
+and can be created manually using `createStandardTableActions` function.
+
 ### Breaking changes
 
 - `useLocalStateTableContext` now accepts an `initialState` parameter instead of `initialSortOrder` and `initialSortOrderDesc`.

--- a/packages/grid/src/features/standard-table/context/StandardTableStateContext.ts
+++ b/packages/grid/src/features/standard-table/context/StandardTableStateContext.ts
@@ -1,16 +1,17 @@
 import { createContext, Dispatch } from "react";
 import { StandardTableConfig } from "../config/StandardTableConfig";
+import { StandardTableState } from "../redux/StandardTableReducer";
+import { ReducerIdGateAction } from "@stenajs-webui/redux";
 import {
   StandardTableAction,
   StandardTableActions
-} from "../redux/StandardTableActionsAndSelectors";
-import { StandardTableState } from "../redux/StandardTableReducer";
-import { ReducerIdGateAction } from "@stenajs-webui/redux";
+} from "../util/ActionsFactory";
+import { InternalStandardTableAction } from "../redux/StandardTableActionsAndSelectors";
 
 export interface StandardTableInternalActionsContext<
   TColumnKeys extends string
 > {
-  dispatch: Dispatch<ReducerIdGateAction<StandardTableAction<TColumnKeys>>>;
+  dispatch: Dispatch<StandardTableAction<TColumnKeys>>;
   actions: StandardTableActions<TColumnKeys>;
 }
 
@@ -19,7 +20,9 @@ export interface StandardTableInternalActionsContext<
  * connect the table to a state.
  */
 export interface TableContext<TColumnKeys extends string> {
-  dispatch: Dispatch<ReducerIdGateAction<StandardTableAction<TColumnKeys>>>;
+  dispatch: Dispatch<
+    ReducerIdGateAction<InternalStandardTableAction<TColumnKeys>>
+  >;
   state: StandardTableState<TColumnKeys>;
   actions: StandardTableActions<TColumnKeys>;
 }

--- a/packages/grid/src/features/standard-table/hooks/UseExpandCollapseActions.ts
+++ b/packages/grid/src/features/standard-table/hooks/UseExpandCollapseActions.ts
@@ -1,23 +1,18 @@
 import {
   useStandardTableActions,
   useStandardTableConfig,
-  useStandardTableId,
   useStandardTableState
 } from "./UseStandardTableConfig";
 import { useCallback, useMemo } from "react";
 import { useArraySet } from "@stenajs-webui/core";
-import { getReducerIdFor } from "../redux/ReducerIdFactory";
 
 export const useExpandCollapseActions = <TItem>(item: TItem) => {
-  const tableId = useStandardTableId();
   const { keyResolver } = useStandardTableConfig();
   const {
     expandedRows: { selectedIds }
   } = useStandardTableState();
   const {
-    actions: {
-      expandedRows: { setSelectedIds }
-    },
+    actions: { expandByIds },
     dispatch
   } = useStandardTableActions();
 
@@ -29,10 +24,7 @@ export const useExpandCollapseActions = <TItem>(item: TItem) => {
   ]);
 
   const { toggle } = useArraySet(selectedIds, (ids: Array<string>) =>
-    dispatch({
-      reducerId: getReducerIdFor(tableId, "expandedRows"),
-      action: setSelectedIds(ids)
-    })
+    dispatch(expandByIds(ids))
   );
 
   const toggleRowExpanded = useCallback(() => {

--- a/packages/grid/src/features/standard-table/hooks/UseLocalStateTableContext.ts
+++ b/packages/grid/src/features/standard-table/hooks/UseLocalStateTableContext.ts
@@ -1,12 +1,13 @@
 import { useMemo, useReducer } from "react";
 import { TableContext } from "../context/StandardTableStateContext";
-import { createStandardTableActions } from "../redux/StandardTableActionsAndSelectors";
+import { createInternalStandardTableActions } from "../redux/StandardTableActionsAndSelectors";
 import {
   createStandardTableInitialState,
   createStandardTableReducer,
   StandardTableReducer,
   StandardTableState
 } from "../redux/StandardTableReducer";
+import { createStandardTableActions } from "../util/ActionsFactory";
 
 export const useLocalStateTableContext = <TColumnKeys extends string>(
   tableId: string,
@@ -19,7 +20,14 @@ export const useLocalStateTableContext = <TColumnKeys extends string>(
     initialState
   );
 
-  const actions = useMemo(() => createStandardTableActions<TColumnKeys>(), []);
+  const actions = useMemo(
+    () =>
+      createStandardTableActions(
+        tableId,
+        createInternalStandardTableActions<TColumnKeys>()
+      ),
+    [tableId]
+  );
 
   const tableContext = useMemo<TableContext<TColumnKeys>>(
     () => ({

--- a/packages/grid/src/features/standard-table/hooks/UseRowCheckbox.ts
+++ b/packages/grid/src/features/standard-table/hooks/UseRowCheckbox.ts
@@ -3,21 +3,17 @@ import { useCallback, useMemo } from "react";
 import {
   useStandardTableActions,
   useStandardTableConfig,
-  useStandardTableId,
   useStandardTableState
 } from "./UseStandardTableConfig";
-import { getReducerIdFor } from "../redux/ReducerIdFactory";
 
 export const useRowCheckbox = <TItem>(item: TItem) => {
   const { keyResolver } = useStandardTableConfig();
-  const tableId = useStandardTableId();
+
   const {
     selectedIds: { selectedIds }
   } = useStandardTableState();
   const {
-    actions: {
-      selectedIds: { setSelectedIds }
-    },
+    actions: { selectByIds },
     dispatch
   } = useStandardTableActions();
 
@@ -29,10 +25,7 @@ export const useRowCheckbox = <TItem>(item: TItem) => {
   ]);
 
   const { toggle } = useArraySet(selectedIds, (ids: Array<string>) =>
-    dispatch({
-      reducerId: getReducerIdFor(tableId, "selectedIds"),
-      action: setSelectedIds(ids)
-    })
+    dispatch(selectByIds(ids))
   );
 
   const toggleSelected = useCallback(() => {

--- a/packages/grid/src/features/standard-table/hooks/UseTableHeadCheckbox.ts
+++ b/packages/grid/src/features/standard-table/hooks/UseTableHeadCheckbox.ts
@@ -2,23 +2,18 @@ import { useCallback } from "react";
 import {
   useStandardTableActions,
   useStandardTableConfig,
-  useStandardTableId,
   useStandardTableState
 } from "./UseStandardTableConfig";
-import { getReducerIdFor } from "../redux/ReducerIdFactory";
 
 export const useTableHeadCheckbox = <TItem>(
   items: Array<TItem> | undefined
 ) => {
-  const tableId = useStandardTableId();
   const { keyResolver } = useStandardTableConfig();
   const {
     selectedIds: { selectedIds }
   } = useStandardTableState();
   const {
-    actions: {
-      selectedIds: { setSelectedIds, clearSelectedIds }
-    },
+    actions: { selectByIds, clearSelection },
     dispatch
   } = useStandardTableActions();
 
@@ -29,25 +24,18 @@ export const useTableHeadCheckbox = <TItem>(
   const onClickCheckbox = useCallback(() => {
     if (items) {
       if (allItemsAreSelected) {
-        dispatch({
-          reducerId: getReducerIdFor(tableId, "selectedIds"),
-          action: clearSelectedIds()
-        });
+        dispatch(clearSelection());
       } else {
-        dispatch({
-          reducerId: getReducerIdFor(tableId, "selectedIds"),
-          action: setSelectedIds(items.map(item => keyResolver(item)))
-        });
+        dispatch(selectByIds(items.map(item => keyResolver(item))));
       }
     }
   }, [
-    tableId,
     allItemsAreSelected,
-    clearSelectedIds,
+    clearSelection,
     dispatch,
     items,
     keyResolver,
-    setSelectedIds
+    selectByIds
   ]);
 
   return {

--- a/packages/grid/src/features/standard-table/hooks/UseTableHeadExpandCollapse.ts
+++ b/packages/grid/src/features/standard-table/hooks/UseTableHeadExpandCollapse.ts
@@ -2,23 +2,18 @@ import { useCallback } from "react";
 import {
   useStandardTableActions,
   useStandardTableConfig,
-  useStandardTableId,
   useStandardTableState
 } from "./UseStandardTableConfig";
-import { getReducerIdFor } from "../redux/ReducerIdFactory";
 
 export const useTableHeadExpandCollapse = <TItem>(
   items: Array<TItem> | undefined
 ) => {
-  const tableId = useStandardTableId();
   const { keyResolver } = useStandardTableConfig();
   const {
     expandedRows: { selectedIds }
   } = useStandardTableState();
   const {
-    actions: {
-      expandedRows: { setSelectedIds, clearSelectedIds }
-    },
+    actions: { collapseAll, expandByIds },
     dispatch
   } = useStandardTableActions();
 
@@ -29,25 +24,18 @@ export const useTableHeadExpandCollapse = <TItem>(
   const toggleExpanded = useCallback(() => {
     if (items) {
       if (allItemsAreExpanded) {
-        dispatch({
-          reducerId: getReducerIdFor(tableId, "expandedRows"),
-          action: clearSelectedIds()
-        });
+        dispatch(collapseAll());
       } else {
-        dispatch({
-          reducerId: getReducerIdFor(tableId, "expandedRows"),
-          action: setSelectedIds(items.map(item => keyResolver(item)))
-        });
+        dispatch(expandByIds(items.map(item => keyResolver(item))));
       }
     }
   }, [
-    tableId,
     allItemsAreExpanded,
-    clearSelectedIds,
+    collapseAll,
     dispatch,
     items,
     keyResolver,
-    setSelectedIds
+    expandByIds
   ]);
 
   return {

--- a/packages/grid/src/features/standard-table/hooks/UseTableResetWhenNewData.ts
+++ b/packages/grid/src/features/standard-table/hooks/UseTableResetWhenNewData.ts
@@ -3,23 +3,17 @@ import {
   useStandardTableActions,
   useStandardTableId
 } from "./UseStandardTableConfig";
-import { getReducerIdFor } from "../redux/ReducerIdFactory";
 
 export const useTableResetWhenNewData = <TItem>(
   items: Array<TItem> | undefined
 ) => {
   const tableId = useStandardTableId();
   const {
-    actions: {
-      selectedIds: { clearSelectedIds }
-    },
+    actions: { clearSelection },
     dispatch
   } = useStandardTableActions();
 
   useEffect(() => {
-    dispatch({
-      reducerId: getReducerIdFor(tableId, "selectedIds"),
-      action: clearSelectedIds()
-    });
-  }, [items, dispatch, clearSelectedIds, tableId]);
+    dispatch(clearSelection());
+  }, [items, dispatch, clearSelection, tableId]);
 };

--- a/packages/grid/src/features/standard-table/hooks/UseTableSortHeader.ts
+++ b/packages/grid/src/features/standard-table/hooks/UseTableSortHeader.ts
@@ -2,10 +2,8 @@ import { useMemo } from "react";
 import { ArrowType } from "../../table-ui/components/table/TableHeadItem";
 import {
   useStandardTableActions,
-  useStandardTableId,
   useStandardTableState
 } from "./UseStandardTableConfig";
-import { getReducerIdFor } from "../redux/ReducerIdFactory";
 
 interface Result {
   selected: boolean;
@@ -15,7 +13,6 @@ interface Result {
 }
 
 export const useTableSortHeader = (columnId: string): Result => {
-  const tableId = useStandardTableId();
   const { dispatch, actions } = useStandardTableActions();
   const {
     sortOrder: { desc, sortBy }
@@ -28,18 +25,8 @@ export const useTableSortHeader = (columnId: string): Result => {
       selected,
       desc,
       onClickColumnHead: () => {
-        if (selected) {
-          dispatch({
-            reducerId: getReducerIdFor(tableId, "sortOrder"),
-            action: actions.sortOrder.sortBy(columnId, !desc)
-          });
-        } else {
-          dispatch({
-            reducerId: getReducerIdFor(tableId, "sortOrder"),
-            action: actions.sortOrder.sortBy(columnId, false)
-          });
-        }
+        dispatch(actions.sortBy(columnId, selected ? !desc : false));
       }
     };
-  }, [sortBy, desc, actions, columnId, dispatch, tableId]);
+  }, [sortBy, desc, actions, columnId, dispatch]);
 };

--- a/packages/grid/src/features/standard-table/redux/StandardTableActionsAndSelectors.ts
+++ b/packages/grid/src/features/standard-table/redux/StandardTableActionsAndSelectors.ts
@@ -10,7 +10,7 @@ import {
 } from "@stenajs-webui/redux";
 import { StandardTableState } from "./StandardTableReducer";
 
-export interface StandardTableActions<TColumnKey extends string> {
+export interface InternalStandardTableActions<TColumnKey extends string> {
   sortOrder: SortOrderActions<TColumnKey>;
   selectedIds: SelectedIdsActions;
   expandedRows: SelectedIdsActions;
@@ -29,11 +29,11 @@ export interface StandardTableActionsAndSelectors<
   TStoreState,
   TColumnKey extends string
 > {
-  actions: StandardTableActions<TColumnKey>;
+  actions: InternalStandardTableActions<TColumnKey>;
   selectors: StandardTableSelectors<TStoreState, TColumnKey>;
 }
 
-export type StandardTableAction<TColumnKey extends string> =
+export type InternalStandardTableAction<TColumnKey extends string> =
   | SortOrderAction<TColumnKey>
   | SelectedIdsAction;
 
@@ -42,9 +42,9 @@ export type StandardTableStateSelector<
   TColumnKey extends string
 > = (state: TStoreState) => StandardTableState<TColumnKey>;
 
-export const createStandardTableActions = <
+export const createInternalStandardTableActions = <
   TColumnKey extends string
->(): StandardTableActions<TColumnKey> => ({
+>(): InternalStandardTableActions<TColumnKey> => ({
   sortOrder: createSortOrderActions<TColumnKey>(),
   selectedIds: createSelectedIdsActions(),
   expandedRows: createSelectedIdsActions()

--- a/packages/grid/src/features/standard-table/redux/StandardTableReducer.ts
+++ b/packages/grid/src/features/standard-table/redux/StandardTableReducer.ts
@@ -8,8 +8,8 @@ import {
   SelectedIdsState,
   SortOrderState
 } from "@stenajs-webui/redux";
-import { StandardTableAction } from "./StandardTableActionsAndSelectors";
 import { getReducerIdFor } from "./ReducerIdFactory";
+import { InternalStandardTableAction } from "./StandardTableActionsAndSelectors";
 
 export interface StandardTableState<TColumnKey extends string> {
   sortOrder: SortOrderState<TColumnKey>;
@@ -32,7 +32,7 @@ export type StandardTableReducer<
   TColumnKey extends string
 > = ReducerIdGateReducer<
   StandardTableState<TColumnKey>,
-  StandardTableAction<TColumnKey>
+  InternalStandardTableAction<TColumnKey>
 >;
 
 export const createStandardTableReducer = <TColumnKey extends string>(

--- a/packages/grid/src/features/standard-table/util/ActionsFactory.ts
+++ b/packages/grid/src/features/standard-table/util/ActionsFactory.ts
@@ -1,0 +1,55 @@
+import { InternalStandardTableActions } from "../redux/StandardTableActionsAndSelectors";
+import {
+  ReducerIdGateAction,
+  SelectedIdsAction,
+  SortOrderAction
+} from "@stenajs-webui/redux";
+import { getReducerIdFor } from "../redux/ReducerIdFactory";
+
+export type StandardTableAction<TColumnKey> =
+  | ReducerIdGateAction<SelectedIdsAction>
+  | ReducerIdGateAction<SortOrderAction<TColumnKey>>;
+
+export interface StandardTableActions<TColumnKey> {
+  selectByIds: (ids: Array<string>) => StandardTableAction<TColumnKey>;
+  clearSelection: () => StandardTableAction<TColumnKey>;
+  expandByIds: (ids: Array<string>) => StandardTableAction<TColumnKey>;
+  collapseAll: () => StandardTableAction<TColumnKey>;
+  sortBy: (
+    columnId: TColumnKey,
+    desc?: boolean
+  ) => StandardTableAction<TColumnKey>;
+  clearSortOrder: () => StandardTableAction<TColumnKey>;
+}
+
+export const createStandardTableActions = <TColumnKey extends string>(
+  tableId: string,
+  actions: InternalStandardTableActions<TColumnKey>
+): StandardTableActions<TColumnKey> => {
+  return {
+    selectByIds: ids => ({
+      reducerId: getReducerIdFor(tableId, "selectedIds"),
+      action: actions.selectedIds.setSelectedIds(ids)
+    }),
+    clearSelection: () => ({
+      reducerId: getReducerIdFor(tableId, "selectedIds"),
+      action: actions.selectedIds.clearSelectedIds()
+    }),
+    expandByIds: ids => ({
+      reducerId: getReducerIdFor(tableId, "expandedRows"),
+      action: actions.expandedRows.setSelectedIds(ids)
+    }),
+    collapseAll: () => ({
+      reducerId: getReducerIdFor(tableId, "expandedRows"),
+      action: actions.expandedRows.clearSelectedIds()
+    }),
+    sortBy: (columnId: TColumnKey, desc?: boolean) => ({
+      reducerId: getReducerIdFor(tableId, "sortOrder"),
+      action: actions.sortOrder.sortBy(columnId, desc ?? false)
+    }),
+    clearSortOrder: () => ({
+      reducerId: getReducerIdFor(tableId, "sortOrder"),
+      action: actions.sortOrder.clearSortOrder()
+    })
+  };
+};

--- a/packages/grid/src/features/table-ui/hooks/UseSortOrderColumnHead.ts
+++ b/packages/grid/src/features/table-ui/hooks/UseSortOrderColumnHead.ts
@@ -1,7 +1,8 @@
-import { SortOrderActions, SortOrderState } from "@stenajs-webui/redux";
+import { SortOrderState } from "@stenajs-webui/redux";
 import { useMemo } from "react";
 import { useStandardTableActions } from "../../standard-table/hooks/UseStandardTableConfig";
 import { ArrowType } from "../components/table/TableHeadItem";
+import { StandardTableActions } from "../../standard-table/util/ActionsFactory";
 
 interface Result {
   selected: boolean;
@@ -12,23 +13,20 @@ interface Result {
 
 export const useSortOrderColumnHead = <TSortBy extends string>(
   state: SortOrderState<TSortBy>,
-  actions: SortOrderActions<TSortBy>,
+  actions: StandardTableActions<TSortBy>,
   sortByForColumn: TSortBy
 ): Result => {
   const { dispatch } = useStandardTableActions<TSortBy>();
   return useMemo(() => {
     const selected = state.sortBy === sortByForColumn;
-    const desc = !!state.desc;
     return {
-      arrow: selected ? (desc ? "up" : "down") : undefined,
+      arrow: selected ? (state.desc ? "up" : "down") : undefined,
       selected: selected,
-      desc: desc,
+      desc: state.desc,
       onClickColumnHead: () => {
-        if (selected) {
-          dispatch(actions.sortBy(sortByForColumn, !state.desc));
-        } else {
-          dispatch(actions.sortBy(sortByForColumn, false));
-        }
+        dispatch(
+          actions.sortBy(sortByForColumn, selected ? !state.desc : false)
+        );
       }
     };
   }, [state, actions, sortByForColumn, dispatch]);

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -46,6 +46,7 @@ export * from "./features/standard-table/hooks/UseLocalStateTableContext";
 
 export * from "./features/standard-table/util/LabelFormatter";
 export * from "./features/standard-table/util/MultitypeComparator";
+export * from "./features/standard-table/util/ActionsFactory";
 
 export * from "./features/grid-cell/hooks/UseEditableCell";
 export * from "./features/grid-cell/hooks/UseGridCell";


### PR DESCRIPTION
- Add new actions to StandardTable which are exposed by UseLocalStateTableContext hook.
- The actions can be created manually by using createStandardTableActions.

### Actions

- selectByIds(ids)
- clearSelection()
- expandByIds(ids)
- collapseAll()
- sortBy(columnId, desc?)
- clearSortOrder()