### PR TITLE
Task 68488: LoadingModal redesign (AB#68488)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,12 @@ It returns the same actions, but wrapped with reducerIdGate action.
 - Sort order icon `amount` variant now has inverted arrow direction.
 
 - When using editable cells, `editorValue` was not always reset and could
-become inconsistent with the value of the data.
-`editorValue` is now always reset when editor for a cell is opened.
+  become inconsistent with the value of the data.
+  `editorValue` is now always reset when editor for a cell is opened.
+
+### LoadingModal
+
+- `LoadingModal` has been redesigned. The props are the same as before.
 
 ### Dependencies
 

--- a/packages/modal/src/components/loading-modal/LoadingModal.module.css
+++ b/packages/modal/src/components/loading-modal/LoadingModal.module.css
@@ -1,0 +1,20 @@
+.modal {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: transparent;
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--swui-overlay-bg-color);
+}

--- a/packages/modal/src/components/loading-modal/LoadingModal.tsx
+++ b/packages/modal/src/components/loading-modal/LoadingModal.tsx
@@ -1,50 +1,65 @@
-import * as React from "react";
-import { CenterModal, CenterModalProps } from "../center-modal/CenterModal";
-import { Box, Column, Indent, Row, Text } from "@stenajs-webui/core";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import {
+  Box,
+  Column,
+  Heading,
+  Indent,
+  Row,
+  Spacing,
+} from "@stenajs-webui/core";
 import { Icon, Spinner } from "@stenajs-webui/elements";
+import * as React from "react";
+import * as ReactModal from "react-modal";
+import styles from "./LoadingModal.module.css";
 
-export interface LoadingModalProps extends Omit<CenterModalProps, "isOpen"> {
-  isOpen?: boolean;
+export interface LoadingModalProps extends Omit<ReactModal.Props, "isOpen"> {
   headerText?: string;
   headerIconLeft?: IconDefinition;
 }
 
 export const LoadingModal: React.FC<LoadingModalProps> = ({
-  isOpen = true,
   headerIconLeft,
   headerText,
   ...modalProps
 }) => {
   return (
-    <CenterModal {...modalProps} isOpen={isOpen}>
-      <Column spacing={2}>
-        <Row indent={2}>
-          {headerIconLeft && (
-            <>
-              <Icon
-                size={14}
-                icon={headerIconLeft}
-                color={"var(--swui-text-primary-color)"}
-              />
-              <Indent />
-            </>
-          )}
-          {headerText && (
-            <Text size={"large"} variant={"bold"}>
-              {headerText}
-            </Text>
-          )}
-        </Row>
+    <ReactModal
+      {...modalProps}
+      isOpen
+      className={styles.modal}
+      overlayClassName={styles.overlay}
+    >
+      <Column spacing={2} alignItems={"center"}>
         <Box
           alignItems={"center"}
           justifyContent={"center"}
-          spacing={6}
-          indent={8}
+          width={"64px"}
+          height={"64px"}
+          borderRadius={"50%"}
+          background={"white"}
+          shadow={"modal"}
         >
-          <Spinner size={"medium"} />
+          <Spinner size={"small"} />
         </Box>
+        {(headerIconLeft || headerText) && (
+          <>
+            <Spacing />
+            <Row indent={2}>
+              {headerIconLeft && (
+                <>
+                  <Icon size={14} icon={headerIconLeft} color={"white"} />
+                  <Indent />
+                </>
+              )}
+              {headerText && (
+                <Heading variant={"h4"} color={"white"}>
+                  {headerText}
+                </Heading>
+              )}
+            </Row>
+          </>
+        )}
       </Column>
-    </CenterModal>
+    </ReactModal>
   );
 };

--- a/packages/theme/src/styles/default-theme.css
+++ b/packages/theme/src/styles/default-theme.css
@@ -13,7 +13,7 @@
   --swui-handle-bg-enabled-color: var(--swui-white);
   --swui-handle-bg-disabled-color: var(--lhds-color-ui-400);
   --swui-modal-border-color: var(--lhds-color-ui-400);
-  --swui-overlay-bg-color: rgba(0, 0, 0, 0.5);
+  --swui-overlay-bg-color: rgba(13, 14, 16, 0.5);
 
   /* State colors */
   --swui-state-error-color: var(--lhds-color-red-300);


### PR DESCRIPTION
- `LoadingModal` has been redesigned. The props are the same as before.

![image](https://user-images.githubusercontent.com/1266041/119452089-3e894800-bd36-11eb-996d-0c66162f7382.png)

![image](https://user-images.githubusercontent.com/1266041/119452112-434dfc00-bd36-11eb-8ed0-f9dcba5917c8.png)

Compared to design:

![image](https://user-images.githubusercontent.com/1266041/119452149-4d6ffa80-bd36-11eb-83ef-5ad9b2f4a07e.png)

In the design, the text appears bolder, but the description specifies h4 so that is being used in the implementation.