### PR TITLE
Correct color for icons in NavBarButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+### NavBar
+
+- `NavBarButton` icon now has same color as the text.
+
 ## 10.1.2
 
 ### StandardTable

--- a/packages/panels/src/components/nav-bar/NavBar.stories.tsx
+++ b/packages/panels/src/components/nav-bar/NavBar.stories.tsx
@@ -1,6 +1,7 @@
 import { faAddressCard } from "@fortawesome/free-solid-svg-icons/faAddressCard";
 import { faCoffee } from "@fortawesome/free-solid-svg-icons/faCoffee";
 import { faFire } from "@fortawesome/free-solid-svg-icons/faFire";
+import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
 import {
   Box,
   Column,
@@ -124,7 +125,7 @@ export const Demo: Story<Pick<NavBarProps, "variant">> = ({ variant }) => {
         }
         center={<NavBarSearchField />}
       >
-        <NavBarButton label={"Customers"} selected />
+        <NavBarButton label={"Customers"} leftIcon={faUsers} selected />
         <NavBarButton label={"Bookings"} />
         <NavBarButton label={"Events"} />
       </NavBar>

--- a/packages/panels/src/components/nav-bar/NavBarButton.module.css
+++ b/packages/panels/src/components/nav-bar/NavBarButton.module.css
@@ -37,6 +37,7 @@
 
   /* Flatbutton overrrides */
   --swui-flat-button-text-color: var(--swui-nav-bar-button-text-color);
+  --swui-flat-button-icon-color: var(--swui-nav-bar-button-text-color);
   --swui-flat-button-text-color-active: var(--swui-nav-bar-button-text-color);
   --swui-flat-button-background-color: var(
     --swui-nav-bar-button-background-color


### PR DESCRIPTION
Icons in NavBarButton now get same color as the text.

![image](https://user-images.githubusercontent.com/1266041/118784400-478a9d00-b890-11eb-887d-d22794954b58.png)
