### PR TITLE
Feature/allow invalid dates in date range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,23 @@
 
 ## Upcoming
 
+## 1.1.0
+
 ### Breaking changes
 
+- No longer clearing `StandardTable` state when new data is fetched.
 
-- No longer clearing `StandardTable` state when new data is fetched
+This caused prefilled checkboxes to be cleared.
+
+This must now be handled manually when there is new data in the table without it being
+unmounted between renders.
+
+- DateRangeInput now allows invalid date range.
+
+Previously, it would switch start date and end date if start date was after end date.
+Instead, it now highlights the inputs with error highlight.
+
+This means that you are no longer guaranteed that the range is valid.
 
 ## 1.0.8
 

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/util/DayStateFactory.ts
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/util/DayStateFactory.ts
@@ -22,11 +22,16 @@ export const buildDayState = (
       statePerMonth
     );
   }
+
+  let state = statePerMonth;
+
   if (start) {
-    return addDayStateHighlights(statePerMonth, start, ["selected"]);
+    state = addDayStateHighlights(state, start, ["selected"]);
   }
+
   if (end) {
-    return addDayStateHighlights(statePerMonth, end, ["selected"]);
+    state = addDayStateHighlights(state, end, ["selected"]);
   }
-  return statePerMonth;
+
+  return state;
 };

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/util/DayStateFactory.ts
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/util/DayStateFactory.ts
@@ -1,4 +1,4 @@
-import { eachDayOfInterval, isSameDay } from "date-fns";
+import { eachDayOfInterval, isAfter, isSameDay } from "date-fns";
 import { CalendarUserData, DayState } from "../../../../types/CalendarTypes";
 import { addDayStateHighlights } from "../../../../util/calendar/StateModifier";
 
@@ -7,7 +7,7 @@ export const buildDayState = (
   start?: Date,
   end?: Date
 ): CalendarUserData<DayState> | undefined => {
-  if (start && end) {
+  if (start && end && isAfter(end, start)) {
     return eachDayOfInterval({ start, end }).reduce(
       (result: CalendarUserData<DayState>, date: Date) => {
         const isFirstInRange = isSameDay(date, start);

--- a/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
+++ b/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
@@ -3,12 +3,11 @@ import { Box, Row, Space, useMultiOnClickOutside } from "@stenajs-webui/core";
 import { TextInput } from "@stenajs-webui/forms";
 import { format } from "date-fns";
 import * as React from "react";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 import * as ReactDOM from "react-dom";
 import { Manager, Reference } from "react-popper";
 import { DateFormats } from "../../../util/date/DateFormats";
 import {
-  DateRangeCalendar,
   DateRangeCalendarOnChangeValue,
   DateRangeCalendarProps
 } from "../../calendar-types/date-range-calendar/DateRangeCalendar";
@@ -20,6 +19,8 @@ import {
 import { useDateRangeInput } from "./hooks/UseDateRangeInput";
 import { Icon } from "@stenajs-webui/elements";
 import { faLongArrowAltRight } from "@fortawesome/free-solid-svg-icons/faLongArrowAltRight";
+import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
+import { buildDayState } from "../../calendar-types/date-range-calendar/util/DayStateFactory";
 
 export interface DateRangeInputProps<T extends {}> {
   /** The current date range value */
@@ -98,19 +99,22 @@ export const DateRangeInput = <T extends {}>({
   const outsideRef = useRef<HTMLDivElement>(null);
   const {
     hideCalendar,
-    onSelectDateRange,
-    setEndDate,
-    setStartDate,
     showCalendarEndDate,
     showCalendarStartDate,
     showingCalendar,
-    setFocusedInput,
     focusedInput,
     startDateInputRef,
-    endDateInputRef
+    endDateInputRef,
+    onClickDay,
+    startDateIsAfterEnd
   } = useDateRangeInput(value, onChange);
 
   useMultiOnClickOutside([popupRef, outsideRef], hideCalendar);
+
+  const statePerMonth = useMemo(
+    () => buildDayState(undefined, value.startDate, value.endDate),
+    [value]
+  );
 
   const popperContent = (
     <CalendarPopperContent
@@ -120,21 +124,16 @@ export const DateRangeInput = <T extends {}>({
       zIndex={zIndex}
       open={showingCalendar}
     >
-      <DateRangeCalendar
+      <CalendarWithMonthSwitcher
         {...calendarProps}
         startDateInFocus={
           focusedInput === "startDate" || focusedInput === "endDate"
             ? value[focusedInput]
             : undefined
         }
-        onChange={onSelectDateRange}
-        startDate={value.startDate}
-        endDate={value.endDate}
-        setStartDate={setStartDate}
-        setEndDate={setEndDate}
-        focusedInput={focusedInput}
-        setFocusedInput={setFocusedInput}
+        statePerMonth={statePerMonth}
         theme={calendarTheme}
+        onClickDay={onClickDay}
       />
     </CalendarPopperContent>
   );
@@ -157,6 +156,7 @@ export const DateRangeInput = <T extends {}>({
                   width={width}
                   inputRef={startDateInputRef}
                   size={9}
+                  variant={startDateIsAfterEnd ? "error" : undefined}
                 />
                 <Space />
                 <Icon
@@ -175,6 +175,7 @@ export const DateRangeInput = <T extends {}>({
                   width={width}
                   inputRef={endDateInputRef}
                   size={9}
+                  variant={startDateIsAfterEnd ? "error" : undefined}
                 />
               </Row>
             </Box>


### PR DESCRIPTION
DateRangeInput no longer uses DateRangeCalendar, which toggles startDate and endDate if startDate is after endDate.
DateRangeInput now allows an invalid date range.
When selecting a date, the focused input is always the one set.
If startDate is after endDate, both inputs are highlighted as errors.