### PR TITLE
Reducer type updates

### DIFF
--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -5,6 +5,7 @@ import { StandardTableConfig } from "../config/StandardTableConfig";
 import {
   StandardTableActionsContext,
   StandardTableConfigContext,
+  StandardTableInternalActionsContext,
   StandardTableStateContext,
   StandardTableTableIdContext,
   TableContext
@@ -81,7 +82,9 @@ export const StandardTable = function StandardTable<
 
   const { state, actions, dispatch } = currentTableContext;
 
-  const actionsContext = useMemo(() => {
+  const actionsContext = useMemo<
+    StandardTableInternalActionsContext<TColumnKey>
+  >(() => {
     return {
       actions,
       dispatch

--- a/packages/grid/src/features/standard-table/context/StandardTableStateContext.ts
+++ b/packages/grid/src/features/standard-table/context/StandardTableStateContext.ts
@@ -1,7 +1,6 @@
 import { createContext, Dispatch } from "react";
 import { StandardTableConfig } from "../config/StandardTableConfig";
 import { StandardTableState } from "../redux/StandardTableReducer";
-import { ReducerIdGateAction } from "@stenajs-webui/redux";
 import {
   StandardTableAction,
   StandardTableActions
@@ -20,9 +19,7 @@ export interface StandardTableInternalActionsContext<
  * connect the table to a state.
  */
 export interface TableContext<TColumnKeys extends string> {
-  dispatch: Dispatch<
-    ReducerIdGateAction<InternalStandardTableAction<TColumnKeys>>
-  >;
+  dispatch: Dispatch<InternalStandardTableAction<TColumnKeys>>;
   state: StandardTableState<TColumnKeys>;
   actions: StandardTableActions<TColumnKeys>;
 }

--- a/packages/grid/src/features/standard-table/redux/StandardTableActionsAndSelectors.ts
+++ b/packages/grid/src/features/standard-table/redux/StandardTableActionsAndSelectors.ts
@@ -1,6 +1,7 @@
 import {
   createSelectedIdsActions,
   createSortOrderActions,
+  ReducerIdGateAction,
   SelectedIdsAction,
   SelectedIdsActions,
   SelectedIdsSelectors,
@@ -34,8 +35,8 @@ export interface StandardTableActionsAndSelectors<
 }
 
 export type InternalStandardTableAction<TColumnKey extends string> =
-  | SortOrderAction<TColumnKey>
-  | SelectedIdsAction;
+  | ReducerIdGateAction<SortOrderAction<TColumnKey>>
+  | ReducerIdGateAction<SelectedIdsAction>;
 
 export type StandardTableStateSelector<
   TStoreState,

--- a/packages/grid/src/features/standard-table/redux/StandardTableReducer.ts
+++ b/packages/grid/src/features/standard-table/redux/StandardTableReducer.ts
@@ -4,12 +4,12 @@ import {
   createSortOrderReducer,
   createSortOrderReducerInitialState,
   reducerIdGate,
-  ReducerIdGateReducer,
   SelectedIdsState,
   SortOrderState
 } from "@stenajs-webui/redux";
 import { getReducerIdFor } from "./ReducerIdFactory";
 import { InternalStandardTableAction } from "./StandardTableActionsAndSelectors";
+import { Reducer } from "redux";
 
 export interface StandardTableState<TColumnKey extends string> {
   sortOrder: SortOrderState<TColumnKey>;
@@ -28,9 +28,7 @@ export const createStandardTableInitialState = <TColumnKey extends string>(
   expandedRows: createSelectedIdsReducerInitialState(expandedRows)
 });
 
-export type StandardTableReducer<
-  TColumnKey extends string
-> = ReducerIdGateReducer<
+export type StandardTableReducer<TColumnKey extends string> = Reducer<
   StandardTableState<TColumnKey>,
   InternalStandardTableAction<TColumnKey>
 >;
@@ -53,10 +51,9 @@ export const createStandardTableReducer = <TColumnKey extends string>(
 
   return (state, action) => {
     return {
-      ...state,
-      sortOrder: sortOrder(state.sortOrder, action as any),
-      selectedIds: selectedIds(state.selectedIds, action as any),
-      expandedRows: expandedRows(state.expandedRows, action as any)
+      sortOrder: sortOrder(state?.sortOrder, action as any),
+      selectedIds: selectedIds(state?.selectedIds, action as any),
+      expandedRows: expandedRows(state?.expandedRows, action as any)
     };
   };
 };

--- a/packages/grid/src/features/standard-table/redux/StandardTableReducer.ts
+++ b/packages/grid/src/features/standard-table/redux/StandardTableReducer.ts
@@ -9,7 +9,7 @@ import {
 } from "@stenajs-webui/redux";
 import { getReducerIdFor } from "./ReducerIdFactory";
 import { InternalStandardTableAction } from "./StandardTableActionsAndSelectors";
-import { Reducer } from "redux";
+import { combineReducers, Reducer } from "redux";
 
 export interface StandardTableState<TColumnKey extends string> {
   sortOrder: SortOrderState<TColumnKey>;
@@ -49,11 +49,9 @@ export const createStandardTableReducer = <TColumnKey extends string>(
     createSelectedIdsReducer()
   );
 
-  return (state, action) => {
-    return {
-      sortOrder: sortOrder(state?.sortOrder, action as any),
-      selectedIds: selectedIds(state?.selectedIds, action as any),
-      expandedRows: expandedRows(state?.expandedRows, action as any)
-    };
-  };
+  return combineReducers({
+    sortOrder,
+    selectedIds,
+    expandedRows
+  });
 };

--- a/packages/grid/src/features/standard-table/util/ActionsFactory.ts
+++ b/packages/grid/src/features/standard-table/util/ActionsFactory.ts
@@ -1,5 +1,6 @@
 import { InternalStandardTableActions } from "../redux/StandardTableActionsAndSelectors";
 import {
+  reducerIdGateAction,
   ReducerIdGateAction,
   SelectedIdsAction,
   SortOrderAction
@@ -27,35 +28,35 @@ export const createStandardTableActions = <TColumnKey extends string>(
   actions: InternalStandardTableActions<TColumnKey>
 ): StandardTableActions<TColumnKey> => {
   return {
-    selectByIds: ids => ({
-      type: "REDUCER_ID_GATE:ACTION",
-      reducerId: getReducerIdFor(tableId, "selectedIds"),
-      action: actions.selectedIds.setSelectedIds(ids)
-    }),
-    clearSelection: () => ({
-      type: "REDUCER_ID_GATE:ACTION",
-      reducerId: getReducerIdFor(tableId, "selectedIds"),
-      action: actions.selectedIds.clearSelectedIds()
-    }),
-    expandByIds: ids => ({
-      type: "REDUCER_ID_GATE:ACTION",
-      reducerId: getReducerIdFor(tableId, "expandedRows"),
-      action: actions.expandedRows.setSelectedIds(ids)
-    }),
-    collapseAll: () => ({
-      type: "REDUCER_ID_GATE:ACTION",
-      reducerId: getReducerIdFor(tableId, "expandedRows"),
-      action: actions.expandedRows.clearSelectedIds()
-    }),
-    sortBy: (columnId: TColumnKey, desc?: boolean) => ({
-      type: "REDUCER_ID_GATE:ACTION",
-      reducerId: getReducerIdFor(tableId, "sortOrder"),
-      action: actions.sortOrder.sortBy(columnId, desc ?? false)
-    }),
-    clearSortOrder: () => ({
-      type: "REDUCER_ID_GATE:ACTION",
-      reducerId: getReducerIdFor(tableId, "sortOrder"),
-      action: actions.sortOrder.clearSortOrder()
-    })
+    selectByIds: ids =>
+      reducerIdGateAction(
+        getReducerIdFor(tableId, "selectedIds"),
+        actions.selectedIds.setSelectedIds(ids)
+      ),
+    clearSelection: () =>
+      reducerIdGateAction(
+        getReducerIdFor(tableId, "selectedIds"),
+        actions.selectedIds.clearSelectedIds()
+      ),
+    expandByIds: ids =>
+      reducerIdGateAction(
+        getReducerIdFor(tableId, "expandedRows"),
+        actions.expandedRows.setSelectedIds(ids)
+      ),
+    collapseAll: () =>
+      reducerIdGateAction(
+        getReducerIdFor(tableId, "expandedRows"),
+        actions.expandedRows.clearSelectedIds()
+      ),
+    sortBy: (columnId: TColumnKey, desc?: boolean) =>
+      reducerIdGateAction(
+        getReducerIdFor(tableId, "sortOrder"),
+        actions.sortOrder.sortBy(columnId, desc ?? false)
+      ),
+    clearSortOrder: () =>
+      reducerIdGateAction(
+        getReducerIdFor(tableId, "sortOrder"),
+        actions.sortOrder.clearSortOrder()
+      )
   };
 };

--- a/packages/grid/src/features/standard-table/util/ActionsFactory.ts
+++ b/packages/grid/src/features/standard-table/util/ActionsFactory.ts
@@ -28,26 +28,32 @@ export const createStandardTableActions = <TColumnKey extends string>(
 ): StandardTableActions<TColumnKey> => {
   return {
     selectByIds: ids => ({
+      type: "REDUCER_ID_GATE:ACTION",
       reducerId: getReducerIdFor(tableId, "selectedIds"),
       action: actions.selectedIds.setSelectedIds(ids)
     }),
     clearSelection: () => ({
+      type: "REDUCER_ID_GATE:ACTION",
       reducerId: getReducerIdFor(tableId, "selectedIds"),
       action: actions.selectedIds.clearSelectedIds()
     }),
     expandByIds: ids => ({
+      type: "REDUCER_ID_GATE:ACTION",
       reducerId: getReducerIdFor(tableId, "expandedRows"),
       action: actions.expandedRows.setSelectedIds(ids)
     }),
     collapseAll: () => ({
+      type: "REDUCER_ID_GATE:ACTION",
       reducerId: getReducerIdFor(tableId, "expandedRows"),
       action: actions.expandedRows.clearSelectedIds()
     }),
     sortBy: (columnId: TColumnKey, desc?: boolean) => ({
+      type: "REDUCER_ID_GATE:ACTION",
       reducerId: getReducerIdFor(tableId, "sortOrder"),
       action: actions.sortOrder.sortBy(columnId, desc ?? false)
     }),
     clearSortOrder: () => ({
+      type: "REDUCER_ID_GATE:ACTION",
       reducerId: getReducerIdFor(tableId, "sortOrder"),
       action: actions.sortOrder.clearSortOrder()
     })

--- a/packages/redux/src/features/higher-order-reducers/entity-list-reducer/entity-list-reducer.ts
+++ b/packages/redux/src/features/higher-order-reducers/entity-list-reducer/entity-list-reducer.ts
@@ -1,10 +1,13 @@
 import { EntityListAction } from "./entity-list-actions";
 import { fieldsMatch } from "../../../common/util/field-matcher";
-import { Reducer } from "react";
+import { Action, AnyAction, Reducer } from "redux";
 
 export type EntityListState<TListItem> = Array<TListItem>;
 
-export const createEntityListReducer = <TListItem, TListItemAction = unknown>(
+export const createEntityListReducer = <
+  TListItem,
+  TListItemAction extends Action = AnyAction
+>(
   reducer?: Reducer<TListItem, TListItemAction>
 ) => (
   state: EntityListState<TListItem> = [],

--- a/packages/redux/src/features/higher-order-reducers/record-object-reducer/record-object-reducer.ts
+++ b/packages/redux/src/features/higher-order-reducers/record-object-reducer/record-object-reducer.ts
@@ -1,4 +1,4 @@
-import { Reducer } from "react";
+import { Reducer } from "redux";
 import {
   RecordObjectAction,
   RecordObjectClearRecordAction,

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
@@ -6,6 +6,8 @@ import {
   createEntityReducer,
   EntityState
 } from "../../../reducer-factories/entity-reducer/entity-reducer";
+import { createSortOrderReducer } from "../../../reducer-factories/sort-order-reducer/sort-order-reducer";
+import { createSelectedIdsReducer } from "../../../reducer-factories/selected-ids-reducer/selected-ids-reducer";
 
 interface User {
   id?: string;
@@ -39,7 +41,28 @@ describe("reducer-id-gate", () => {
           you: reducerIdGate("you", createEntityReducer<User>({})),
           me: reducerIdGate("me", createEntityReducer<User>({}))
         });
+
+        const sortOrder = reducerIdGate(
+          "sortOrder",
+          createSortOrderReducer<"a">()
+        );
+        const selectedIds = reducerIdGate(
+          "selectedIds",
+          createSelectedIdsReducer()
+        );
+        const expandedRows = reducerIdGate(
+          "expandedRows",
+          createSelectedIdsReducer()
+        );
+
+        const y = combineReducers({
+          sortOrder,
+          selectedIds,
+          expandedRows
+        });
+
         expect(x).toBeDefined();
+        expect(y).toBeDefined();
       });
     });
     describe("with useReducer", () => {

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
@@ -1,4 +1,16 @@
 import { reducerIdGate, reducerIdGateAction } from "../reducer-id-gate";
+import { combineReducers } from "redux";
+import { renderHook } from "@testing-library/react-hooks";
+import { useReducer } from "react";
+import {
+  createEntityReducer,
+  EntityState
+} from "../../../reducer-factories/entity-reducer/entity-reducer";
+
+interface User {
+  id?: string;
+  email?: string;
+}
 
 describe("reducer-id-gate", () => {
   describe("reducerIdGate", () => {
@@ -6,7 +18,7 @@ describe("reducer-id-gate", () => {
       it("runs the specified reducer", () => {
         const innerReducer = () => "hello";
         const reducer = reducerIdGate("test", innerReducer);
-        const r = reducer("", reducerIdGateAction("test", {}));
+        const r = reducer("", reducerIdGateAction("test", { type: "" }));
         expect(r).toBe("hello");
       });
     });
@@ -14,8 +26,27 @@ describe("reducer-id-gate", () => {
       it("does not run the specified reducer", () => {
         const innerReducer = () => "hello";
         const reducer = reducerIdGate("test", innerReducer);
-        const r = reducer("", reducerIdGateAction("notTest", {}));
-        expect(r === "hello").toBe(false);
+        const r = reducer("", reducerIdGateAction("notTest", { type: "" }));
+        expect(r).not.toBe("hello");
+      });
+    });
+    describe("with combineReducers", () => {
+      it("works", () => {
+        const x = combineReducers<{
+          you: EntityState<User>;
+          me: EntityState<User>;
+        }>({
+          you: reducerIdGate("you", createEntityReducer<User>({})),
+          me: reducerIdGate("me", createEntityReducer<User>({}))
+        });
+        expect(x).toBeDefined();
+      });
+    });
+    describe("with useReducer", () => {
+      it("works", () => {
+        const reducer = () => "hello";
+        const x = renderHook(() => useReducer(reducer, "hai"));
+        expect(x).toBeDefined();
       });
     });
   });

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/reducer-id-gate.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/reducer-id-gate.ts
@@ -1,20 +1,27 @@
-import { Reducer } from "react";
+import { Action, Reducer } from "redux";
 
 export interface ReducerIdGateAction<TInnerAction> {
+  type: "REDUCER_ID_GATE:ACTION";
   reducerId: string;
   action: TInnerAction;
 }
 
-export type ReducerIdGateReducer<TState, TInnerAction> = Reducer<
-  TState,
-  ReducerIdGateAction<TInnerAction>
->;
+export type ReducerIdGateReducer<TState, TInnerAction> = (
+  state: TState | undefined,
+  action: ReducerIdGateAction<TInnerAction>
+) => TState;
 
-export const reducerIdGate = <TState, TInnerAction>(
+export const reducerIdGate = <TState, TInnerAction extends Action>(
   reducerId: string,
   reducer: Reducer<TState, TInnerAction>
 ): ReducerIdGateReducer<TState, TInnerAction> => (state, action) => {
-  if (reducerId !== action.reducerId) {
+  if (state === undefined) {
+    return reducer(state, action.action);
+  }
+  if (
+    reducerId !== action.reducerId ||
+    action.type !== "REDUCER_ID_GATE:ACTION"
+  ) {
     return state;
   }
   return reducer(state, action.action);
@@ -23,4 +30,8 @@ export const reducerIdGate = <TState, TInnerAction>(
 export const reducerIdGateAction = <TInnerAction>(
   reducerId: string,
   action: TInnerAction
-): ReducerIdGateAction<TInnerAction> => ({ action, reducerId });
+): ReducerIdGateAction<TInnerAction> => ({
+  type: "REDUCER_ID_GATE:ACTION",
+  action,
+  reducerId
+});

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/reducer-id-gate.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/reducer-id-gate.ts
@@ -1,4 +1,4 @@
-import { Action, Reducer } from "redux";
+import { Action, AnyAction, Reducer } from "redux";
 
 export interface ReducerIdGateAction<TInnerAction> {
   type: "REDUCER_ID_GATE:ACTION";
@@ -6,12 +6,12 @@ export interface ReducerIdGateAction<TInnerAction> {
   action: TInnerAction;
 }
 
-export type ReducerIdGateReducer<TState, TInnerAction> = (
-  state: TState | undefined,
-  action: ReducerIdGateAction<TInnerAction>
-) => TState;
+export type ReducerIdGateReducer<
+  TState,
+  TInnerAction extends Action = AnyAction
+> = Reducer<TState, ReducerIdGateAction<TInnerAction>>;
 
-export const reducerIdGate = <TState, TInnerAction extends Action>(
+export const reducerIdGate = <TState, TInnerAction extends Action = AnyAction>(
   reducerId: string,
   reducer: Reducer<TState, TInnerAction>
 ): ReducerIdGateReducer<TState, TInnerAction> => (state, action) => {

--- a/packages/redux/src/features/reducer-factories/entity-reducer/entity-reducer.ts
+++ b/packages/redux/src/features/reducer-factories/entity-reducer/entity-reducer.ts
@@ -1,8 +1,11 @@
 import { EntityAction } from "./entity-actions";
+import { Reducer } from "redux";
 
 export type EntityState<T> = T;
 
-export const createEntityReducer = <T>(initialEntity: T) => {
+export const createEntityReducer = <T>(
+  initialEntity: T
+): Reducer<EntityState<T>, EntityAction<T>> => {
   const INITIAL_STATE = initialEntity;
 
   return (


### PR DESCRIPTION
- Update higher order reducer types to use type `Reducer` from `redux` package instead of `react`.

- Fix bug in reducerIdGate where undefined state return undefined, which is not allowed by Redux. Instead, it now invokes inner reducer to get initial state.