### PR TITLE
add banner variant for showing test env warning

### DIFF
--- a/packages/elements/src/components/ui/banner/Banner.module.css
+++ b/packages/elements/src/components/ui/banner/Banner.module.css
@@ -34,4 +34,14 @@
     --current-bg-color: var(--lhds-color-red-50);
     --current-icon-color: var(--lhds-color-red-500);
   }
+
+  &.environmentWarning {
+    padding: calc(var(--swui-metrics-spacing) / 2)
+      calc(var(--swui-metrics-indent));
+    border-radius: calc(var(--swui-metrics-spacing) / 2);
+    border: 2px solid var(--lhds-color-red-300);
+    color: var(--lhds-color-red-500);
+    --current-bg-color: var(--lhds-color-red-50);
+    --current-icon-color: var(--lhds-color-red-500);
+  }
 }

--- a/packages/elements/src/components/ui/banner/Banner.stories.tsx
+++ b/packages/elements/src/components/ui/banner/Banner.stories.tsx
@@ -61,6 +61,12 @@ export const VariantError = () => (
   </Box>
 );
 
+export const VariantEnvironmentWarning = () => (
+  <Box width={"100px"}>
+    <Banner variant={"environmentWarning"} text={"TEST!"} />
+  </Box>
+);
+
 export const NoHeader = () => (
   <Box width={"500px"}>
     <Banner text={"This is some text."} />

--- a/packages/elements/src/components/ui/banner/Banner.tsx
+++ b/packages/elements/src/components/ui/banner/Banner.tsx
@@ -14,6 +14,7 @@ import styles from "./Banner.module.css";
 import cx from "classnames";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons/faExclamationCircle";
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExclamationTriangle";
+import { faFlask } from "@fortawesome/free-solid-svg-icons/faFlask";
 import { Spinner } from "../spinner/Spinner";
 import { faCheckCircle } from "@fortawesome/free-solid-svg-icons/faCheckCircle";
 
@@ -22,7 +23,8 @@ export type BannerVariant =
   | "info"
   | "success"
   | "warning"
-  | "error";
+  | "error"
+  | "environmentWarning";
 
 export interface BannerProps {
   icon?: IconDefinition;
@@ -39,6 +41,7 @@ const iconPerVariant: Record<BannerVariant, IconDefinition | undefined> = {
   success: faCheckCircle,
   warning: faExclamationCircle,
   error: faExclamationTriangle,
+  environmentWarning: faFlask,
 };
 
 export const Banner: React.FC<BannerProps> = ({


### PR DESCRIPTION
for test environments add variant of banner with less spacing and indent, border and a icon
![image](https://user-images.githubusercontent.com/495782/96871992-4e287180-1473-11eb-80f2-0b543df6c8a3.png)
