### PR TITLE
Add `commitEditableEntityToPersisted` action to editable-entity-reducer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.7
+
+### Improvements
+
+- Add `commitEditableEntityToPersisted` action to editable-entity-reducer.
+- Remove internal indent in `TableCell` which could break styling of cell.
+
 ## 2.0.6
 
 ### Hotfix

--- a/packages/grid/src/features/table-ui/components/table/TableCell.tsx
+++ b/packages/grid/src/features/table-ui/components/table/TableCell.tsx
@@ -1,4 +1,4 @@
-import { BoxProps, Indent, Row } from "@stenajs-webui/core";
+import { BoxProps, Row } from "@stenajs-webui/core";
 import * as React from "react";
 
 export interface TableCellProps extends BoxProps {}
@@ -7,7 +7,7 @@ export const TableCell: React.FC<TableCellProps> = ({
   alignItems = "center",
   justifyContent = "flex-start",
   overflow = "hidden",
-  children,
+  indent = 1,
   ...boxProps
 }) => {
   return (
@@ -16,9 +16,8 @@ export const TableCell: React.FC<TableCellProps> = ({
       alignItems={alignItems}
       justifyContent={justifyContent}
       overflow={overflow}
+      indent={indent}
       {...boxProps}
-    >
-      <Indent>{children}</Indent>
-    </Row>
+    />
   );
 };

--- a/packages/redux/src/features/reducer-factories/editable-entity-reducer/editable-entity-action-creators.ts
+++ b/packages/redux/src/features/reducer-factories/editable-entity-reducer/editable-entity-action-creators.ts
@@ -1,4 +1,5 @@
 import {
+  EditableEntityCommitEditableEntityToPersistedAction,
   EditableEntityRevertEditableEntityAction,
   EditableEntitySetEditableEntityAction,
   EditableEntitySetEditableEntityFieldsAction,
@@ -18,6 +19,7 @@ export interface EditableEntityActions<T> {
     fields: Partial<T>
   ) => EditableEntitySetEditableEntityFieldsAction<T>;
   revertEditableEntity: () => EditableEntityRevertEditableEntityAction;
+  commitEditableEntityToPersisted: () => EditableEntityCommitEditableEntityToPersistedAction;
 }
 
 export const createEditableEntityActions = <T>(): EditableEntityActions<T> => ({
@@ -40,5 +42,8 @@ export const createEditableEntityActions = <T>(): EditableEntityActions<T> => ({
   }),
   revertEditableEntity: () => ({
     type: "EDITABLE_ENTITY:REVERT_EDITABLE_ENTITY",
+  }),
+  commitEditableEntityToPersisted: () => ({
+    type: "EDITABLE_ENTITY:COMMIT_EDITABLE_ENTITY_TO_PERSISTED",
   }),
 });

--- a/packages/redux/src/features/reducer-factories/editable-entity-reducer/editable-entity-actions.ts
+++ b/packages/redux/src/features/reducer-factories/editable-entity-reducer/editable-entity-actions.ts
@@ -4,7 +4,8 @@ export type EditableEntityAction<T> =
   | EditableEntitySetEditableEntityAction<T>
   | EditableEntitySetEntityIdAction
   | EditableEntitySetEditableEntityFieldsAction<T>
-  | EditableEntityRevertEditableEntityAction;
+  | EditableEntityRevertEditableEntityAction
+  | EditableEntityCommitEditableEntityToPersistedAction;
 
 export interface EditableEntitySetEntityAction<T> {
   type: "EDITABLE_ENTITY:SET_ENTITY";
@@ -33,4 +34,8 @@ export interface EditableEntitySetEditableEntityFieldsAction<T> {
 
 export interface EditableEntityRevertEditableEntityAction {
   type: "EDITABLE_ENTITY:REVERT_EDITABLE_ENTITY";
+}
+
+export interface EditableEntityCommitEditableEntityToPersistedAction {
+  type: "EDITABLE_ENTITY:COMMIT_EDITABLE_ENTITY_TO_PERSISTED";
 }

--- a/packages/redux/src/features/reducer-factories/editable-entity-reducer/editable-entity-reducer.ts
+++ b/packages/redux/src/features/reducer-factories/editable-entity-reducer/editable-entity-reducer.ts
@@ -19,6 +19,14 @@ export const createEditableEntityReducer = <T>(
 
   return (state = initialState, action) => {
     switch (action.type) {
+      case "EDITABLE_ENTITY:SET_ENTITY_ID": {
+        const { id } = action;
+        return {
+          ...state,
+          id,
+        };
+      }
+
       case "EDITABLE_ENTITY:SET_ENTITY": {
         const { entity } = action;
         return {
@@ -59,6 +67,13 @@ export const createEditableEntityReducer = <T>(
         return {
           ...state,
           editable: state.persisted,
+        };
+      }
+
+      case "EDITABLE_ENTITY:COMMIT_EDITABLE_ENTITY_TO_PERSISTED": {
+        return {
+          ...state,
+          persisted: state.editable,
         };
       }
 


### PR DESCRIPTION
- Add `commitEditableEntityToPersisted` action to editable-entity-reducer.
- Remove internal indent in `TableCell` which could break styling of cell.