### PR TITLE
Fix z-index issue in column groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed bug where `left` was improperly set when
   `stickyCheckboxColumn` was true but `showRowCheckbox` was false.
 - Column group now has `error` property, which displays an error triangle to the right of the label.
+- Fix problem where `contentRight` in column group could not be interacted with.
 
 ### ChipMultiSelect
 

--- a/packages/grid/src/features/standard-table/components/StandardTable.module.css
+++ b/packages/grid/src/features/standard-table/components/StandardTable.module.css
@@ -5,6 +5,7 @@
   --swui-sticky-header-z-index: 2;
   --swui-sticky-column-z-index: 1;
   --swui-sticky-popover-z-index: 3;
+  --swui-sticky-column-group-label-z-index: 4;
 
   /* Current */
   --current-row-height: var(--swui-standard-table-height);

--- a/packages/grid/src/features/standard-table/features/column-groups/ColumnInGroup.tsx
+++ b/packages/grid/src/features/standard-table/features/column-groups/ColumnInGroup.tsx
@@ -45,6 +45,7 @@ export const ColumnInGroup = function ColumnGroupColumnItem<
     <>
       {contentLeft && (
         <>
+          <Space />
           {contentLeft}
           <Space num={0.5} />
         </>
@@ -82,7 +83,7 @@ export const ColumnInGroup = function ColumnGroupColumnItem<
 
   return (
     <Box
-      position={sticky ? "sticky" : "relative"}
+      position={sticky ? "sticky" : undefined}
       height={"var(--current-row-height)"}
       width={width}
       minWidth={minWidth ?? width}
@@ -99,15 +100,22 @@ export const ColumnInGroup = function ColumnGroupColumnItem<
       shadow={sticky ? "var(--swui-sticky-column-shadow-right)" : undefined}
     >
       {content && (
-        <Row
-          height={"var(--current-row-height)"}
-          position={"absolute"}
-          top={0}
-          left={0}
-          alignItems={"center"}
+        <Box
+          position={"relative"}
+          zIndex={
+            "var(--swui-sticky-column-group-label-z-index)" as Property.ZIndex
+          }
         >
-          {content}
-        </Row>
+          <Row
+            height={"var(--current-row-height)"}
+            position={"absolute"}
+            top={0}
+            left={0}
+            alignItems={"center"}
+          >
+            {content}
+          </Row>
+        </Box>
       )}
     </Box>
   );

--- a/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
@@ -1,3 +1,5 @@
+import { faAngleLeft } from "@fortawesome/free-solid-svg-icons/faAngleLeft";
+import { faAngleRight } from "@fortawesome/free-solid-svg-icons/faAngleRight";
 import { faCoffee } from "@fortawesome/free-solid-svg-icons/faCoffee";
 import { Box, Indent, Space, Text } from "@stenajs-webui/core";
 import { Chip, FlatButton, Icon, Tag } from "@stenajs-webui/elements";
@@ -598,6 +600,12 @@ const createSalesPerformanceStandardTableConfig = (
   columnGroups: {
     departures: {
       label: "Departures",
+      contentLeft: (
+        <FlatButton size={"small"} leftIcon={faAngleLeft} onClick={() => {}} />
+      ),
+      contentRight: (
+        <FlatButton size={"small"} leftIcon={faAngleRight} onClick={() => {}} />
+      ),
       columnOrder: [
         "link",
         "leg",


### PR DESCRIPTION
Fix z-index issue in column groups, which made buttons in contentRight of column group not clickable.

Previously, only the left button was clickable.

![image](https://user-images.githubusercontent.com/1266041/122878611-3d990580-d338-11eb-9846-cbae1dc05f13.png)
