### PR TITLE
Clearing value of DateTimeInput did not clear time input

### DIFF
--- a/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.stories.tsx
@@ -1,3 +1,6 @@
+import { faTrash } from "@fortawesome/free-solid-svg-icons/faTrash";
+import { Indent, Row } from "@stenajs-webui/core";
+import { FlatButton } from "@stenajs-webui/elements";
 import { Story } from "@storybook/react";
 import * as React from "react";
 import { useState } from "react";
@@ -16,13 +19,19 @@ export default {
 };
 
 export const Standard = () => {
-  const [value, setValue] = useState<Date | undefined>(undefined);
+  const [value, setValue] = useState<Date | null>(null);
 
-  return <DateTimeInput value={value} onValueChange={setValue} />;
+  return (
+    <Row>
+      <DateTimeInput value={value} onValueChange={setValue} />
+      <Indent />
+      <FlatButton leftIcon={faTrash} onClick={() => setValue(null)} />
+    </Row>
+  );
 };
 
 export const PreselectedValue = () => {
-  const [value, setValue] = useState<Date | undefined>(new Date());
+  const [value, setValue] = useState<Date | null>(new Date());
 
   return <DateTimeInput value={value} onValueChange={setValue} />;
 };

--- a/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.tsx
+++ b/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.tsx
@@ -133,7 +133,7 @@ export const DateTimeInput: React.FC<DateTimeInputProps> = ({
                 <Column>
                   <Column overflow={"hidden"} height={"250px"}>
                     <TimePicker
-                      value={timeValue}
+                      value={timeValue ?? ""}
                       onValueChange={onChangeTime}
                     />
                   </Column>
@@ -167,7 +167,7 @@ export const DateTimeInput: React.FC<DateTimeInputProps> = ({
           onClickRight={onFocusRight}
           inputRefLeft={dateInputRef}
           inputRefRight={timeInputRef}
-          valueRight={timeValue}
+          valueRight={timeValue ?? ""}
           widthLeft={"104px"}
           widthRight={"64px"}
         />

--- a/packages/calendar/src/components/input-types/date-time-input/hooks/UseDateRangeHandlers.ts
+++ b/packages/calendar/src/components/input-types/date-time-input/hooks/UseDateRangeHandlers.ts
@@ -33,7 +33,7 @@ export const useDateRangeHandlers = (
         newDate.setMinutes(date.getMinutes());
 
         onValueChange?.(newDate);
-        setLocalDate(newDate);
+        setLocalDate(undefined);
       } else if (localTime) {
         // Only time has been selected
         const { minute, hour } = getHoursAndMinutesFromTimeString(localTime);
@@ -42,7 +42,7 @@ export const useDateRangeHandlers = (
         newDate.setMinutes(minute ?? 0);
 
         onValueChange?.(newDate);
-        setLocalDate(newDate);
+        setLocalDate(undefined);
       } else {
         // Nothing has been selected
         setLocalDate(newDate);
@@ -70,7 +70,7 @@ export const useDateRangeHandlers = (
         newDate.setMinutes(newTime.minute || 0);
 
         onValueChange?.(newDate);
-        setLocalTime(time);
+        setLocalTime(undefined);
       } else if (localDate) {
         // Only date has already been selected
         const newTime = getHoursAndMinutesFromTimeString(time);
@@ -80,7 +80,7 @@ export const useDateRangeHandlers = (
         newDate.setMinutes(newTime.minute || 0);
 
         onValueChange?.(newDate);
-        setLocalTime(time);
+        setLocalTime(undefined);
       } else {
         // Nothing has been selected
         setLocalTime(time);

--- a/packages/calendar/src/components/input-types/date-time-input/hooks/UseUserInputHandlers.ts
+++ b/packages/calendar/src/components/input-types/date-time-input/hooks/UseUserInputHandlers.ts
@@ -31,7 +31,8 @@ export const useUserInputHandlers = (
   const onClickDay = useCallback(
     (day: DayData) => {
       onChangeDate(day.date);
-      setTimeout(hideCalendar, 50);
+      hideCalendar();
+      showTimePicker();
     },
     [onChangeDate, hideCalendar]
   );

--- a/packages/calendar/src/components/input-types/date-time-input/hooks/UseUserInputHandlers.ts
+++ b/packages/calendar/src/components/input-types/date-time-input/hooks/UseUserInputHandlers.ts
@@ -34,7 +34,7 @@ export const useUserInputHandlers = (
       hideCalendar();
       showTimePicker();
     },
-    [onChangeDate, hideCalendar]
+    [onChangeDate, hideCalendar, showTimePicker]
   );
 
   const onClickArrowButton = useCallback(() => {


### PR DESCRIPTION
- Opening time picker after clicking on day in DateTimeInput.
- Add clear button to DateTimeInput.
- Clearing the date exposed an issue where time input was not cleared. That issue has been fixed as well.