### PR TITLE
Fix bug in reducer-id-gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This fixes a bug where `useMultiOnClickOutside` would cause the popover to close
 
 `PrimaryButton` is no longer larger than intended on some Windows browsers.
 
+`reducer-id-gate` was calling internal reducer with the action when reducerId did not match, if state was undefined.
+
 ## 2.0.7
 
 ### New components

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
@@ -9,6 +9,7 @@ import {
 import { createSortOrderReducer } from "../../../reducer-factories/sort-order-reducer/sort-order-reducer";
 import { createSelectedIdsReducer } from "../../../reducer-factories/selected-ids-reducer/selected-ids-reducer";
 import fn = jest.fn;
+import { createSelectedIdsActions } from "../../../reducer-factories/selected-ids-reducer/selected-ids-action-creators";
 
 interface User {
   id?: string;
@@ -91,6 +92,22 @@ describe("reducer-id-gate", () => {
         const reducer = () => "hello";
         const x = renderHook(() => useReducer(reducer, "hai"));
         expect(x).toBeDefined();
+      });
+    });
+    describe("when correct internal reducer, but wrong reducerId", () => {
+      describe("and state is not set", () => {
+        describe("it lets internal reducer set internal state", () => {
+          const selectedIdsReducer = reducerIdGate(
+            "selectedIds",
+            createSelectedIdsReducer()
+          );
+          const action = reducerIdGateAction(
+            "wrongId",
+            createSelectedIdsActions().setSelectedIds(["123"])
+          );
+          const r = selectedIdsReducer(undefined, action);
+          expect(r.selectedIds.length).toBe(0);
+        });
       });
     });
   });

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
@@ -94,9 +94,9 @@ describe("reducer-id-gate", () => {
         expect(x).toBeDefined();
       });
     });
-    describe("when correct internal reducer, but wrong reducerId", () => {
+    describe("when matching internal reducer, but wrong reducerId", () => {
       describe("and state is not set", () => {
-        describe("it lets internal reducer set internal state", () => {
+        describe("it lets internal reducer set initial state", () => {
           const selectedIdsReducer = reducerIdGate(
             "selectedIds",
             createSelectedIdsReducer()

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
@@ -8,8 +8,8 @@ import {
 } from "../../../reducer-factories/entity-reducer/entity-reducer";
 import { createSortOrderReducer } from "../../../reducer-factories/sort-order-reducer/sort-order-reducer";
 import { createSelectedIdsReducer } from "../../../reducer-factories/selected-ids-reducer/selected-ids-reducer";
-import fn = jest.fn;
 import { createSelectedIdsActions } from "../../../reducer-factories/selected-ids-reducer/selected-ids-action-creators";
+import fn = jest.fn;
 
 interface User {
   id?: string;

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
@@ -9,7 +9,6 @@ import {
 import { createSortOrderReducer } from "../../../reducer-factories/sort-order-reducer/sort-order-reducer";
 import { createSelectedIdsReducer } from "../../../reducer-factories/selected-ids-reducer/selected-ids-reducer";
 import { createSelectedIdsActions } from "../../../reducer-factories/selected-ids-reducer/selected-ids-action-creators";
-import fn = jest.fn;
 
 interface User {
   id?: string;
@@ -37,7 +36,7 @@ describe("reducer-id-gate", () => {
     describe("when receiving other actions", () => {
       describe("and state is not set", () => {
         it("calls internal reducer with empty action", () => {
-          const innerReducer = fn();
+          const innerReducer = jest.fn();
           const reducer = reducerIdGate("test", innerReducer);
           reducer(undefined, { type: "@@INIT" } as any);
           expect(innerReducer).toHaveBeenCalledWith(undefined, {});
@@ -45,7 +44,7 @@ describe("reducer-id-gate", () => {
       });
       describe("and state is set", () => {
         it("just returns state", () => {
-          const innerReducer = fn();
+          const innerReducer = jest.fn();
           const state = { hello: "world" };
           const reducer = reducerIdGate("test", innerReducer);
           const r = reducer(state, { type: "@@INIT" } as any);

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/reducer-id-gate.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/reducer-id-gate.ts
@@ -15,16 +15,14 @@ export const reducerIdGate = <TState, TInnerAction extends Action = AnyAction>(
   reducerId: string,
   reducer: Reducer<TState, TInnerAction>
 ): ReducerIdGateReducer<TState, TInnerAction> => (state, action) => {
-  if (!isValidReducerIdGateAction(action)) {
-    if (state === undefined) {
-      return reducer(undefined, {} as any);
-    } else {
-      return state;
-    }
-  }
   if (state === undefined) {
-    return reducer(state, action.action);
+    return reducer(undefined, {} as any);
   }
+
+  if (!isValidReducerIdGateAction(action)) {
+    return state;
+  }
+
   if (
     reducerId !== action.reducerId ||
     action.type !== "REDUCER_ID_GATE:ACTION"


### PR DESCRIPTION
reducer-id-gate called the internal reducer even though there was no reducerId match, when state was undefined.