### PR TITLE
StandardTableColumnGroupOrderContext value fix

### DIFF
--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -198,9 +198,7 @@ export const StandardTable = function StandardTable<
                       value={usingColumnGroups}
                     >
                       <StandardTableColumnGroupOrderContext.Provider
-                        value={
-                          columnGroupOrder ?? config.columnGroupOrder ?? []
-                        }
+                        value={columnGroupOrder ?? config.columnGroupOrder}
                       >
                         <OnKeyDownContext.Provider value={onKeyDown}>
                           {(columnGroupOrder || config.columnGroupOrder) && (

--- a/packages/grid/src/features/standard-table/context/StandardTableColumnOrderContext.ts
+++ b/packages/grid/src/features/standard-table/context/StandardTableColumnOrderContext.ts
@@ -1,8 +1,8 @@
 import { createContext, useContext } from "react";
 
 export const StandardTableColumnGroupOrderContext = createContext<
-  Array<string>
->([]);
+  Array<string> | undefined
+>(undefined);
 
 export const StandardTableUsingColumnGroupsContext = createContext<boolean>(
   false


### PR DESCRIPTION
StandardTableColumnGroupOrderContext value is now undefined if no groupOrder has been set, instead of [].