### PR TITLE
Fixes for Excel export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 7.1.0
+
+### grid-export
+
+- Null and undefined in cells are now rendered as empty strings.
+- Add support for booleans, will render "Y" when true and "" when false.
+
+#### Fixes
+
+- When `itemLabelFormatter` returned falsy value, Excel cell would instead contain the non-formatted value.
+
 ## 7.0.0
 
 ### StandardTable

--- a/packages/grid-export/src/transformers/CellTransformer.ts
+++ b/packages/grid-export/src/transformers/CellTransformer.ts
@@ -1,16 +1,27 @@
-import { ZipCelXCell } from "zipcelx";
+import { StandardTableColumnConfig } from "@stenajs-webui/grid";
 import { format } from "date-fns";
+import { ZipCelXCell } from "zipcelx";
+import { CustomCellFormatter } from "./ConfigTransformer";
 
-export const transformItemToCell = <TValue>(
-  value: TValue,
-  label: string | undefined,
-  formatted?: string | number
+export const transformItemToCell = <TItem, TItemValue>(
+  item: TItem,
+  itemValueResolver: StandardTableColumnConfig<
+    TItem,
+    TItemValue
+  >["itemValueResolver"],
+  itemLabelFormatter:
+    | StandardTableColumnConfig<TItem, TItemValue>["itemLabelFormatter"]
+    | undefined,
+  formatter?: CustomCellFormatter<TItem>
 ): ZipCelXCell => {
-  if (formatted != null) {
-    return createCell(formatted);
+  if (formatter) {
+    return createCell(formatter(item));
   }
 
-  if (label) {
+  const value = itemValueResolver(item);
+
+  if (itemLabelFormatter) {
+    const label = itemLabelFormatter?.(value, item);
     return createCell(label);
   }
 
@@ -18,8 +29,16 @@ export const transformItemToCell = <TValue>(
     return createCell(value);
   }
 
+  if (typeof value === "boolean") {
+    return createCell(value ? "Y" : "");
+  }
+
   if (value instanceof Date) {
     return createCell(format(value, "yyyy-MM-dd HH:mm"));
+  }
+
+  if (value == null) {
+    return createCell("");
   }
 
   return createCell(String(value));

--- a/packages/grid-export/src/transformers/RowTransformer.ts
+++ b/packages/grid-export/src/transformers/RowTransformer.ts
@@ -1,7 +1,9 @@
-import { StandardTableConfig } from "@stenajs-webui/grid";
+import {
+  StandardTableColumnGroupConfig,
+  StandardTableConfig,
+} from "@stenajs-webui/grid";
 import { flatten } from "lodash";
 import { ZipCelXCell, ZipCelXRow } from "zipcelx";
-import { StandardTableColumnGroupConfig } from "@stenajs-webui/grid";
 import { transformItemToCell } from "./CellTransformer";
 import { CustomCellFormatters } from "./ConfigTransformer";
 
@@ -36,7 +38,10 @@ export const transformCell = <
 ): ZipCelXCell => {
   const columnConfig = config.columns[columnId];
   const formatter = formatters?.[columnId];
-  const value = columnConfig.itemValueResolver(item);
-  const label = columnConfig.itemLabelFormatter?.(value, item);
-  return transformItemToCell(value, label, formatter?.(item));
+  return transformItemToCell(
+    item,
+    columnConfig.itemValueResolver,
+    columnConfig.itemLabelFormatter,
+    formatter
+  );
 };

--- a/packages/grid-export/src/transformers/__tests__/CellTransformer.test.ts
+++ b/packages/grid-export/src/transformers/__tests__/CellTransformer.test.ts
@@ -2,10 +2,12 @@ import { transformItemToCell } from "../CellTransformer";
 
 describe("CellTransformer", () => {
   describe("transformItemToCell", () => {
-    describe("when label is undefined", () => {
+    describe("when there is no itemLabelFormatter", () => {
       describe("and value is string", () => {
         it("returns value and type string", () => {
-          expect(transformItemToCell("hej", undefined)).toStrictEqual({
+          expect(
+            transformItemToCell({ x: "hej" }, (item) => item.x, undefined)
+          ).toStrictEqual({
             value: "hej",
             type: "string",
           });
@@ -13,26 +15,58 @@ describe("CellTransformer", () => {
       });
       describe("and value is number", () => {
         it("returns value and type number", () => {
-          expect(transformItemToCell(123, undefined)).toStrictEqual({
+          expect(
+            transformItemToCell({ x: 123 }, (item) => item.x, undefined)
+          ).toStrictEqual({
             value: 123,
             type: "number",
+          });
+        });
+      });
+      describe("and value is boolean", () => {
+        describe("and value is true", () => {
+          it("returns Y and type string", () => {
+            expect(
+              transformItemToCell({ x: true }, (item) => item.x, undefined)
+            ).toStrictEqual({
+              value: "Y",
+              type: "string",
+            });
+          });
+        });
+        describe("and value is false", () => {
+          it("returns empty and type string", () => {
+            expect(
+              transformItemToCell({ x: false }, (item) => item.x, undefined)
+            ).toStrictEqual({
+              value: "",
+              type: "string",
+            });
           });
         });
       });
       describe("and value is Date", () => {
         it("returns formatted date and type string", () => {
           let date = new Date(2020, 4, 9, 12, 0, 0);
-          expect(transformItemToCell(date, undefined)).toStrictEqual({
+          expect(
+            transformItemToCell({ x: date }, (item) => item.x, undefined)
+          ).toStrictEqual({
             value: "2020-05-09 12:00",
             type: "string",
           });
         });
       });
     });
-    describe("when label is defined", () => {
+    describe("when there is an itemLabelFormatter", () => {
       it("returns label and type string", () => {
         let date = new Date(2020, 4, 9, 12, 0, 0);
-        expect(transformItemToCell(date, "hello")).toStrictEqual({
+        expect(
+          transformItemToCell(
+            { x: date },
+            (item) => item.x,
+            () => "hello"
+          )
+        ).toStrictEqual({
           value: "hello",
           type: "string",
         });
@@ -42,7 +76,14 @@ describe("CellTransformer", () => {
       describe("custom format is string", () => {
         it("returns custom format and type string", () => {
           let date = new Date(2020, 4, 9, 12, 0, 0);
-          expect(transformItemToCell(date, "hello", "custom")).toStrictEqual({
+          expect(
+            transformItemToCell(
+              date,
+              () => null,
+              undefined,
+              () => "custom"
+            )
+          ).toStrictEqual({
             value: "custom",
             type: "string",
           });
@@ -51,7 +92,14 @@ describe("CellTransformer", () => {
       describe("custom format is number", () => {
         it("returns custom format and type number", () => {
           let date = new Date(2020, 4, 9, 12, 0, 0);
-          expect(transformItemToCell(date, "hello", 3)).toStrictEqual({
+          expect(
+            transformItemToCell(
+              date,
+              () => null,
+              undefined,
+              () => 3
+            )
+          ).toStrictEqual({
             value: 3,
             type: "number",
           });


### PR DESCRIPTION
### grid-export

- Null and undefined in cells are now rendered as empty strings.
- Add support for booleans, will render "Y" when true and "" when false.

#### Fixes

- When `itemLabelFormatter` returned falsy value, Excel cell would instead contain the non-formatted value.
