### PR TITLE
Updates to sort order icon in standard table AB#67111

### DIFF
--- a/packages/grid/src/features/standard-table/components/StandardTableHeadItem.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableHeadItem.tsx
@@ -30,8 +30,12 @@ export const StandardTableHeadItem = React.memo(
       sticky,
       zIndex,
       left,
+      sortOrderIconVariant,
     } = useColumnConfigById(columnId);
-    const { disableSorting } = useStandardTableConfig();
+    const {
+      disableSorting,
+      sortOrderIconVariant: defaultSortOrderIconVariant,
+    } = useStandardTableConfig();
 
     const { arrow, onClickColumnHead } = useTableSortHeader(columnId);
 
@@ -62,6 +66,10 @@ export const StandardTableHeadItem = React.memo(
         left={sticky && left == null ? "0px" : left}
         shadow={sticky ? "var(--swui-sticky-column-shadow-right)" : undefined}
         zIndex={zIndex}
+        alignRight={justifyContentHeader === "flex-end"}
+        sortOrderIconVariant={
+          sortOrderIconVariant ?? defaultSortOrderIconVariant
+        }
       />
     );
   }

--- a/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
@@ -3,6 +3,7 @@ import {
   UseGridCellOptions,
   UseGridCellResult,
 } from "../../grid-cell/hooks/UseGridCell";
+import { SortOrderIconVariant } from "../../table-ui/components/table/SortOrderIcon";
 
 export type StandardTableColumnConfig<
   TItem,
@@ -121,6 +122,11 @@ export interface StandardTableColumnOptions<TItem, TItemValue> {
    * Offset column from left (ex if we have multiple sticky columns)
    */
   left?: string;
+
+  /**
+   * The icon variant to use when displaying sort order.
+   */
+  sortOrderIconVariant?: SortOrderIconVariant;
 }
 
 export type StandardTableCellRenderer<TItemValue, TItem> = (

--- a/packages/grid/src/features/standard-table/config/StandardTableConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableConfig.ts
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { UseGridCellOptions } from "../../grid-cell/hooks/UseGridCell";
+import { SortOrderIconVariant } from "../../table-ui/components/table/SortOrderIcon";
 import { StandardTableColumnConfig } from "./StandardTableColumnConfig";
 import { StandardTableColumnGroupConfig } from "./StandardTableColumnGroupConfig";
 
@@ -165,4 +166,10 @@ export interface StandardTableConfig<
    * Offset header row from top (top css property)
    */
   headerRowOffsetTop?: string;
+
+  /**
+   * The default icon variant to use when displaying sort order. Can be overridden per column.
+   * @default amount
+   */
+  sortOrderIconVariant?: SortOrderIconVariant;
 }

