### PR TITLE
renderCell options argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@
 
 - Small chip wrapping fix.
 
+### Breaking changes
+
+#### StandardTable
+
+`renderCell` has changed it arguments.
+
+It now receives an options object as argument instead of multiple arguments.
+
+Change from:
+
+```
+// Old
+renderCell: (label, item) => (
+// New
+renderCell: ({ label, item }) => (
+```
+
 ## 11.3.1
 
 ### ButtonContent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `renderCell` function now receives `isSelected` flag. True if checkbox is checked.
 - Fixed bug where `left` was improperly set when
   `stickyCheckboxColumn` was true but `showRowCheckbox` was false.
+- Column group now has `error` property, which displays an error triangle to the right of the label.
 
 ### ChipMultiSelect
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `renderCell` receives options argument.
 - `renderCell` function now receives `isSelected` flag. True if checkbox is checked.
+- Fixed bug where `left` was improperly set when
+  `stickyCheckboxColumn` was true but `showRowCheckbox` was false.
 
 ### ChipMultiSelect
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next
 
+### StandardTable
+
+- `renderCell` receives options argument.
+- `renderCell` function now receives `isSelected` flag. True if checkbox is checked.
+
 ### ChipMultiSelect
 
 - Small chip wrapping fix.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 #### StandardTable
 
-`renderCell` has changed it arguments.
+`renderCell` has changed its arguments.
 
 It now receives an options object as argument instead of multiple arguments.
 

--- a/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
@@ -130,12 +130,17 @@ export interface StandardTableColumnOptions<TItem, TItemValue> {
 }
 
 export type StandardTableCellRenderer<TItemValue, TItem> = (
-  label: string,
-  value: TItemValue,
-  item: TItem,
-  gridCell: UseGridCellResult<string>,
-  isEditable?: boolean
+  arg: StandardTableCellRendererArgObject<TItemValue, TItem>
 ) => ReactNode;
+
+export interface StandardTableCellRendererArgObject<TItemValue, TItem> {
+  label: string;
+  value: TItemValue;
+  item: TItem;
+  gridCell: UseGridCellResult<string>;
+  isEditable?: boolean;
+  isSelected: boolean;
+}
 
 export type BackgroundResolver<TItem> = (item: TItem) => string | undefined;
 

--- a/packages/grid/src/features/standard-table/config/StandardTableColumnGroupConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableColumnGroupConfig.ts
@@ -8,4 +8,5 @@ export interface StandardTableColumnGroupConfig<TColumnKey extends string> {
   columnOrder: Array<TColumnKey>;
   borderLeft?: boolean | string;
   loading?: boolean;
+  error?: string;
 }

--- a/packages/grid/src/features/standard-table/features/column-groups/ColumnInGroup.tsx
+++ b/packages/grid/src/features/standard-table/features/column-groups/ColumnInGroup.tsx
@@ -1,5 +1,8 @@
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExclamationTriangle";
 import { Box, Heading, Indent, Row, Space } from "@stenajs-webui/core";
-import { InputSpinner } from "@stenajs-webui/elements";
+import { Icon, InputSpinner } from "@stenajs-webui/elements";
+import { cssColor } from "@stenajs-webui/theme";
+import { Tooltip } from "@stenajs-webui/tooltip";
 import { Property } from "csstype";
 import * as React from "react";
 import { StandardTableColumnGroupConfig } from "../../config/StandardTableColumnGroupConfig";
@@ -20,7 +23,14 @@ export const ColumnInGroup = function ColumnGroupColumnItem<
   isFirstInGroup,
   borderFromGroup,
 }: ColumnGroupColumnItemProps<TColumnKey>) {
-  const { label, render, contentLeft, contentRight, loading } = groupConfig;
+  const {
+    label,
+    render,
+    contentLeft,
+    contentRight,
+    loading,
+    error,
+  } = groupConfig;
   const {
     flex = 1,
     width,
@@ -54,12 +64,17 @@ export const ColumnInGroup = function ColumnGroupColumnItem<
           {contentRight}
         </>
       )}
