### PR TITLE
Task 66558: Update react-select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Next
+
+## Select
+
+- Update `react-select` to 4.3.0.
+- New component `MultiSelect`.
+
+## Breaking changes
+
+- `Select` no longer supports `isMulti` prop.
+- `AsyncSelect` no longer supports `isMulti` prop.
+
 ## 9.1.3
 
 - Fix bug introduced in 9.1.2 where border-radius was not applied in `ActionMenuItem`.

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@stenajs-webui/core": "9.1.3",
     "@stenajs-webui/elements": "9.1.3",
-    "@types/react-select": "^3.0.20",
-    "react-select": "^3.1.0"
+    "@types/react-select": "^4.0.15",
+    "react-select": "^4.3.0"
   },
   "peerDependencies": {
     "@fortawesome/fontawesome-svg-core": ">=1.2.18",

--- a/packages/select/src/components/ui/AsyncSelect.tsx
+++ b/packages/select/src/components/ui/AsyncSelect.tsx
@@ -19,7 +19,7 @@ export const AsyncSelect = <T extends {}>({
       variant === "light" ? defaultSelectTheme : selectThemeDark
     );
 
-    return styles ? mergeStyles<T, false>(sourceStyles, styles) : sourceStyles;
+    return styles ? mergeStyles(sourceStyles, styles) : sourceStyles;
   }, [variant, styles]);
 
   return <AsyncComponent styles={selectStyles} {...selectProps} />;

