### PR TITLE
Change bold font weight to 500

### DIFF
--- a/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
+++ b/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
@@ -2,7 +2,7 @@
   color: var(--swui-text-action-color);
   font-size: 10px;
   font-family: var(--swui-font-primary);
-  font-weight: 600;
+  font-weight: var(--swui-font-weight-text-bold);
   letter-spacing: 1px;
   text-decoration: none;
   cursor: pointer;

--- a/packages/panels/src/components/collapsible/Collapsible.module.css
+++ b/packages/panels/src/components/collapsible/Collapsible.module.css
@@ -46,9 +46,6 @@
   .header {
     background-color: var(--swui-collapsible-header-background-color);
     width: 100%;
-    font-size: inherit;
-    font-family: var(--swui-font-primary);
-    font-weight: var(--swui-collapsible-header-font-weight);
     text-align: left;
 
     min-height: var(--swui-collapsible-min-height);
@@ -101,6 +98,10 @@
     bottom: 0;
     left: 0;
     z-index: 1;
+  }
+
+  .headerText {
+    font-weight: var(--swui-collapsible-header-font-weight);
   }
 
   &[aria-expanded="false"] {
@@ -157,7 +158,7 @@
       font-family: var(--swui-font-primary);
       color: var(--swui-collapsible-groupheading-text-color);
       text-transform: uppercase;
-      font-weight: 600;
+      font-weight: var(--swui-font-weight-text-bold);
       letter-spacing: 1px;
     }
 

--- a/packages/panels/src/components/collapsible/Collapsible.tsx
+++ b/packages/panels/src/components/collapsible/Collapsible.tsx
@@ -92,7 +92,10 @@ export const Collapsible = forwardRef<HTMLButtonElement, CollapsibleProps>(
             <div className={styles.contentLeft}>{contentLeft}</div>
           )}
           <div className={styles.label}>
-            <Text color={"var(--swui-collapsible-header-text-color)"}>
+            <Text
+              color={"var(--swui-collapsible-header-text-color)"}
+              className={styles.headerText}
+            >
               {label}
             </Text>
           </div>

--- a/packages/theme/src/styles/default-theme.css
+++ b/packages/theme/src/styles/default-theme.css
@@ -30,7 +30,7 @@
   /* Fonts */
   --swui-font-primary: "Stena Sans", "Open Sans", Arial, sans-serif;
   --swui-font-weight-text: 400;
-  --swui-font-weight-text-bold: 600;
+  --swui-font-weight-text-bold: 500;
   --swui-font-weight-link: 400;
   --swui-font-buttons: var(--swui-font-primary);
   --swui-font-input: var(--swui-font-primary);


### PR DESCRIPTION
Should probably solve the rest of the migration to Stena Sans with this, because Open Sans thinks of 500 as regular, i.e. it won't play nice if you're still running Open Sans.