### PR TITLE
Feature/fix new bug in reducer id gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.9
+
+### Bug fix
+
+`reducer-id-gate` did not send action to inner reducer when state was undefined.
+
 ## 2.0.8
 
 ### Design changes

--- a/packages/redux/src/features/higher-order-reducers/record-object-reducer/record-object-action-creators.ts
+++ b/packages/redux/src/features/higher-order-reducers/record-object-reducer/record-object-action-creators.ts
@@ -21,7 +21,7 @@ export const createRecordObjectActions = <
   TInnerAction extends RecordObjectWrappedAction
 >(): RecordObjectActions<TInnerAction> => ({
   recordAction: (recordId, action) => ({
-    type: action.type,
+    type: "RECORD_OBJECT:ACTION",
     action,
     recordId,
   }),

--- a/packages/redux/src/features/higher-order-reducers/record-object-reducer/record-object-actions.ts
+++ b/packages/redux/src/features/higher-order-reducers/record-object-reducer/record-object-actions.ts
@@ -14,7 +14,7 @@ export type RecordObjectKey = string | number;
 export interface RecordObjectRecordAction<
   TInnerAction extends RecordObjectWrappedAction
 > {
-  type: TInnerAction["type"];
+  type: "RECORD_OBJECT:ACTION";
   recordId: RecordObjectKey;
   action: TInnerAction;
 }

--- a/packages/redux/src/features/higher-order-reducers/record-object-reducer/record-object-reducer.ts
+++ b/packages/redux/src/features/higher-order-reducers/record-object-reducer/record-object-reducer.ts
@@ -2,7 +2,6 @@ import { Reducer } from "redux";
 import {
   RecordObjectAction,
   RecordObjectClearRecordAction,
-  RecordObjectRecordAction,
   RecordObjectKey,
   RecordObjectWrappedAction,
 } from "./record-object-actions";
@@ -32,18 +31,16 @@ export const createRecordObjectReducer = <
     case "RECORD_OBJECT:CLEAR_ALL_RECORDS": {
       return {};
     }
-  }
 
-  if ("recordId" in action && "action" in action) {
-    const {
-      recordId,
-      action: innerAction,
-    } = action as RecordObjectRecordAction<TInnerAction>;
-    return {
-      ...state,
-      [recordId]: reducer(state[recordId], innerAction),
-    };
-  }
+    case "RECORD_OBJECT:ACTION": {
+      const { recordId, action: innerAction } = action;
+      return {
+        ...state,
+        [recordId]: reducer(state[recordId], innerAction),
+      };
+    }
 
-  return state;
+    default:
+      return state;
+  }
 };

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
@@ -93,19 +93,36 @@ describe("reducer-id-gate", () => {
         expect(x).toBeDefined();
       });
     });
-    describe("when matching internal reducer, but wrong reducerId", () => {
-      describe("and state is not set", () => {
-        describe("it lets internal reducer set initial state", () => {
-          const selectedIdsReducer = reducerIdGate(
-            "selectedIds",
-            createSelectedIdsReducer()
-          );
-          const action = reducerIdGateAction(
-            "wrongId",
-            createSelectedIdsActions().setSelectedIds(["123"])
-          );
-          const r = selectedIdsReducer(undefined, action);
-          expect(r.selectedIds.length).toBe(0);
+    describe("when state is not set", () => {
+      describe("and matching internal reducer", () => {
+        describe("and correct reducerId", () => {
+          describe("it passes the action to the reducer", () => {
+            const selectedIdsReducer = reducerIdGate(
+              "selectedIds",
+              createSelectedIdsReducer()
+            );
+            const action = reducerIdGateAction(
+              "selectedIds",
+              createSelectedIdsActions().setSelectedIds(["123"])
+            );
+            const r = selectedIdsReducer(undefined, action);
+            expect(r.selectedIds.length).toBe(1);
+            expect(r.selectedIds).toStrictEqual(["123"]);
+          });
+        });
+        describe("but wrong reducerId", () => {
+          describe("it lets internal reducer set initial state", () => {
+            const selectedIdsReducer = reducerIdGate(
+              "selectedIds",
+              createSelectedIdsReducer()
+            );
+            const action = reducerIdGateAction(
+              "wrongId",
+              createSelectedIdsActions().setSelectedIds(["123"])
+            );
+            const r = selectedIdsReducer(undefined, action);
+            expect(r.selectedIds.length).toBe(0);
+          });
         });
       });
     });

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/__tests__/reducer-id-gate.test.ts
@@ -96,7 +96,7 @@ describe("reducer-id-gate", () => {
     describe("when state is not set", () => {
       describe("and matching internal reducer", () => {
         describe("and correct reducerId", () => {
-          describe("it passes the action to the reducer", () => {
+          it("passes the action to the reducer", () => {
             const selectedIdsReducer = reducerIdGate(
               "selectedIds",
               createSelectedIdsReducer()
@@ -111,7 +111,7 @@ describe("reducer-id-gate", () => {
           });
         });
         describe("but wrong reducerId", () => {
-          describe("it lets internal reducer set initial state", () => {
+          it("lets internal reducer set initial state", () => {
             const selectedIdsReducer = reducerIdGate(
               "selectedIds",
               createSelectedIdsReducer()

--- a/packages/redux/src/features/higher-order-reducers/reducer-id-gate/reducer-id-gate.ts
+++ b/packages/redux/src/features/higher-order-reducers/reducer-id-gate/reducer-id-gate.ts
@@ -15,21 +15,19 @@ export const reducerIdGate = <TState, TInnerAction extends Action = AnyAction>(
   reducerId: string,
   reducer: Reducer<TState, TInnerAction>
 ): ReducerIdGateReducer<TState, TInnerAction> => (state, action) => {
-  if (state === undefined) {
-    return reducer(undefined, {} as any);
-  }
+  let newState = state == null ? reducer(undefined, {} as any) : state;
 
   if (!isValidReducerIdGateAction(action)) {
-    return state;
+    return newState;
   }
 
   if (
     reducerId !== action.reducerId ||
     action.type !== "REDUCER_ID_GATE:ACTION"
   ) {
-    return state;
+    return newState;
   }
-  return reducer(state, action.action);
+  return reducer(newState, action.action);
 };
 
 export const reducerIdGateAction = <TInnerAction>(


### PR DESCRIPTION
Reducer id gate did not pass actions down to inner reducer when state was undefined.

Record object action now has own type "RECORD_OBJECT:ACTION" instead of inheriting type from inner action.

