### PR TITLE
New components ResultList, ResultListBanner.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,26 @@
 # Changelog
 
-## 2.1.1
+## 2.2.0
+
+### New components
+
+#### `ResultListBanner`
+
+A banner that contains a list of results. Can be used when displaying multiple errors.
+
+- `useResultListBannerState`
+
+A hook that contains all state needed for `ResultListBanner`.
+
+It exposes functions for setting the state of the banner.
+
+#### `ResultList`
+
+A list of results, presented in `ul` tag.
 
 ### Changes
+
+- `Spinner` has new size `tiny`.
 
 - `Banner` changed to have optional text.
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "rollup-plugin-postcss": "^3.1.8",
     "rollup-plugin-typescript2": "^0.27.3",
     "rollup-plugin-url": "^3.0.1",
-    "ts-jest": "^26.4.1",
+    "ts-jest": "^26.4.3",
     "typescript": "^4.0.3"
   },
   "bundlesize": [

--- a/packages/core/src/theme/DefaultTheme.ts
+++ b/packages/core/src/theme/DefaultTheme.ts
@@ -39,9 +39,9 @@ export const defaultTheme: Theme = {
     highlightBoxBorder: "#7498AD",
   },
   metrics: {
-    indent: 10,
-    spacing: 10,
-    space: 10,
+    indent: 8,
+    spacing: 8,
+    space: 8,
   },
   fontWeights: {
     bold: 600,

--- a/packages/elements/src/components/ui/banners/banner/Banner.module.css
+++ b/packages/elements/src/components/ui/banners/banner/Banner.module.css
@@ -2,9 +2,10 @@
   --current-bg-color: var(--lhds-color-ui-200);
   --current-icon-color: var(--lhds-color-ui-500);
 
+  padding: calc(var(--swui-metrics-spacing) * 2) 0;
+  padding-right: calc(var(--swui-metrics-indent) * 2);
+
   background: var(--current-bg-color);
-  padding: calc(var(--swui-metrics-spacing) * 2)
-    calc(var(--swui-metrics-indent) * 2);
 
   .icon {
     color: var(--current-icon-color);

--- a/packages/elements/src/components/ui/banners/banner/Banner.stories.tsx
+++ b/packages/elements/src/components/ui/banners/banner/Banner.stories.tsx
@@ -3,7 +3,7 @@ import { Box } from "@stenajs-webui/core";
 import { Banner, FlatButton, PrimaryButton } from "@stenajs-webui/elements";
 
 export default {
-  title: "elements/Banner",
+  title: "elements/Banners/Banner",
 };
 
 export const Standard = () => (
@@ -94,7 +94,9 @@ export const BottomContentAndText = () => (
       headerText={"This is header"}
       text={"An additional text"}
     >
-      <PrimaryButton label={"Retry"} />
+      <div style={{ display: "inline-block" }}>
+        <PrimaryButton label={"Retry"} />
+      </div>
     </Banner>
   </Box>
 );

--- a/packages/elements/src/components/ui/banners/banner/Banner.tsx
+++ b/packages/elements/src/components/ui/banners/banner/Banner.tsx
@@ -1,13 +1,13 @@
 import * as React from "react";
 import { ReactNode } from "react";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
-import { Column, Indent, Space, Row, StandardText } from "@stenajs-webui/core";
-import { Icon } from "../icon/Icon";
+import { Box, Column, Row, Space, StandardText } from "@stenajs-webui/core";
+import { Icon } from "../../icon/Icon";
 import styles from "./Banner.module.css";
 import cx from "classnames";
 import { faExclamationCircle } from "@fortawesome/free-solid-svg-icons/faExclamationCircle";
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExclamationTriangle";
-import { Spinner } from "../spinner/Spinner";
+import { Spinner } from "../../spinner/Spinner";
 import { faCheckCircle } from "@fortawesome/free-solid-svg-icons/faCheckCircle";
 
 export type BannerVariant =
@@ -46,23 +46,22 @@ export const Banner: React.FC<BannerProps> = ({
   return (
     <div className={cx(styles.banner, styles[variant])}>
       <Row justifyContent={"space-between"}>
-        <Row>
+        <Row width={"64px"} justifyContent={"center"} alignItems={"center"}>
           {(icon || iconPerVariant[variant] || loading) && (
             <>
-              <Column justifyContent={"center"}>
-                {loading ? (
-                  <Spinner size={"small"} color={"var(--current-icon-color)"} />
-                ) : (
-                  <Icon
-                    icon={icon ?? iconPerVariant[variant]}
-                    size={24}
-                    className={styles.icon}
-                  />
-                )}
-              </Column>
-              <Indent />
+              {loading ? (
+                <Spinner size={"tiny"} color={"var(--current-icon-color)"} />
+              ) : (
+                <Icon
+                  icon={icon ?? iconPerVariant[variant]}
+                  size={24}
+                  className={styles.icon}
+                />
+              )}
             </>
           )}
+        </Row>
+        <Row justifyContent={"space-between"} flexGrow={1}>
           <Column justifyContent={"center"}>
             {headerText && (
               <>
@@ -71,18 +70,27 @@ export const Banner: React.FC<BannerProps> = ({
             )}
             {text && (
               <>
-                <Space />
+                {headerText && <Space num={2} />}
                 <StandardText>{text}</StandardText>
               </>
             )}
-            <Space />
-            {children}
           </Column>
+          {contentRight && (
+            <Column justifyContent={"center"}>{contentRight}</Column>
+          )}
         </Row>
-        {contentRight && (
-          <Column justifyContent={"center"}>{contentRight}</Column>
-        )}
       </Row>
+      {children && (
+        <Row>
+          <Box minWidth={"64px"} />
+          <Box>
+            <>
+              <Space num={2} />
+              {children}
+            </>
+          </Box>
+        </Row>
+      )}
     </div>
   );
 };

--- a/packages/elements/src/components/ui/banners/result-list-banner/ResultListBanner.stories.tsx
+++ b/packages/elements/src/components/ui/banners/result-list-banner/ResultListBanner.stories.tsx
@@ -1,0 +1,94 @@
+import {
+  ResultListBanner,
+  useResultListBannerState,
+} from "@stenajs-webui/elements";
+import * as React from "react";
+
+export default {
+  title: "elements/Banners/ResultListBanner",
+};
+
+export const Standard = () => {
+  const { bannerState } = useResultListBannerState({
+    headerText: "Could not save bookings",
+    items: [
+      {
+        text: "Booking has no route.",
+      },
+      {
+        text: "Booking has no customer.",
+        linkText: "1232",
+        onClickLink: () => alert("Clicked link"),
+      },
+      {
+        text:
+          " https://agreements-api-sl-freight-core-dev.apps-internal.ocp.aws.stena.io/api/v1/AgrRoutePrice/?ids%5B0%5D=ef9a5650-cdc0-4f5a-b009-1db021ee201b&ids%5B1%5D=031635ca-76e4-4ac8-8679-227bf1b42534&ids%5B2%5D=4f8c5549-3c24-47a2-9627-34a07c832479",
+        linkText: "This is a long link that must look good",
+        onClickLink: () => alert("Clicked link"),
+      },
+    ],
+  });
+
+  if (!bannerState) {
+    return null;
+  }
+
+  return <ResultListBanner variant={"error"} bannerState={bannerState} />;
+};
+
+export const WithText = () => {
+  const { bannerState } = useResultListBannerState({
+    headerText: "Could not save bookings",
+    text: "You need to take action on these bookings.",
+    items: [
+      {
+        text: "Booking has no route.",
+      },
+      {
+        text: "Booking has no customer.",
+        linkText: "1232",
+        onClickLink: () => alert("Clicked link"),
+      },
+      {
+        text:
+          "https://agreements-api-sl-freight-core-dev.apps-internal.ocp.aws.stena.io/api/v1/AgrRoutePrice/?ids%5B0%5D=ef9a5650-cdc0-4f5a-b009-1db021ee201b&ids%5B1%5D=031635ca-76e4-4ac8-8679-227bf1b42534&ids%5B2%5D=4f8c5549-3c24-47a2-9627-34a07c832479",
+        linkText: "1234",
+        onClickLink: () => alert("Clicked link"),
+      },
+    ],
+  });
+
+  if (!bannerState) {
+    return null;
+  }
+
+  return <ResultListBanner variant={"error"} bannerState={bannerState} />;
+};
+
+export const WithTextOnly = () => {
+  const { bannerState } = useResultListBannerState({
+    text: "You need to take action on these bookings.",
+    items: [
+      {
+        text: "Booking has no route.",
+      },
+      {
+        text: "Booking has no customer.",
+        linkText: "1232",
+        onClickLink: () => alert("Clicked link"),
+      },
+      {
+        text:
+          "https://agreements-api-sl-freight-core-dev.apps-internal.ocp.aws.stena.io/api/v1/AgrRoutePrice/?ids%5B0%5D=ef9a5650-cdc0-4f5a-b009-1db021ee201b&ids%5B1%5D=031635ca-76e4-4ac8-8679-227bf1b42534&ids%5B2%5D=4f8c5549-3c24-47a2-9627-34a07c832479",
+        linkText: "1234",
+        onClickLink: () => alert("Clicked link"),
+      },
+    ],
+  });
+
+  if (!bannerState) {
+    return null;
+  }
+
+  return <ResultListBanner variant={"error"} bannerState={bannerState} />;
+};

--- a/packages/elements/src/components/ui/banners/result-list-banner/ResultListBanner.tsx
+++ b/packages/elements/src/components/ui/banners/result-list-banner/ResultListBanner.tsx
@@ -1,0 +1,42 @@
+import * as React from "react";
+import { Banner, BannerProps } from "../banner/Banner";
+import { ResultItem, ResultListRow } from "../../result-list/ResultListRow";
+import { ResultList } from "../../result-list/ResultList";
+
+export interface ResultListBannerState {
+  headerText?: string;
+  text?: string;
+  items?: Array<ResultItem>;
+}
+
+export interface ResultListBannerProps
+  extends Omit<BannerProps, "headerText" | "text"> {
+  bannerState: ResultListBannerState;
+}
+
+export const ResultListBanner: React.FC<ResultListBannerProps> = ({
+  bannerState,
+  ...bannerProps
+}) => {
+  return (
+    <Banner
+      {...bannerProps}
+      headerText={bannerState.headerText}
+      text={bannerState.text}
+    >
+      {bannerState.items && (
+        <>
+          <ResultList>
+            {bannerState.items.map((item) => (
+              <ResultListRow
+                text={item.text}
+                linkText={item.linkText}
+                onClickLink={item.onClickLink}
+              />
+            ))}
+          </ResultList>
+        </>
+      )}
+    </Banner>
+  );
+};

--- a/packages/elements/src/components/ui/banners/result-list-banner/hooks/UseResultListBannerState.ts
+++ b/packages/elements/src/components/ui/banners/result-list-banner/hooks/UseResultListBannerState.ts
@@ -1,0 +1,54 @@
+import { useCallback, useState } from "react";
+import { ResultItem } from "../../../result-list/ResultListRow";
+import { ResultListBannerState } from "../ResultListBanner";
+
+export const useResultListBannerState = (
+  initialState: ResultListBannerState | undefined
+) => {
+  const [bannerState, setBannerState] = useState(initialState);
+
+  const setBannerResultWithTexts = useCallback(
+    (listTexts: Array<string>) => {
+      setBannerState((bannerState) => ({
+        ...bannerState,
+        items: listTexts.map<ResultItem>((text) => ({ text })),
+      }));
+    },
+    [setBannerState]
+  );
+
+  const setBannerResultWithErrors = useCallback(
+    (errors: Array<Error>) => {
+      setBannerResultWithTexts(errors.map((e) => e.message));
+    },
+    [setBannerResultWithTexts]
+  );
+
+  const clearBannerResult = useCallback(() => {
+    setBannerState(undefined);
+  }, [setBannerState]);
+
+  return {
+    bannerState,
+    setBannerState,
+    setBannerResultWithTexts,
+    setBannerResultWithErrors,
+    clearBannerResult,
+  };
+};
+
+export type ResultListBannerStateSetter = ReturnType<
+  typeof useResultListBannerState
+>["setBannerState"];
+
+export type ResultListBannerStateSetterWithTexts = ReturnType<
+  typeof useResultListBannerState
+>["setBannerResultWithTexts"];
+
+export type ResultListBannerStateSetterWithErrors = ReturnType<
+  typeof useResultListBannerState
+>["setBannerResultWithErrors"];
+
+export type ResultListBannerStateClearer = ReturnType<
+  typeof useResultListBannerState
+>["clearBannerResult"];

--- a/packages/elements/src/components/ui/result-list/ResultList.module.css
+++ b/packages/elements/src/components/ui/result-list/ResultList.module.css
@@ -1,0 +1,9 @@
+.resultList {
+  margin: 0;
+  padding-inline-start: 20px;
+  padding-inline-end: 0;
+
+  li:not(:last-child) {
+    margin-bottom: calc(var(--swui-metrics-spacing));
+  }
+}

--- a/packages/elements/src/components/ui/result-list/ResultList.tsx
+++ b/packages/elements/src/components/ui/result-list/ResultList.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+import { Children } from "react";
+import styles from "./ResultList.module.css";
+
+interface Props {}
+
+export const ResultList: React.FC<Props> = ({ children }) => {
+  return (
+    <ul className={styles.resultList}>
+      {Children.map(children, (child) => (
+        <li>{child}</li>
+      ))}
+    </ul>
+  );
+};

--- a/packages/elements/src/components/ui/result-list/ResultListRow.module.css
+++ b/packages/elements/src/components/ui/result-list/ResultListRow.module.css
@@ -1,0 +1,8 @@
+.resultItemRow {
+  display: flex;
+  flex-direction: column;
+
+  .link {
+    margin-top: 4px;
+  }
+}

--- a/packages/elements/src/components/ui/result-list/ResultListRow.tsx
+++ b/packages/elements/src/components/ui/result-list/ResultListRow.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { StandardText } from "@stenajs-webui/core";
+import { Link } from "../link/Link";
+import styles from "./ResultListRow.module.css";
+
+export interface ResultItem {
+  text: string;
+  linkText?: string;
+  onClickLink?: () => void;
+}
+
+export interface ResultItemProps extends ResultItem {}
+
+export const ResultListRow: React.FC<ResultItemProps> = ({
+  text,
+  onClickLink,
+  linkText,
+}) => {
+  return (
+    <div className={styles.resultItemRow}>
+      <StandardText>{text}</StandardText>
+      {linkText && (
+        <Link className={styles.link} onClick={onClickLink}>
+          {linkText}
+        </Link>
+      )}
+    </div>
+  );
+};

--- a/packages/elements/src/components/ui/spinner/Spinner.tsx
+++ b/packages/elements/src/components/ui/spinner/Spinner.tsx
@@ -2,7 +2,7 @@ import { ClassNames, keyframes } from "@emotion/core";
 import * as React from "react";
 import { ReactComponent as SpinnerSvg } from "./spinner-large.svg";
 
-export type SpinnerSize = "large" | "normal" | "small";
+export type SpinnerSize = "large" | "normal" | "small" | "tiny";
 
 export interface SpinnerProps {
   size?: SpinnerSize | string;
@@ -10,7 +10,7 @@ export interface SpinnerProps {
   inverted?: boolean;
 }
 
-const sizes = {
+const sizes: Record<SpinnerSize, string> = {
   large: "78px",
   normal: "54px",
   small: "34px",

--- a/packages/elements/src/index.ts
+++ b/packages/elements/src/index.ts
@@ -3,7 +3,11 @@ import "./default-theme.css";
 
 export * from "./icons/Icons";
 
-export * from "./components/ui/banner/Banner";
+export * from "./components/ui/banners/banner/Banner";
+export * from "./components/ui/banners/result-list-banner/ResultListBanner";
+export * from "./components/ui/banners/result-list-banner/hooks/UseResultListBannerState";
+export * from "./components/ui/result-list/ResultList";
+export * from "./components/ui/result-list/ResultListRow";
 export * from "./components/ui/spinner/Spinner";
 export * from "./components/ui/spinner/InputSpinner";
 export * from "./components/ui/buttons/FlatButton";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,6 +1354,11 @@
     slash "^2.0.0"
     strip-ansi "^5.0.0"
 
+"@jest/create-cache-key-function@^26.5.0":
+  version "26.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-26.5.0.tgz#1d07947adc51ea17766d9f0ccf5a8d6ea94c47dc"
+  integrity sha512-DJ+pEBUIqarrbv1W/C39f9YH0rJ4wsXZ/VC6JafJPlHW2HOucKceeaqTOQj9MEDQZjySxMLkOq5mfXZXNZcmWw==
+
 "@jest/environment@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-24.9.0.tgz#21e3afa2d65c0586cbd6cbefe208bafade44ab18"
@@ -16795,11 +16800,12 @@ ts-essentials@^2.0.3:
   resolved "https://registry.yarnpkg.com/ts-essentials/-/ts-essentials-2.0.12.tgz#c9303f3d74f75fa7528c3d49b80e089ab09d8745"
   integrity sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==
 
-ts-jest@^26.4.1:
-  version "26.4.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.1.tgz#08ec0d3fc2c3a39e4a46eae5610b69fafa6babd0"
-  integrity sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==
+ts-jest@^26.4.3:
+  version "26.4.3"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.3.tgz#d153a616033e7ec8544b97ddbe2638cbe38d53db"
+  integrity sha512-pFDkOKFGY+nL9v5pkhm+BIFpoAuno96ff7GMnIYr/3L6slFOS365SI0fGEVYx2RKGji5M2elxhWjDMPVcOCdSw==
   dependencies:
+    "@jest/create-cache-key-function" "^26.5.0"
     "@types/jest" "26.x"
     bs-logger "0.x"
     buffer-from "1.x"


### PR DESCRIPTION
### New components

#### `ResultListBanner`

A banner that contains a list of results. Can be used when displaying multiple errors.

![image](https://user-images.githubusercontent.com/1266041/97426125-4ce3c280-1913-11eb-9b5f-afd3a15cf220.png)

![image](https://user-images.githubusercontent.com/1266041/97425460-70f2d400-1912-11eb-8a93-32d9ebc89df7.png)

- `useResultListBannerState`

A hook that contains all state needed for `ResultListBanner`.

It exposes functions for setting the state of the banner.

#### `ResultList`

A list of results, presented in `ul` tag.

### Changes

- `Spinner` has new size `tiny`.

- `Banner` changed to have optional text.

To make room for arbitrary children under header if no text provided.

- `Banner` children (i.e bottom content) is now in proper layout under header and text.
- Added story for Banner with both header, text and bottom content.