### PR TITLE
Fix loading button being larger than intended in some Windows browsers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Increased contrast in `Select` light theme hover states.
 `DateTextInput` popover content is now wrapped with a popupRef.
 This fixes a bug where `useMultiOnClickOutside` would cause the popover to close before being able trigger a change.
 
-`PrimaryButton` is now not larger than intended in some Windows browsers.
+`PrimaryButton` is no longer larger than intended on some Windows browsers.
 
 ## 2.0.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,12 @@ Increased contrast in `Select` light theme hover states.
 
 `Banner` component now has `success` & `warning` variants.
 
-### Bug fix
+### Bug fixes
 
 `DateTextInput` popover content is now wrapped with a popupRef.
 This fixes a bug where `useMultiOnClickOutside` would cause the popover to close before being able trigger a change.
+
+`PrimaryButton` is now not larger than intended in some Windows browsers.
 
 ## 2.0.7
 

--- a/packages/elements/src/components/ui/buttons/PrimaryButton.tsx
+++ b/packages/elements/src/components/ui/buttons/PrimaryButton.tsx
@@ -161,7 +161,7 @@ export const PrimaryButton: React.FC<PrimaryButtonProps> = ({
         <FontAwesomeIcon icon={faCheck} className={styles.iconLeft} />
       ) : loading ? (
         <div className={styles.iconLeft}>
-          <InputSpinner size={"100%"} />
+          <InputSpinner />
         </div>
       ) : left ? (
         left


### PR DESCRIPTION
Loading spinner icon with 100% width causes larger than intended buttons in some Windows browsers. This fixes that.

Before: ![image](https://user-images.githubusercontent.com/2521318/96419097-f3cdad80-11f3-11eb-9bdd-8a97a4987361.png)
After: ![image](https://user-images.githubusercontent.com/2521318/96419124-fa5c2500-11f3-11eb-87ea-bdf0fcd9368d.png)