--- a/packages/select/src/components/ui/AsyncSelect.tsx
+++ b/packages/select/src/components/ui/AsyncSelect.tsx
@@ -15,11 +15,11 @@ export const AsyncSelect = <T extends {}>({
   ...selectProps
 }: AsyncSelectProps<T>) => {
   const selectStyles = useMemo(() => {
-    const sourceStyles = createStylesFromTheme(
+    const sourceStyles = createStylesFromTheme<T, false>(
       variant === "light" ? defaultSelectTheme : selectThemeDark
     );
 
-    return styles ? mergeStyles(sourceStyles, styles) : sourceStyles;
+    return styles ? mergeStyles<T, false>(sourceStyles, styles) : sourceStyles;
   }, [variant, styles]);
 
   return <AsyncComponent styles={selectStyles} {...selectProps} />;

--- a/packages/select/src/components/ui/GroupedMultiSelect.tsx
+++ b/packages/select/src/components/ui/GroupedMultiSelect.tsx
@@ -22,8 +22,8 @@ import {
   createOnChange,
   InternalDropdownOption,
 } from "../../util/multiDropdownUtils";
-import { Select, SelectProps } from "./Select";
 import { DropdownOption } from "./GroupedMultiSelectTypes";
+import { MultiSelect, MultiSelectProps } from "./MultiSelect";
 
 export type OnChangeValue<TData> =
   | OptionsType<DropdownOption<TData>>
@@ -36,14 +36,14 @@ export type OnChange<TData> = (
 
 export interface GroupedMultiSelectProps<TData>
   extends Omit<
-    SelectProps<DropdownOption<TData>>,
+    MultiSelectProps<DropdownOption<TData>>,
     "options" | "onChange" | "value" | "components"
   > {
   /**
    * Same as Select prop `component` but without MultiValue and Option since they can not be modified
    */
   components?: Omit<
-    SelectComponentsConfig<DropdownOption<TData>>,
+    SelectComponentsConfig<DropdownOption<TData>, true>,
     "MultiValue" | "Option"
   >;
   /**
@@ -81,7 +81,7 @@ export const GroupedMultiSelect = <TData extends {}>({
 > => {
   const theme = variant === "light" ? defaultSelectTheme : selectThemeDark;
 
-  const Option = (props: OptionProps<DropdownOption<TData>>) => {
+  const Option = (props: OptionProps<DropdownOption<TData>, true>) => {
     if (props.data.internalOptions) {
       return (
         <components.Option {...props}>
@@ -150,7 +150,7 @@ export const GroupedMultiSelect = <TData extends {}>({
   );
 
   return (
-    <Select<DropdownOption<TData>>
+    <MultiSelect<DropdownOption<TData>>
       {...selectProps}
       onChange={createOnChange<TData>(onChange)}
       hideSelectedOptions={false}

--- a/packages/select/src/components/ui/MultiSelect.stories.tsx
+++ b/packages/select/src/components/ui/MultiSelect.stories.tsx
@@ -1,15 +1,15 @@
 import { Box, Indent, Spacing } from "@stenajs-webui/core";
 import * as React from "react";
-import { Select } from "./Select";
+import { MultiSelect } from "./MultiSelect";
 
 export default {
-  title: "select/Select",
-  component: Select,
+  title: "select/MultiSelect",
+  component: MultiSelect,
 };
 
 export const Standard = () => (
   <div style={{ width: "400px" }}>
-    <Select
+    <MultiSelect
       options={[
         {
           value: "Mattias",
@@ -28,61 +28,11 @@ export const Standard = () => (
   </div>
 );
 
-export const LongLabels = () => (
-  <div style={{ width: "400px" }}>
-    <Select
-      options={[
-        {
-          value: "lorem",
-          label:
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent purus massa, molestie ac sapien in, sodales interdum arcu",
-        },
-        {
-          value: "Johan",
-          label: "Johan",
-        },
-        {
-          value: "Dennis the menace",
-          label: "Dennis the menace",
-        },
-      ]}
-    />
-  </div>
-);
-
-export const StandardDark = () => (
-  <div style={{ width: "400px" }}>
-    <Box background={"#2e4662"}>
-      <Indent num={4}>
-        <Spacing num={4}>
-          <Select
-            options={[
-              {
-                value: "Mattias",
-                label: "Mattias",
-              },
-              {
-                value: "Johan",
-                label: "Johan",
-              },
-              {
-                value: "Dennis the menace",
-                label: "Dennis the menace",
-              },
-            ]}
-            variant={"dark"}
-          />
-        </Spacing>
-      </Indent>
-    </Box>
-  </div>
-);
-
 export const WithGroupHeadings = () => (
   <div style={{ width: "400px" }}>
     <Indent num={4}>
       <Spacing num={4}>
-        <Select
+        <MultiSelect
           options={[
             {
               label: "Group heading 1",
@@ -117,9 +67,37 @@ export const WithGroupHeadings = () => (
   </div>
 );
 
+export const MultiselectDark = () => (
+  <div style={{ width: "600px" }}>
+    <Box background={"#2e4662"}>
+      <Indent num={4}>
+        <Spacing num={4}>
+          <MultiSelect
+            options={[
+              {
+                value: "Mattias",
+                label: "Mattias",
+              },
+              {
+                value: "Johan",
+                label: "Johan",
+              },
+              {
+                value: "Dennis the menace",
+                label: "Dennis the menace",
+              },
+            ]}
+            variant={"dark"}
+          />
+        </Spacing>
+      </Indent>
+    </Box>
+  </div>
+);
+
 export const Disabled = () => (
   <div style={{ width: "400px" }}>
-    <Select
+    <MultiSelect
       options={[
         {
           value: "Mattias",

--- a/packages/select/src/components/ui/MultiSelect.tsx
+++ b/packages/select/src/components/ui/MultiSelect.tsx
@@ -1,19 +1,18 @@
 import * as React from "react";
 import { useMemo } from "react";
-import AsyncComponent, { Props } from "react-select/async";
+import SelectComponent, { mergeStyles, Props } from "react-select";
 import { defaultSelectTheme, selectThemeDark } from "../../SelectTheme";
 import { createStylesFromTheme } from "../../util/StylesBuilder";
-import { mergeStyles } from "react-select";
 
-export interface AsyncSelectProps<T> extends Props<T, false> {
+export interface MultiSelectProps<T> extends Omit<Props<T, true>, "isMulti"> {
   variant?: "dark" | "light";
 }
 
-export const AsyncSelect = <T extends {}>({
+export const MultiSelect = <T extends {}>({
   variant = "light",
   styles,
   ...selectProps
-}: AsyncSelectProps<T>) => {
+}: MultiSelectProps<T>) => {
   const selectStyles = useMemo(() => {
     const sourceStyles = createStylesFromTheme(
       variant === "light" ? defaultSelectTheme : selectThemeDark
@@ -22,5 +21,5 @@ export const AsyncSelect = <T extends {}>({
     return styles ? mergeStyles(sourceStyles, styles) : sourceStyles;
   }, [variant, styles]);
 
-  return <AsyncComponent styles={selectStyles} {...selectProps} />;
+  return <SelectComponent styles={selectStyles} isMulti {...selectProps} />;
 };

--- a/packages/select/src/components/ui/MultiSelect.tsx
+++ b/packages/select/src/components/ui/MultiSelect.tsx
@@ -14,7 +14,7 @@ export const MultiSelect = <T extends {}>({
   ...selectProps
 }: MultiSelectProps<T>) => {
   const selectStyles = useMemo(() => {
-    const sourceStyles = createStylesFromTheme(
+    const sourceStyles = createStylesFromTheme<T, true>(
       variant === "light" ? defaultSelectTheme : selectThemeDark
     );
 

--- a/packages/select/src/components/ui/Select.tsx
+++ b/packages/select/src/components/ui/Select.tsx
@@ -4,7 +4,7 @@ import SelectComponent, { mergeStyles, Props } from "react-select";
 import { defaultSelectTheme, selectThemeDark } from "../../SelectTheme";
 import { createStylesFromTheme } from "../../util/StylesBuilder";
 
-export interface SelectProps<T> extends Props<T> {
+export interface SelectProps<T> extends Props<T, false> {
   variant?: "dark" | "light";
 }
 

--- a/packages/select/src/components/ui/Select.tsx
+++ b/packages/select/src/components/ui/Select.tsx
@@ -14,7 +14,7 @@ export const Select = <T extends {}>({
   ...selectProps
 }: SelectProps<T>) => {
   const selectStyles = useMemo(() => {
-    const sourceStyles = createStylesFromTheme(
+    const sourceStyles = createStylesFromTheme<T, false>(
       variant === "light" ? defaultSelectTheme : selectThemeDark
     );
 

--- a/packages/select/src/util/StylesBuilder.ts
+++ b/packages/select/src/util/StylesBuilder.ts
@@ -1,3 +1,4 @@
+import { OptionTypeBase } from "react-select/src/types";
 import { SelectTheme } from "../SelectTheme";
 import { StylesConfig } from "react-select";
 
@@ -39,7 +40,10 @@ const resolveOptionColor = (
   }
 };
 
-export const createStylesFromTheme = ({
+export const createStylesFromTheme = <
+  OptionType extends OptionTypeBase,
+  IsMulti extends boolean
+>({
   menu,
   menuPortal,
   input,
@@ -47,7 +51,7 @@ export const createStylesFromTheme = ({
   clearButtonColor,
   arrowColor,
   loadingIndicator,
-}: SelectTheme): StylesConfig => ({
+}: SelectTheme): StylesConfig<OptionType, IsMulti> => ({
   option: (base, { isDisabled, isFocused, isSelected }) => ({
     ...base,
     fontFamily: input.fontFamily,
@@ -62,14 +66,16 @@ export const createStylesFromTheme = ({
     cursor: isDisabled ? "not-allowed" : "default",
     whiteSpace: menu.whiteSpace || base.whiteSpace,
     ":active": {
-      backgroundColor:
-        !isDisabled &&
-        (isSelected
-          ? menu.selectedItemActiveBackgroundColor
-          : menu.activeBackgroundColor),
-      color:
-        !isDisabled &&
-        (isSelected ? menu.selectedItemActiveTextColor : menu.activeTextColor),
+      backgroundColor: isDisabled
+        ? undefined
+        : isSelected
+        ? menu.selectedItemActiveBackgroundColor
+        : menu.activeBackgroundColor,
+      color: isDisabled
+        ? undefined
+        : isSelected
+        ? menu.selectedItemActiveTextColor
+        : menu.activeTextColor,
     },
   }),
   control: (base, { isFocused, isDisabled }) => ({

--- a/packages/select/src/util/StylesMerger.ts
+++ b/packages/select/src/util/StylesMerger.ts
@@ -1,10 +1,14 @@
 import { merge } from "lodash";
 import { StylesConfig } from "react-select";
+import { OptionTypeBase } from "react-select/src/types";
 
-export const mergeStyles = (
-  themeStyle: StylesConfig,
-  userStyle?: StylesConfig
-): StylesConfig => {
+export const mergeStyles = <
+  OptionType extends OptionTypeBase,
+  IsMulti extends boolean
+>(
+  themeStyle: StylesConfig<OptionType, IsMulti>,
+  userStyle?: StylesConfig<OptionType, IsMulti>
+): StylesConfig<OptionType, IsMulti> => {
   if (!userStyle) {
     return themeStyle;
   }

--- a/packages/select/src/util/__tests__/multiDropdownUtils.test.ts
+++ b/packages/select/src/util/__tests__/multiDropdownUtils.test.ts
@@ -1,6 +1,7 @@
 import {
+  ActionMeta,
   GroupedOptionsType,
-  GroupType,
+  GroupTypeBase,
   OptionsType,
   ValueType,
 } from "react-select";
@@ -14,7 +15,6 @@ import {
   convertValueToInternalValue,
   createOnChange,
   InternalDropdownOption,
-  Meta,
 } from "../multiDropdownUtils";
 
 describe("multiDropdownUtils", () => {
@@ -53,7 +53,7 @@ describe("multiDropdownUtils", () => {
             },
           ];
           const newOnChange = createOnChange(onChange);
-          const meta: Meta<string> = {
+          const meta: ActionMeta<DropdownOption<string>> = {
             action: "select-option",
             option: options[0].options[0],
           };
@@ -62,7 +62,7 @@ describe("multiDropdownUtils", () => {
           > = convertGroupedDropdownOptionsToInternalOptions(options);
 
           newOnChange([selectedOptions[1], selectedOptions[3]], meta);
-          const expected: ValueType<DropdownOption<string>> = [
+          const expected: ValueType<DropdownOption<string>, true> = [
             convertDropdownOptionToInternalOption(options[0].options[0]),
             convertDropdownOptionToInternalOption(options[1].options[0]),
           ];
@@ -107,13 +107,13 @@ describe("multiDropdownUtils", () => {
             const selectedOptions: OptionsType<
               InternalDropdownOption<string>
             > = convertGroupedDropdownOptionsToInternalOptions(options);
-            const meta: Meta<string> = {
+            const meta: ActionMeta<DropdownOption<string>> = {
               action: "select-option",
               option: selectedOptions[2],
             };
 
             newOnChange([selectedOptions[1], selectedOptions[2]], meta);
-            const expected: ValueType<DropdownOption<string>> = [
+            const expected: ValueType<DropdownOption<string>, true> = [
               options[0].options[0],
               ...options[1].options,
             ];
@@ -157,7 +157,7 @@ describe("multiDropdownUtils", () => {
             const selectedOptions: OptionsType<
               InternalDropdownOption<string>
             > = convertGroupedDropdownOptionsToInternalOptions(options);
-            const meta: Meta<string> = {
+            const meta: ActionMeta<DropdownOption<string>> = {
               action: "select-option",
               option: selectedOptions[2],
             };
@@ -166,7 +166,7 @@ describe("multiDropdownUtils", () => {
               [selectedOptions[1], selectedOptions[2], selectedOptions[3]],
               meta
             );
-            const expected: ValueType<DropdownOption<string>> = [
+            const expected: ValueType<DropdownOption<string>, true> = [
               options[0].options[0],
               ...options[1].options,
             ];
@@ -210,7 +210,7 @@ describe("multiDropdownUtils", () => {
             const selectedOptions: OptionsType<
               InternalDropdownOption<string>
             > = convertGroupedDropdownOptionsToInternalOptions(options);
-            const meta: Meta<string> = {
+            const meta: ActionMeta<DropdownOption<string>> = {
               action: "select-option",
               option: selectedOptions[2],
             };
@@ -224,7 +224,7 @@ describe("multiDropdownUtils", () => {
               ],
               meta
             );
-            const expected: ValueType<DropdownOption<string>> = [
+            const expected: ValueType<DropdownOption<string>, true> = [
               options[0].options[0],
               ...options[1].options,
             ];
@@ -268,7 +268,7 @@ describe("multiDropdownUtils", () => {
             const selectedOptions: OptionsType<
               InternalDropdownOption<string>
             > = convertGroupedDropdownOptionsToInternalOptions(options);
-            const meta: Meta<string> = {
+            const meta: ActionMeta<DropdownOption<string>> = {
               action: "select-option",
               option: selectedOptions[3],
             };
@@ -278,7 +278,7 @@ describe("multiDropdownUtils", () => {
               meta
             );
 
-            const expected: ValueType<DropdownOption<string>> = [
+            const expected: ValueType<DropdownOption<string>, true> = [
               options[0].options[0],
               options[1].options[0],
             ];
@@ -323,7 +323,7 @@ describe("multiDropdownUtils", () => {
               },
             ];
             const newOnChange = createOnChange(onChange);
-            const meta: Meta<string> = {
+            const meta: ActionMeta<DropdownOption<string>> = {
               action: "deselect-option",
               option: options[1].options[0],
             };
@@ -339,7 +339,7 @@ describe("multiDropdownUtils", () => {
               ],
               meta
             );
-            const expected: ValueType<DropdownOption<string>> = [
+            const expected: ValueType<DropdownOption<string>, true> = [
               convertDropdownOptionToInternalOption(options[0].options[0]),
               convertDropdownOptionToInternalOption(options[1].options[1]),
             ];
@@ -380,7 +380,7 @@ describe("multiDropdownUtils", () => {
               },
             ];
             const newOnChange = createOnChange(onChange);
-            const meta: Meta<string> = {
+            const meta: ActionMeta<DropdownOption<string>> = {
               action: "deselect-option",
               option: options[0].options[0],
             };
@@ -389,7 +389,7 @@ describe("multiDropdownUtils", () => {
             > = convertGroupedDropdownOptionsToInternalOptions(options);
 
             newOnChange([selectedOptions[3]], meta);
-            const expected: ValueType<DropdownOption<string>> = [
+            const expected: ValueType<DropdownOption<string>, true> = [
               convertDropdownOptionToInternalOption(options[1].options[0]),
             ];
             expect(onChange).toHaveBeenCalledWith(expected, meta);
@@ -433,7 +433,7 @@ describe("multiDropdownUtils", () => {
           const selectedOptions: OptionsType<
             InternalDropdownOption<string>
           > = convertGroupedDropdownOptionsToInternalOptions(options);
-          const meta: Meta<string> = {
+          const meta: ActionMeta<DropdownOption<string>> = {
             action: "deselect-option",
             option: selectedOptions[2],
           };
@@ -448,7 +448,7 @@ describe("multiDropdownUtils", () => {
             ],
             meta
           );
-          const expected: ValueType<DropdownOption<string>> = [
+          const expected: ValueType<DropdownOption<string>, true> = [
             options[0].options[0],
           ];
           expect(onChange).toHaveBeenCalledWith(expected, meta);
@@ -492,7 +492,7 @@ describe("multiDropdownUtils", () => {
                 },
               ];
               const newOnChange = createOnChange(onChange);
-              const meta: Meta<string> = {
+              const meta: ActionMeta<DropdownOption<string>> = {
                 action: "remove-value",
                 removedValue: options[1].options[0],
               };
@@ -509,7 +509,7 @@ describe("multiDropdownUtils", () => {
                 ],
                 meta
               );
-              const expected: ValueType<DropdownOption<string>> = [
+              const expected: ValueType<DropdownOption<string>, true> = [
                 convertDropdownOptionToInternalOption(options[0].options[0]),
                 convertDropdownOptionToInternalOption(options[1].options[1]),
               ];
@@ -550,13 +550,13 @@ describe("multiDropdownUtils", () => {
                 },
               ];
               const newOnChange = createOnChange(onChange);
-              const meta: Meta<string> = {
+              const meta: ActionMeta<DropdownOption<string>> = {
                 action: "remove-value",
                 removedValue: options[1].options[0],
               };
 
-              newOnChange(undefined, meta);
-              const expected: ValueType<DropdownOption<string>> = [];
+              newOnChange(undefined as any, meta);
+              const expected: ValueType<DropdownOption<string>, true> = [];
               expect(onChange).toHaveBeenCalledWith(expected, meta);
             });
           });
@@ -595,7 +595,7 @@ describe("multiDropdownUtils", () => {
               },
             ];
             const newOnChange = createOnChange(onChange);
-            const meta: Meta<string> = {
+            const meta: ActionMeta<DropdownOption<string>> = {
               action: "remove-value",
               removedValue: options[0].options[0],
             };
@@ -604,7 +604,7 @@ describe("multiDropdownUtils", () => {
             > = convertGroupedDropdownOptionsToInternalOptions(options);
 
             newOnChange([selectedOptions[3]], meta);
-            const expected: ValueType<DropdownOption<string>> = [
+            const expected: ValueType<DropdownOption<string>, true> = [
               convertDropdownOptionToInternalOption(options[1].options[0]),
             ];
             expect(onChange).toHaveBeenCalledWith(expected, meta);
@@ -648,7 +648,7 @@ describe("multiDropdownUtils", () => {
           const selectedOptions: OptionsType<
             InternalDropdownOption<string>
           > = convertGroupedDropdownOptionsToInternalOptions(options);
-          const meta: Meta<string> = {
+          const meta: ActionMeta<DropdownOption<string>> = {
             action: "remove-value",
             removedValue: selectedOptions[2],
           };
@@ -663,7 +663,7 @@ describe("multiDropdownUtils", () => {
             ],
             meta
           );
-          const expected: ValueType<DropdownOption<string>> = [
+          const expected: ValueType<DropdownOption<string>, true> = [
             options[0].options[0],
           ];
           expect(onChange).toHaveBeenCalledWith(expected, meta);
@@ -706,7 +706,7 @@ describe("multiDropdownUtils", () => {
               },
             ];
             const newOnChange = createOnChange(onChange);
-            const meta: Meta<string> = {
+            const meta: ActionMeta<DropdownOption<string>> = {
               action: "pop-value",
               removedValue: options[1].options[0],
             };
@@ -722,7 +722,7 @@ describe("multiDropdownUtils", () => {
               ],
               meta
             );
-            const expected: ValueType<DropdownOption<string>> = [
+            const expected: ValueType<DropdownOption<string>, true> = [
               convertDropdownOptionToInternalOption(options[0].options[0]),
               convertDropdownOptionToInternalOption(options[1].options[1]),
             ];
@@ -763,7 +763,7 @@ describe("multiDropdownUtils", () => {
               },
             ];
             const newOnChange = createOnChange(onChange);
-            const meta: Meta<string> = {
+            const meta: ActionMeta<DropdownOption<string>> = {
               action: "pop-value",
               removedValue: options[0].options[0],
             };
@@ -772,7 +772,7 @@ describe("multiDropdownUtils", () => {
             > = convertGroupedDropdownOptionsToInternalOptions(options);
 
             newOnChange([selectedOptions[3]], meta);
-            const expected: ValueType<DropdownOption<string>> = [
+            const expected: ValueType<DropdownOption<string>, true> = [
               convertDropdownOptionToInternalOption(options[1].options[0]),
             ];
             expect(onChange).toHaveBeenCalledWith(expected, meta);
@@ -816,7 +816,7 @@ describe("multiDropdownUtils", () => {
           const selectedOptions: OptionsType<
             InternalDropdownOption<string>
           > = convertGroupedDropdownOptionsToInternalOptions(options);
-          const meta: Meta<string> = {
+          const meta: ActionMeta<DropdownOption<string>> = {
             action: "pop-value",
             removedValue: selectedOptions[2],
           };
@@ -830,7 +830,7 @@ describe("multiDropdownUtils", () => {
             ],
             meta
           );
-          const expected: ValueType<DropdownOption<string>> = [
+          const expected: ValueType<DropdownOption<string>, true> = [
             options[0].options[0],
           ];
           expect(onChange).toHaveBeenCalledWith(expected, meta);
@@ -1068,7 +1068,7 @@ describe("multiDropdownUtils", () => {
           value: "string 1",
         },
       ];
-      const option: GroupType<DropdownOption<string>> = {
+      const option: GroupTypeBase<DropdownOption<string>> = {
         label: "label",
         value: "string",
         options,

--- a/packages/select/src/util/multiDropdownUtils.ts
+++ b/packages/select/src/util/multiDropdownUtils.ts
@@ -2,7 +2,7 @@ import { differenceWith, intersectionWith, isEqual, uniqWith } from "lodash";
 import {
   ActionMeta,
   GroupedOptionsType,
-  GroupType,
+  GroupTypeBase,
   OptionsType,
   ValueType,
 } from "react-select";
@@ -26,30 +26,6 @@ interface InternalParentDropdownOption<TData> {
   internalOptions: OptionsType<DropdownOption<TData>>;
 }
 
-interface SelectActionMeta<TData> extends ActionMeta<DropdownOption<TData>> {
-  option?: InternalDropdownOption<TData>;
-  action: "select-option" | "deselect-option";
-}
-
-interface RemoveActionMeta<TData> extends ActionMeta<DropdownOption<TData>> {
-  removedValue?: InternalDropdownOption<TData>;
-  action: "remove-value" | "pop-value";
-}
-
-interface ClearActionMeta extends ActionMeta<any> {
-  action: "clear";
-}
-
-interface RestActionMeta extends ActionMeta<any> {
-  action: "set-value" | "create-option";
-}
-
-export type Meta<TData> =
-  | ClearActionMeta
-  | SelectActionMeta<TData>
-  | RemoveActionMeta<TData>
-  | RestActionMeta;
-
 const removeGroupedOptions = <TData>(
   removedValue: InternalParentDropdownOption<TData>,
   selectedInternalOptions: OptionsType<InternalDropdownOption<TData>>
@@ -72,8 +48,11 @@ const removeOptionHeaders = <TData>(
     .map(convertInternalOptionToDropdownOption);
 
 export const createOnChange = <TData>(onChange: OnChange<TData>) => (
-  incomingSelectedInternalOptions: ValueType<InternalDropdownOption<TData>>,
-  meta: Meta<TData>
+  incomingSelectedInternalOptions: ValueType<
+    InternalDropdownOption<TData>,
+    true
+  >,
+  meta: ActionMeta<DropdownOption<TData>>
 ) => {
   const selectedInternalOptions = (() => {
     if (!incomingSelectedInternalOptions) {
@@ -136,12 +115,6 @@ export const createOnChange = <TData>(onChange: OnChange<TData>) => (
       } else {
         onChange(removeOptionHeaders(selectedInternalOptions), meta);
       }
-      break;
-    case "set-value":
-      onChange(
-        selectedInternalOptions.map(convertInternalOptionToDropdownOption),
-        meta
-      );
       break;
     case "clear":
       onChange(
@@ -220,7 +193,7 @@ export const convertDropdownOptionToInternalOption = <TData>(
 });
 
 export const convertGroupedDropdownOptionToInternalOption = <TData>(
-  option: GroupType<DropdownOption<TData>>
+  option: GroupTypeBase<DropdownOption<TData>>
 ): InternalDropdownOption<TData> => ({
   data: option.label,
   label: option.label,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,10 +1739,17 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.3.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
   integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.12.0":
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz#46794bc20b612c5f75e62dd071e24dfd95f1cbe6"
+  integrity sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1841,7 +1848,7 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
-"@emotion/cache@^10.0.27", "@emotion/cache@^10.0.9":
+"@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"
   integrity sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==
@@ -1851,7 +1858,18 @@
     "@emotion/utils" "0.11.3"
     "@emotion/weak-memoize" "0.2.5"
 
-"@emotion/core@^10.0.10", "@emotion/core@^10.0.9", "@emotion/core@^10.1.1":
+"@emotion/cache@^11.0.0", "@emotion/cache@^11.1.3":
+  version "11.1.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.1.3.tgz#c7683a9484bcd38d5562f2b9947873cf66829afd"
+  integrity sha512-n4OWinUPJVaP6fXxWZD9OUeQ0lY7DvtmtSuqtRWT0Ofo/sBLCVSgb4/Oa0Q5eFxcwablRKjUXqXtNZVyEwCAuA==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.0.0"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "^4.0.3"
+
+"@emotion/core@^10.0.10", "@emotion/core@^10.1.1":
   version "10.1.1"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.1.1.tgz#c956c1365f2f2481960064bcb8c4732e5fb612c3"
   integrity sha512-ZMLG6qpXR8x031NXD8HJqugy/AZSkAuMxxqB46pmAR7ze47MhNJ56cdoX243QPZdGctrdfo+s08yZTiwaUcRKA==
@@ -1863,7 +1881,7 @@
     "@emotion/sheet" "0.9.4"
     "@emotion/utils" "0.11.3"
 
-"@emotion/css@^10.0.27", "@emotion/css@^10.0.9":
+"@emotion/css@^10.0.27":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/css/-/css-10.0.27.tgz#3a7458198fbbebb53b01b2b87f64e5e21241e14c"
   integrity sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==
@@ -1872,7 +1890,7 @@
     "@emotion/utils" "0.11.3"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/hash@0.8.0":
+"@emotion/hash@0.8.0", "@emotion/hash@^0.8.0":
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
@@ -1889,6 +1907,24 @@
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
   integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
 
+"@emotion/memoize@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.5.tgz#2c40f81449a4e554e9fc6396910ed4843ec2be50"
+  integrity sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==
+
+"@emotion/react@^11.1.1":
+  version "11.1.5"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.1.5.tgz#15e78f9822894cdc296e6f4e0688bac8120dfe66"
+  integrity sha512-xfnZ9NJEv9SU9K2sxXM06lzjK245xSeHRpUh67eARBm3PBHjjKIZlfWZ7UQvD0Obvw6ZKjlC79uHrlzFYpOB/Q==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    "@emotion/cache" "^11.1.3"
+    "@emotion/serialize" "^1.0.0"
+    "@emotion/sheet" "^1.0.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
 "@emotion/serialize@^0.11.15", "@emotion/serialize@^0.11.16":
   version "0.11.16"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.16.tgz#dee05f9e96ad2fb25a5206b6d759b2d1ed3379ad"
@@ -1900,10 +1936,26 @@
     "@emotion/utils" "0.11.3"
     csstype "^2.5.7"
 
+"@emotion/serialize@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.2.tgz#77cb21a0571c9f68eb66087754a65fa97bfcd965"
+  integrity sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
 "@emotion/sheet@0.9.4":
   version "0.9.4"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-0.9.4.tgz#894374bea39ec30f489bbfc3438192b9774d32e5"
   integrity sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==
+
+"@emotion/sheet@^1.0.0", "@emotion/sheet@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.0.1.tgz#245f54abb02dfd82326e28689f34c27aa9b2a698"
+  integrity sha512-GbIvVMe4U+Zc+929N1V7nW6YYJtidj31lidSmdYcWozwoBIObXBnaJkKNDjZrLm9Nc0BR+ZyHNaRZxqNZbof5g==
 
 "@emotion/styled-base@^10.0.27":
   version "10.0.31"
@@ -1928,7 +1980,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -1938,7 +1990,12 @@
   resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.3.tgz#a759863867befa7e583400d322652a3f44820924"
   integrity sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==
 
-"@emotion/weak-memoize@0.2.5":
+"@emotion/utils@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-1.0.0.tgz#abe06a83160b10570816c913990245813a2fd6af"
+  integrity sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA==
+
+"@emotion/weak-memoize@0.2.5", "@emotion/weak-memoize@^0.2.5":
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
@@ -4446,11 +4503,12 @@
     hoist-non-react-statics "^3.3.0"
     redux "^4.0.0"
 
-"@types/react-select@^3.0.20":
-  version "3.0.26"
-  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-3.0.26.tgz#f1b1a1e2b624ed9843eb56dda837e7a0f4a76a8f"
-  integrity sha512-rAaiD0SFkBi3PUwp1DrJV04CobPl2LuZXF+kv6MKw8kaeGo82xTOZzjM8DDi4lrdkqGbInZiE2QO9nIJm3bqgw==
+"@types/react-select@^4.0.15":
+  version "4.0.15"
+  resolved "https://registry.yarnpkg.com/@types/react-select/-/react-select-4.0.15.tgz#2e6a1cff22c4bbae6c95b8dbee5b5097c12eae54"
+  integrity sha512-GPyBFYGMVFCtF4eg9riodEco+s2mflR10Nd5csx69+bcdvX6Uo9H/jgrIqovBU9yxBppB9DS66OwD6xxgVqOYQ==
   dependencies:
+    "@emotion/serialize" "^1.0.0"
     "@types/react" "*"
     "@types/react-dom" "*"
     "@types/react-transition-group" "*"
@@ -9747,7 +9805,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -14741,10 +14799,10 @@ react-infinite@0.13.0:
     lodash.isfinite "3.2.0"
     object-assign "4.0.1"
 
-react-input-autosize@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.2.tgz#fcaa7020568ec206bc04be36f4eb68e647c4d8c2"
-  integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
+react-input-autosize@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-3.0.0.tgz#6b5898c790d4478d69420b55441fcc31d5c50a85"
+  integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
   dependencies:
     prop-types "^15.5.8"
 
@@ -14830,18 +14888,17 @@ react-refresh@^0.8.3:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.8.3.tgz#721d4657672d400c5e3c75d063c4a85fb2d5d68f"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-select@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/react-select/-/react-select-3.1.1.tgz#156a5b4a6c22b1e3d62a919cb1fd827adb4060bc"
-  integrity sha512-HjC6jT2BhUxbIbxMZWqVcDibrEpdUJCfGicN0MMV+BQyKtCaPTgFekKWiOizSCy4jdsLMGjLqcFGJMhVGWB0Dg==
+react-select@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-4.3.0.tgz#6bde634ae7a378b49f3833c85c126f533483fa2e"
+  integrity sha512-SBPD1a3TJqE9zoI/jfOLCAoLr/neluaeokjOixr3zZ1vHezkom8K0A9J4QG9IWDqIDE9K/Mv+0y1GjidC2PDtQ==
   dependencies:
-    "@babel/runtime" "^7.4.4"
-    "@emotion/cache" "^10.0.9"
-    "@emotion/core" "^10.0.9"
-    "@emotion/css" "^10.0.9"
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.0.0"
+    "@emotion/react" "^11.1.1"
     memoize-one "^5.0.0"
     prop-types "^15.6.0"
-    react-input-autosize "^2.2.2"
+    react-input-autosize "^3.0.0"
     react-transition-group "^4.3.0"
 
 react-sizeme@^3.0.1:
@@ -16524,6 +16581,11 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
+
+stylis@^4.0.3:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
+  integrity sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg==
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Select

- Update `react-select` to 4.3.0.
- New component `MultiSelect`.

## Breaking changes

- `Select` no longer supports `isMulti` prop.
- `AsyncSelect` no longer supports `isMulti` prop.