### PR TITLE
Task 66744: Use Banner in StandardTable no items message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Next
+
+### StandardTable
+
+- Now uses `Banner` to show no items available message.
+- Add props `noItemsContentRight`, `noItemsContentBottom`
+  and `noItemsHeader` to customize the banner.
+
+### Banner
+
+- Design updated to make it slightly more compact.
+
 ## 9.1.3
 
 - Fix bug introduced in 9.1.2 where border-radius was not applied in `ActionMenuItem`.

--- a/packages/elements/src/components/ui/banners/banner/Banner.tsx
+++ b/packages/elements/src/components/ui/banners/banner/Banner.tsx
@@ -1,7 +1,15 @@
 import * as React from "react";
 import { ReactNode } from "react";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
-import { Box, Column, Indent, Row, Space, Text } from "@stenajs-webui/core";
+import {
+  Box,
+  Column,
+  Heading,
+  Indent,
+  Row,
+  Space,
+  Text,
+} from "@stenajs-webui/core";
 import { Icon } from "../../icon/Icon";
 import styles from "./Banner.module.css";
 import cx from "classnames";
@@ -70,12 +78,12 @@ export const Banner: React.FC<BannerProps> = ({
           <Column justifyContent={"center"}>
             {headerText && (
               <>
-                <Text variant={"bold"}>{headerText}</Text>
+                <Heading variant={"h5"}>{headerText}</Heading>
               </>
             )}
             {text && (
               <>
-                {headerText && <Space num={2} />}
+                {headerText && <Space />}
                 <Text>{text}</Text>
               </>
             )}
@@ -93,7 +101,7 @@ export const Banner: React.FC<BannerProps> = ({
           <Box minWidth={"64px"} />
           <Box>
             <>
-              <Space num={2} />
+              <Space />
               {children}
             </>
           </Box>

--- a/packages/elements/src/components/ui/banners/result-list-banner/ResultListBanner.stories.tsx
+++ b/packages/elements/src/components/ui/banners/result-list-banner/ResultListBanner.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { FlatButton } from "../../buttons/FlatButton";
 import { useResultListBannerState } from "./hooks/UseResultListBannerState";
 import { ResultListBanner, ResultListBannerProps } from "./ResultListBanner";
 import { Story } from "@storybook/react";
@@ -105,4 +106,39 @@ export const WithTextOnly = () => {
   }
 
   return <ResultListBanner variant={"error"} bannerState={bannerState} />;
+};
+
+export const WithTextAndContentRight = () => {
+  const { bannerState } = useResultListBannerState({
+    headerText: "Could not save bookings",
+    text: "You need to take action on these bookings.",
+    items: [
+      {
+        text: "Booking has no route.",
+      },
+      {
+        text: "Booking has no customer.",
+        linkText: "1232",
+        onClickLink: () => alert("Clicked link"),
+      },
+      {
+        text:
+          "https://agreements-api-sl-freight-core-dev.apps-internal.ocp.aws.stena.io/api/v1/AgrRoutePrice/?ids%5B0%5D=ef9a5650-cdc0-4f5a-b009-1db021ee201b&ids%5B1%5D=031635ca-76e4-4ac8-8679-227bf1b42534&ids%5B2%5D=4f8c5549-3c24-47a2-9627-34a07c832479",
+        linkText: "1234",
+        onClickLink: () => alert("Clicked link"),
+      },
+    ],
+  });
+
+  if (!bannerState) {
+    return null;
+  }
+
+  return (
+    <ResultListBanner
+      variant={"error"}
+      bannerState={bannerState}
+      contentRight={<FlatButton label={"Refresh"} />}
+    />
+  );
 };

--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -77,7 +77,7 @@ export interface StandardTableProps<
   noItemsContentRight?: ReactNode;
 
   /**
-   * Content right in banner shown when there are no items.
+   * Content bottom in banner shown when there are no items.
    */
   noItemsContentBottom?: ReactNode;
 

--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -1,7 +1,7 @@
 import { Box, useDomId } from "@stenajs-webui/core";
 import cx from "classnames";
 import * as React from "react";
-import { useMemo } from "react";
+import { ReactNode, useMemo } from "react";
 import { StandardTableConfig } from "../config/StandardTableConfig";
 import { GroupConfigsForRowsContext } from "../context/GroupConfigsForRowsContext";
 import { OnKeyDownContext } from "../context/OnKeyDownContext";
@@ -70,6 +70,21 @@ export interface StandardTableProps<
   items?: Array<TItem>;
   error?: Error;
   loading?: boolean;
+
+  /**
+   * Content right in banner shown when there are no items.
+   */
+  noItemsContentRight?: ReactNode;
+
+  /**
+   * Content right in banner shown when there are no items.
+   */
+  noItemsContentBottom?: ReactNode;
+
+  /**
+   * Header in banner shown when there are no items.
+   */
+  noItemsHeader?: string;
 
   /**
    * Message displayed when there are no items to display, and it is not loading or has error.

--- a/packages/grid/src/features/standard-table/components/StandardTableContent.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableContent.tsx
@@ -1,6 +1,7 @@
-import * as React from "react";
-import { Row, Spacing, Text } from "@stenajs-webui/core";
+import { Row, Spacing } from "@stenajs-webui/core";
+import { Banner } from "@stenajs-webui/elements";
 import { ErrorScreen, LoadingScreen } from "@stenajs-webui/panels";
+import * as React from "react";
 import { StandardTableProps, StandardTableVariant } from "./StandardTable";
 import { StandardTableRowList } from "./StandardTableRowList";
 
@@ -25,6 +26,9 @@ export const StandardTableContent = React.memo(function StandardTableContent<
   loading,
   items,
   noItemsLabel = "There is no data available.",
+  noItemsContentRight,
+  noItemsContentBottom,
+  noItemsHeader,
   colIndexOffset,
   rowIndexOffset,
   variant,
@@ -47,8 +51,15 @@ export const StandardTableContent = React.memo(function StandardTableContent<
 
   if (!items || !items.length) {
     return (
-      <Row spacing={10} justifyContent={"center"}>
-        <Text>{noItemsLabel}</Text>
+      <Row spacing={2} justifyContent={"center"}>
+        <Banner
+          text={noItemsLabel}
+          headerText={noItemsHeader}
+          contentRight={noItemsContentRight}
+          variant={"info"}
+        >
+          {noItemsContentBottom}
+        </Banner>
       </Row>
     );
   }

--- a/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
@@ -383,6 +383,16 @@ export const MissingItems = () => (
   <StandardTable items={[]} config={standardTableConfigForStories} />
 );
 
+export const MissingItemsCustomBanner = () => (
+  <StandardTable
+    items={[]}
+    config={standardTableConfigForStories}
+    noItemsHeader={"There are no users."}
+    noItemsLabel={"Change filter settings to widen the search."}
+    noItemsContentRight={<FlatButton label={"Open filter"} />}
+  />
+);
+
 export const NavigationBetweenTables = () => {
   const { items, onChangeNumPassengers } = useListState(mockedItems);
 


### PR DESCRIPTION
### StandardTable

- Now uses `Banner` to show no items available message.
- Add props `noItemsContentRight`, `noItemsContentBottom`
  and `noItemsHeader` to customize the banner.

### Banner

- Design updated to make it slightly more compact.

![image](https://user-images.githubusercontent.com/1266041/117120078-2bb4d080-ad93-11eb-8500-c178403a9b18.png)

![image](https://user-images.githubusercontent.com/1266041/117120061-248dc280-ad93-11eb-986c-773b872bb923.png)
(screenshot above does not have the compact banner)

![image](https://user-images.githubusercontent.com/1266041/117120140-40916400-ad93-11eb-9fb5-fc188f649d7b.png)
