### PR TITLE
change banner layout and make text optional to make room for children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2.1.1
+
+### Changes
+
+- `Banner` changed to have optional text
+
+To make room for arbitrary children under header if no text provided
+
+- `Banner` children (i.e bottom content) is now in proper layout under header and text
+- Added story for Banner with both header, text and bottom content
+
 ## 2.1.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 
 ### Changes
 
-- `Banner` changed to have optional text
+- `Banner` changed to have optional text.
 
-To make room for arbitrary children under header if no text provided
+To make room for arbitrary children under header if no text provided.
 
-- `Banner` children (i.e bottom content) is now in proper layout under header and text
-- Added story for Banner with both header, text and bottom content
+- `Banner` children (i.e bottom content) is now in proper layout under header and text.
+- Added story for Banner with both header, text and bottom content.
 
 ## 2.1.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,7 +231,7 @@ Do not export everything, only the things that should be available to the users 
 
 ### 9) Update CHANGELOG.md
 
-State your improvements and changes and increment version
+State your improvements and changes and increment version.
 
 ### 10) Create a pull request in Github
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,13 @@ $ yarn build-all
 First, build the library.
 
 Terminal 1
+
 ```
 $ yarn start-storybook
 ```
+
 Terminal 2
+
 ```
 $ yarn watch
 ```
@@ -29,8 +32,8 @@ $ yarn watch
 
 ### Resources
 
-* https://emotion.sh/docs/introduction
-* https://styled-system.com/
+- https://emotion.sh/docs/introduction
+- https://styled-system.com/
 
 ## Dependencies
 