--- a/packages/grid/src/features/standard-table/features/sorting/UseTableSortHeader.ts
+++ b/packages/grid/src/features/standard-table/features/sorting/UseTableSortHeader.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { ArrowType } from "../../../table-ui/components/table/TableHeadItem";
+import { SortOrderDirection } from "../../../table-ui/components/table/SortOrderIcon";
 import {
   useStandardTableActions,
   useStandardTableState,
@@ -8,7 +8,7 @@ import {
 interface Result {
   selected: boolean;
   desc: boolean;
-  arrow: ArrowType | undefined;
+  arrow: SortOrderDirection | undefined;
   onClickColumnHead: () => void;
 }
 

--- a/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
@@ -112,6 +112,7 @@ const standardTableConfigForStories: StandardTableConfig<
   columns: {
     id: createColumnConfig((item) => item.id, {
       width: "100px",
+      sortOrderIconVariant: "numeric",
     }),
     active: createColumnConfig((item) => item.active, {
       itemLabelFormatter: (value) => (value ? "Y" : ""),
@@ -120,9 +121,14 @@ const standardTableConfigForStories: StandardTableConfig<
     }),
     name: createColumnConfig((item) => item.name, {
       width: "200px",
+      justifyContentHeader: "flex-end",
+      justifyContentCell: "flex-end",
+      infoIconTooltipText: "Ohoh",
+      sortOrderIconVariant: "alpha",
     }),
     ship: createColumnConfig((item) => item.ship, {
       width: "150px",
+      sortOrderIconVariant: "alpha",
     }),
     numPassengers: createColumnConfig((item) => item.numPassengers, {
       renderCell: createStandardEditableTextCell(),
@@ -131,6 +137,7 @@ const standardTableConfigForStories: StandardTableConfig<
       justifyContentHeader: "flex-end",
       justifyContentCell: "flex-end",
       width: "200px",
+      sortOrderIconVariant: "numeric",
     }),
     departure: createColumnConfig((item) => item.departure, {
       itemLabelFormatter: (value) => format(value, "yyyy-MM-dd"),

--- a/packages/grid/src/features/table-ui/components/table/SortOrderIcon.tsx
+++ b/packages/grid/src/features/table-ui/components/table/SortOrderIcon.tsx
@@ -1,0 +1,48 @@
+import { IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import { faSortAlphaDown } from "@fortawesome/free-solid-svg-icons/faSortAlphaDown";
+import { faSortAlphaUp } from "@fortawesome/free-solid-svg-icons/faSortAlphaUp";
+import { faSortAmountDown } from "@fortawesome/free-solid-svg-icons/faSortAmountDown";
+import { faSortAmountUp } from "@fortawesome/free-solid-svg-icons/faSortAmountUp";
+import { faSortNumericDown } from "@fortawesome/free-solid-svg-icons/faSortNumericDown";
+import { faSortNumericUp } from "@fortawesome/free-solid-svg-icons/faSortNumericUp";
+import { exhaustSwitchCaseElseThrow } from "@stenajs-webui/core";
+import { Icon } from "@stenajs-webui/elements";
+import { cssColor } from "@stenajs-webui/theme";
+import * as React from "react";
+
+export type SortOrderDirection = "up" | "down";
+export type SortOrderIconVariant = "numeric" | "alpha" | "amount";
+
+interface Props {
+  direction: SortOrderDirection;
+  iconVariant?: SortOrderIconVariant;
+}
+
+export const SortOrderIcon: React.FC<Props> = ({
+  iconVariant = "amount",
+  direction,
+}) => {
+  return (
+    <Icon
+      size={14}
+      color={cssColor("--lhds-color-ui-500")}
+      icon={getIcon(direction, iconVariant)}
+    />
+  );
+};
+
+export const getIcon = (
+  arrow: SortOrderDirection,
+  iconType: SortOrderIconVariant
+): IconDefinition => {
+  switch (iconType) {
+    case "alpha":
+      return arrow === "up" ? faSortAlphaUp : faSortAlphaDown;
+    case "numeric":
+      return arrow === "up" ? faSortNumericUp : faSortNumericDown;
+    case "amount":
+      return arrow === "up" ? faSortAmountUp : faSortAmountDown;
+    default:
+      return exhaustSwitchCaseElseThrow(iconType);
+  }
+};

--- a/packages/grid/src/features/table-ui/components/table/TableHeadItem.tsx
+++ b/packages/grid/src/features/table-ui/components/table/TableHeadItem.tsx
@@ -2,6 +2,7 @@ import { faEllipsisV } from "@fortawesome/free-solid-svg-icons/faEllipsisV";
 import { faInfoCircle } from "@fortawesome/free-solid-svg-icons/faInfoCircle";
 import { BoxProps, Heading, Row, Space } from "@stenajs-webui/core";
 import { FlatButton, Icon, InputSpinner } from "@stenajs-webui/elements";
+import { cssColor } from "@stenajs-webui/theme";
 import {
   ButtonWithPopoverProps,
   Popover,
@@ -9,20 +10,22 @@ import {
 } from "@stenajs-webui/tooltip";
 import * as React from "react";
 import { CSSProperties, useRef } from "react";
-import { faLongArrowAltDown } from "@fortawesome/free-solid-svg-icons/faLongArrowAltDown";
-import { faLongArrowAltUp } from "@fortawesome/free-solid-svg-icons/faLongArrowAltUp";
-import { cssColor } from "@stenajs-webui/theme";
-
-export type ArrowType = "up" | "down";
+import {
+  SortOrderDirection,
+  SortOrderIcon,
+  SortOrderIconVariant,
+} from "./SortOrderIcon";
 
 export interface TableHeadProps extends BoxProps {
   label?: string;
   infoIconTooltipText?: string;
   popoverContent?: ButtonWithPopoverProps["children"];
   loading?: boolean;
-  arrow?: ArrowType;
+  arrow?: SortOrderDirection;
   onClick?: () => void;
   selected?: boolean;
+  alignRight?: boolean;
+  sortOrderIconVariant?: SortOrderIconVariant;
 }
 
 export const TableHeadItem: React.FC<TableHeadProps> = React.memo(
@@ -36,6 +39,8 @@ export const TableHeadItem: React.FC<TableHeadProps> = React.memo(
     loading,
     infoIconTooltipText,
     overflow = "hidden",
+    alignRight,
+    sortOrderIconVariant,
     ...boxProps
   }) => {
     const containerRef = useRef(null);
@@ -66,16 +71,23 @@ export const TableHeadItem: React.FC<TableHeadProps> = React.memo(
                   {!hasOnlyChildren && <Space num={0.5} />}
                 </>
               )}
+              {arrow && alignRight && (
+                <>
+                  <Space />
+                  <SortOrderIcon
+                    direction={arrow}
+                    iconVariant={sortOrderIconVariant}
+                  />
+                  <Space num={0.5} />
+                </>
+              )}
               {label && <Heading variant={"h6"}>{label}</Heading>}
-              {arrow && (
+              {arrow && !alignRight && (
                 <>
                   <Space num={0.5} />
-                  <Icon
-                    size={14}
-                    color={cssColor("--lhds-color-blue-500")}
-                    icon={
-                      arrow === "up" ? faLongArrowAltUp : faLongArrowAltDown
-                    }
+                  <SortOrderIcon
+                    direction={arrow}
+                    iconVariant={sortOrderIconVariant}
                   />
                   <Space />
                 </>
@@ -85,7 +97,7 @@ export const TableHeadItem: React.FC<TableHeadProps> = React.memo(
 
           {infoIconTooltipText && (
             <>
-              <Space num={0.5} />
+              <Space />
               <Row onClick={(ev) => ev.stopPropagation()}>
                 <Tooltip
                   label={infoIconTooltipText}

--- a/packages/grid/src/features/table-ui/hooks/UseSortOrderColumnHead.ts
+++ b/packages/grid/src/features/table-ui/hooks/UseSortOrderColumnHead.ts
@@ -1,13 +1,13 @@
 import { SortOrderState } from "@stenajs-webui/redux";
 import { useMemo } from "react";
 import { useStandardTableActions } from "../../standard-table/hooks/UseStandardTableConfig";
-import { ArrowType } from "../components/table/TableHeadItem";
+import { SortOrderDirection } from "../components/table/SortOrderIcon";
 import { StandardTableActions } from "../../standard-table/util/ActionsFactory";
 
 interface Result {
   selected: boolean;
   desc: boolean;
-  arrow: ArrowType | undefined;
+  arrow: SortOrderDirection | undefined;
   onClickColumnHead: () => void;
 }
 

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -57,3 +57,6 @@ export * from "./features/grid-cell/hooks/UseGridCell";
 export * from "./features/grid-cell/hooks/UseGridNavigation";
 export * from "./features/grid-cell/hooks/UseGridNavigationOptionsFromContext";
 export * from "./features/grid-cell/hooks/UseRevertableValue";
+
+export { SortOrderIconVariant } from "./features/table-ui/components/table/SortOrderIcon";
+export { SortOrderDirection } from "./features/table-ui/components/table/SortOrderIcon";


### PR DESCRIPTION
# sortOrderIconVariant

Add support for sort order icon variants in standard table config. Can be set for whole table, and overridden per column. Options are "amount", "alpha" and "numeric".

# Sort icon placement

Icon is now placed on the left side of header label if header is aligned to the right.

![image](https://user-images.githubusercontent.com/1266041/117284706-6a1bbf80-ae67-11eb-9089-70b486838f1c.png)

![image](https://user-images.githubusercontent.com/1266041/117284734-7142cd80-ae67-11eb-8d15-47784d45d0c6.png)

![image](https://user-images.githubusercontent.com/1266041/117284752-7738ae80-ae67-11eb-8722-8100b085bc94.png)