-      {loading && (
-        <>
-          <Indent />
-          <InputSpinner />
-        </>
-      )}
+      {(error || loading) && <Indent />}
+      {loading ? (
+        <InputSpinner />
+      ) : error ? (
+        <Tooltip label={error}>
+          <Icon
+            icon={faExclamationTriangle}
+            color={cssColor("--lhds-color-red-500")}
+          />
+        </Tooltip>
+      ) : undefined}
     </>
   ) : null;
 

--- a/packages/grid/src/features/standard-table/helpers/cell-renderers/editable-text-cell/EditableTextCell.tsx
+++ b/packages/grid/src/features/standard-table/helpers/cell-renderers/editable-text-cell/EditableTextCell.tsx
@@ -6,11 +6,9 @@ import { StandardTableCellRenderer } from "../../../config/StandardTableColumnCo
 export const createStandardEditableTextCell = <
   TItemValue,
   TItem
->(): StandardTableCellRenderer<TItemValue, TItem> => (
+>(): StandardTableCellRenderer<TItemValue, TItem> => ({
   label,
-  _itemValue,
-  _item,
-  {
+  gridCell: {
     editorValue,
     isEditing,
     setEditorValue,
@@ -18,8 +16,8 @@ export const createStandardEditableTextCell = <
     lastKeyEvent,
     stopEditing,
     stopEditingAndMove,
-  }
-) =>
+  },
+}) =>
   isEditing ? (
     <TextInput
       onValueChange={setEditorValue}

--- a/packages/grid/src/features/standard-table/helpers/cell-renderers/editable-text-cell/EditableTextCellWithStatus.tsx
+++ b/packages/grid/src/features/standard-table/helpers/cell-renderers/editable-text-cell/EditableTextCellWithStatus.tsx
@@ -9,11 +9,10 @@ export const createEditableTextCellWithStatus = <TItemValue, TItem>(
   warningOnEmpty?: string | ((item: TItem) => string),
   crudStatusProvider?: (item: TItem) => EntityCrudStatus | undefined,
   modifiedFieldProvider?: (item: TItem) => ModifiedFieldItemState | undefined
-): StandardTableCellRenderer<TItemValue, TItem> => (
+): StandardTableCellRenderer<TItemValue, TItem> => ({
   label,
-  _itemValue,
-  _item,
-  {
+  item,
+  gridCell: {
     editorValue,
     isEditing,
     setEditorValue,
@@ -22,17 +21,17 @@ export const createEditableTextCellWithStatus = <TItemValue, TItem>(
     stopEditing,
     stopEditingAndMove,
   },
-  isEditable
-) => {
+  isEditable,
+}) => {
   const warnOnEmpty =
     typeof warningOnEmpty === "function"
-      ? warningOnEmpty(_item)
+      ? warningOnEmpty(item)
       : warningOnEmpty;
 
-  const crudStatus = crudStatusProvider ? crudStatusProvider(_item) : undefined;
+  const crudStatus = crudStatusProvider ? crudStatusProvider(item) : undefined;
 
   const modifiedField = modifiedFieldProvider
-    ? modifiedFieldProvider(_item)
+    ? modifiedFieldProvider(item)
     : undefined;
 
   return isEditable && isEditing ? (

--- a/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
@@ -286,12 +286,12 @@ const createSalesPerformanceStandardTableConfig = (
         item?.automation?.departureAutomation?.fareClassMethodName
           .toUpperCase()
           .replace("_", " ") ?? "-",
-      renderCell: (label, item) => (
+      renderCell: ({ label, item }) => (
         <Indent>
           <Tag
             label={label}
             variant={
-              item?.departureAutomation.automationEnabled
+              item?.automation.departureAutomation.automationEnabled
                 ? "success"
                 : "passive"
             }
@@ -343,7 +343,7 @@ const createSalesPerformanceStandardTableConfig = (
      */
     efpVehiclesReserved: createColumnConfig((item) => item.efpVehicles, {
       columnLabel: "Res.",
-      renderCell: (_, value) => (
+      renderCell: ({ value }) => (
         <Indent>
           <Text>{value?.salesPerformance.booked}</Text>
           <Space />
@@ -385,7 +385,7 @@ const createSalesPerformanceStandardTableConfig = (
         columnLabel: "-1",
         width: smallTableRowWidth,
         minWidth: smallTableRowWidth,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.efpHistory.minus1?.textColor}>
               {label}
@@ -403,7 +403,7 @@ const createSalesPerformanceStandardTableConfig = (
         columnLabel: "-3",
         width: smallTableRowWidth,
         minWidth: smallTableRowWidth,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.efpHistory.minus3?.textColor}>
               {label}
@@ -421,7 +421,7 @@ const createSalesPerformanceStandardTableConfig = (
         columnLabel: "-7",
         width: smallTableRowWidth,
         minWidth: smallTableRowWidth,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.efpHistory.minus7?.textColor}>
               {label}
@@ -439,7 +439,7 @@ const createSalesPerformanceStandardTableConfig = (
         columnLabel: "-30",
         width: smallTableRowWidth,
         minWidth: smallTableRowWidth,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.efpHistory.minus30?.textColor}>
               {label}
@@ -457,7 +457,7 @@ const createSalesPerformanceStandardTableConfig = (
         columnLabel: "-45",
         width: smallTableRowWidth,
         minWidth: smallTableRowWidth,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.efpHistory.minus45?.textColor}>
               {label}
@@ -517,7 +517,7 @@ const createSalesPerformanceStandardTableConfig = (
         minWidth: smallTableRowWidth,
         backgroundResolver: (item) =>
           item.tableColors.guestsHistory.minus1?.bgColor,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.guestsHistory.minus1?.textColor}>
               {label}
@@ -534,7 +534,7 @@ const createSalesPerformanceStandardTableConfig = (
         minWidth: smallTableRowWidth,
         backgroundResolver: (item) =>
           item.tableColors.guestsHistory.minus3?.bgColor,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.guestsHistory.minus3?.textColor}>
               {label}
@@ -551,7 +551,7 @@ const createSalesPerformanceStandardTableConfig = (
         minWidth: smallTableRowWidth,
         backgroundResolver: (item) =>
           item.tableColors.guestsHistory.minus7?.bgColor,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.guestsHistory.minus7?.textColor}>
               {label}
@@ -568,7 +568,7 @@ const createSalesPerformanceStandardTableConfig = (
         minWidth: smallTableRowWidth,
         backgroundResolver: (item) =>
           item.tableColors.guestsHistory.minus30?.bgColor,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.guestsHistory.minus30?.textColor}>
               {label}
@@ -585,7 +585,7 @@ const createSalesPerformanceStandardTableConfig = (
         minWidth: smallTableRowWidth,
         backgroundResolver: (item) =>
           item.tableColors.guestsHistory.minus45?.bgColor,
-        renderCell: (label, _, item) => (
+        renderCell: ({ label, item }) => (
           <Indent>
             <Text color={item.tableColors.guestsHistory.minus45?.textColor}>
               {label}


### PR DESCRIPTION
- `renderCell` receives options argument.
- `renderCell` function now receives `isSelected` flag. True if checkbox is checked.
- Fixed bug where `left` was improperly set when
  `stickyCheckboxColumn` was true but `showRowCheckbox` was false.
- Column group now has `error` property, which displays an error triangle to the right of the label.

# Breaking change

- Change renderCell, it now receives one argument containing all relevant info, instead of several arguments.
 
```
// Old
renderCell: (label, item) => (
// New
renderCell: ({ label, item }) => (
```