@@ -133,10 +136,12 @@ export const NiceButton: React.FC<NiceButtonProps> = ({ onClick }) => {
 Boolean props with default value that toggle something, should always default to false.
 
 For example:
+
 ```
 <SomeComp />
 <SomeComp showProfile />
 ```
+
 In this example `showProfile` defaults to `true` when omitted.
 It should be changed to this instead:
 
@@ -224,7 +229,11 @@ Chrome, Firefox, Edge, Safari.
 In `<package>/src/index.ts`, make sure that you export at least your component and the props interface.
 Do not export everything, only the things that should be available to the users (developers).
 
-### 9) Create a pull request in Github
+### 9) Update CHANGELOG.md
+
+State your improvements and changes and increment version
+
+### 10) Create a pull request in Github
 
 Add screenshots for extra points!
 

--- a/packages/elements/src/components/ui/banner/Banner.stories.tsx
+++ b/packages/elements/src/components/ui/banner/Banner.stories.tsx
@@ -1,11 +1,6 @@
 import * as React from "react";
-import { Box, StandardText, Row, Indent } from "@stenajs-webui/core";
-import {
-  Banner,
-  FlatButton,
-  PrimaryButton,
-  Link,
-} from "@stenajs-webui/elements";
+import { Box } from "@stenajs-webui/core";
+import { Banner, FlatButton, PrimaryButton } from "@stenajs-webui/elements";
 
 export default {
   title: "elements/Banner",
@@ -87,26 +82,19 @@ export const LoadingNoHeader = () => (
 export const BottomContent = () => (
   <Box width={"500px"}>
     <Banner variant={"error"} headerText={"This is header"}>
-      <ul style={{ paddingInlineStart: "20px" }}>
-        <li>
-          <Row>
-            <StandardText>
-              This is error one, please correct problem
-            </StandardText>
-            <Indent />
-            <Link onClick={() => alert("Link to error")}>Link to Error</Link>
-          </Row>
-        </li>
-        <li>
-          <Row>
-            <StandardText>
-              This is error two, please correct problem
-            </StandardText>
-            <Indent />
-            <Link onClick={() => alert("Link to error")}>Link to Error</Link>
-          </Row>
-        </li>
-      </ul>
+      <PrimaryButton label={"Retry"} />
+    </Banner>
+  </Box>
+);
+
+export const BottomContentAndText = () => (
+  <Box width={"500px"}>
+    <Banner
+      variant={"error"}
+      headerText={"This is header"}
+      text={"An additional text"}
+    >
+      <PrimaryButton label={"Retry"} />
     </Banner>
   </Box>
 );

--- a/packages/elements/src/components/ui/banner/Banner.stories.tsx
+++ b/packages/elements/src/components/ui/banner/Banner.stories.tsx
@@ -1,6 +1,11 @@
 import * as React from "react";
-import { Box } from "@stenajs-webui/core";
-import { Banner, FlatButton, PrimaryButton } from "@stenajs-webui/elements";
+import { Box, StandardText, Row, Indent } from "@stenajs-webui/core";
+import {
+  Banner,
+  FlatButton,
+  PrimaryButton,
+  Link,
+} from "@stenajs-webui/elements";
 
 export default {
   title: "elements/Banner",
@@ -81,12 +86,27 @@ export const LoadingNoHeader = () => (
 
 export const BottomContent = () => (
   <Box width={"500px"}>
-    <Banner
-      variant={"error"}
-      headerText={"This is header"}
-      text={"This is not working."}
-    >
-      <PrimaryButton label={"Retry"} />
+    <Banner variant={"error"} headerText={"This is header"}>
+      <ul style={{ paddingInlineStart: "20px" }}>
+        <li>
+          <Row>
+            <StandardText>
+              This is error one, please correct problem
+            </StandardText>
+            <Indent />
+            <Link onClick={() => alert("Link to error")}>Link to Error</Link>
+          </Row>
+        </li>
+        <li>
+          <Row>
+            <StandardText>
+              This is error two, please correct problem
+            </StandardText>
+            <Indent />
+            <Link onClick={() => alert("Link to error")}>Link to Error</Link>
+          </Row>
+        </li>
+      </ul>
     </Banner>
   </Box>
 );

--- a/packages/elements/src/components/ui/banner/Banner.tsx
+++ b/packages/elements/src/components/ui/banner/Banner.tsx
@@ -36,7 +36,7 @@ const iconPerVariant: Record<BannerVariant, IconDefinition | undefined> = {
 
 export const Banner: React.FC<BannerProps> = ({
   headerText,
-  text = "",
+  text,
   children,
   contentRight,
   icon,
@@ -67,15 +67,16 @@ export const Banner: React.FC<BannerProps> = ({
             {headerText && (
               <>
                 <StandardText fontWeight={"bold"}>{headerText}</StandardText>
-                {text && <Space />}
               </>
             )}
             {text && (
               <>
+                <Space />
                 <StandardText>{text}</StandardText>
               </>
             )}
-            {children && <>{children}</>}
+            <Space />
+            {children}
           </Column>
         </Row>
         {contentRight && (

--- a/packages/elements/src/components/ui/banner/Banner.tsx
+++ b/packages/elements/src/components/ui/banner/Banner.tsx
@@ -1,14 +1,7 @@
 import * as React from "react";
 import { ReactNode } from "react";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
-import {
-  Column,
-  Indent,
-  Row,
-  Space,
-  Spacing,
-  StandardText,
-} from "@stenajs-webui/core";
+import { Column, Indent, Space, Row, StandardText } from "@stenajs-webui/core";
 import { Icon } from "../icon/Icon";
 import styles from "./Banner.module.css";
 import cx from "classnames";
@@ -27,7 +20,7 @@ export type BannerVariant =
 export interface BannerProps {
   icon?: IconDefinition;
   headerText?: string;
-  text: string;
+  text?: string;
   loading?: boolean;
   contentRight?: ReactNode;
   variant?: BannerVariant;
@@ -43,7 +36,7 @@ const iconPerVariant: Record<BannerVariant, IconDefinition | undefined> = {
 
 export const Banner: React.FC<BannerProps> = ({
   headerText,
-  text,
+  text = "",
   children,
   contentRight,
   icon,
@@ -74,23 +67,21 @@ export const Banner: React.FC<BannerProps> = ({
             {headerText && (
               <>
                 <StandardText fontWeight={"bold"}>{headerText}</StandardText>
-                <Space />
+                {text && <Space />}
               </>
             )}
-            <StandardText>{text}</StandardText>
+            {text && (
+              <>
+                <StandardText>{text}</StandardText>
+              </>
+            )}
+            {children && <>{children}</>}
           </Column>
         </Row>
         {contentRight && (
           <Column justifyContent={"center"}>{contentRight}</Column>
         )}
       </Row>
-
-      {children && (
-        <>
-          <Spacing />
-          {children}
-        </>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
Make banner bottom more customisable with the correct padding and location
Change bottom content story to preview multiline children