### PR TITLE
Add ability to change bg color when a row is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 10.1.2
+
+### StandardTable
+
+- `rowBackgroundResolver` now gets `selected` as second argument.
+  This makes it possible to change background color depending on
+  the checkbox being checked or not.
+
 ## 10.1.1
 
 ### Select

--- a/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
@@ -52,7 +52,10 @@ export const StandardTableRow = React.memo(function StandardTableRow<TItem>({
   const { isSelected, toggleSelected } = useRowCheckbox(item);
 
   const background = useMemo(
-    () => (rowBackgroundResolver ? rowBackgroundResolver(item) : undefined),
+    () =>
+      rowBackgroundResolver
+        ? rowBackgroundResolver(item, isSelected)
+        : undefined,
     [item, rowBackgroundResolver]
   );
 

--- a/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
@@ -57,11 +57,10 @@ export const StandardTableRow = React.memo(function StandardTableRow<TItem>({
     rowBackgroundResolver,
   ]);
 
-  const disabled = useMemo(
-    () =>
-      checkboxDisabledResolver ? checkboxDisabledResolver(item) : undefined,
-    [item, checkboxDisabledResolver]
-  );
+  const disabled = useMemo(() => checkboxDisabledResolver?.(item), [
+    item,
+    checkboxDisabledResolver,
+  ]);
 
   const firstColumn = useFirstColumnConfig();
   const firstColumnBackground = useCellBackgroundByColumnConfig(

--- a/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
@@ -51,13 +51,11 @@ export const StandardTableRow = React.memo(function StandardTableRow<TItem>({
   const { isExpanded, toggleRowExpanded } = useExpandCollapseActions(item);
   const { isSelected, toggleSelected } = useRowCheckbox(item);
 
-  const background = useMemo(
-    () =>
-      rowBackgroundResolver
-        ? rowBackgroundResolver(item, isSelected)
-        : undefined,
-    [item, rowBackgroundResolver]
-  );
+  const background = useMemo(() => rowBackgroundResolver?.(item, isSelected), [
+    isSelected,
+    item,
+    rowBackgroundResolver,
+  ]);
 
   const disabled = useMemo(
     () =>

--- a/packages/grid/src/features/standard-table/config/StandardTableConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableConfig.ts
@@ -106,7 +106,10 @@ export interface StandardTableConfig<
    * Add this to create a background color for the row, based on the item displayed.
    * @param item
    */
-  rowBackgroundResolver?: (item: TItem) => string | undefined;
+  rowBackgroundResolver?: (
+    item: TItem,
+    selected: boolean
+  ) => string | undefined;
 
   /**
    * This makes it possible to disable the checkbox for a row, based in the item.


### PR DESCRIPTION
### StandardTable
- `rowBackgroundResolver` now gets `selected` as second argument.
  This makes it possible to change background color depending on
  the checkbox is checked or not.