### PR TITLE
Move animation outside css module to fix Jest CSS parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Next
+
+- Spinner has updated animation.
+
 ## 12.0.0
 
 ### StandardTable

--- a/packages/elements/src/components/ui/spinner/Spinner.module.css
+++ b/packages/elements/src/components/ui/spinner/Spinner.module.css
@@ -43,27 +43,27 @@
     width: 20px;
     height: 20px;
   }
+}
 
-  @keyframes dash {
-    0% {
-      stroke-dashoffset: 187;
-    }
-    50% {
-      stroke-dashoffset: 46.75;
-      transform: rotate(135deg);
-    }
-    100% {
-      stroke-dashoffset: 187;
-      transform: rotate(450deg);
-    }
+@keyframes dash {
+  0% {
+    stroke-dashoffset: 187;
   }
+  50% {
+    stroke-dashoffset: 46.75;
+    transform: rotate(135deg);
+  }
+  100% {
+    stroke-dashoffset: 187;
+    transform: rotate(450deg);
+  }
+}
 
-  @keyframes rotator {
-    0% {
-      transform: rotate(0deg);
-    }
-    100% {
-      transform: rotate(270deg);
-    }
+@keyframes rotator {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(270deg);
   }
 }

--- a/packages/elements/src/components/ui/spinner/Spinner.module.css
+++ b/packages/elements/src/components/ui/spinner/Spinner.module.css
@@ -1,31 +1,34 @@
 .spinner {
-  animation: rotator 1.4s linear infinite;
+  animation: rotator 2s linear infinite both;
 
   circle {
-    stroke-dasharray: 187;
-    stroke-dashoffset: 0;
-    stroke-width: 6;
     stroke-linecap: round;
     transform-origin: center;
+    fill: transparent;
+    stroke-dasharray: 283;
+    stroke-dashoffset: 280;
+    stroke-width: 10px;
   }
 
   &.standard {
     stroke: var(--lhds-color-blue-500);
+
     circle {
-      animation: dash 1.4s ease-in-out infinite;
+      animation: dash 1.4s ease-in-out infinite both;
     }
   }
 
   &.inverted {
     stroke: var(--lhds-color-ui-300);
+
     circle {
-      animation: dash 1.4s ease-in-out infinite;
+      animation: dash 1.4s ease-in-out infinite both;
     }
   }
 
   &.customColor {
     circle {
-      animation: dash 1.4s ease-in-out infinite;
+      animation: dash 1.4s ease-in-out infinite both;
     }
   }
 
@@ -46,16 +49,21 @@
 }
 
 @keyframes dash {
-  0% {
-    stroke-dashoffset: 187;
+  0%,
+  25% {
+    stroke-dashoffset: 280;
+    transform: rotate(0);
   }
-  50% {
-    stroke-dashoffset: 46.75;
-    transform: rotate(135deg);
+
+  50%,
+  75% {
+    stroke-dashoffset: 75;
+    transform: rotate(45deg);
   }
+
   100% {
-    stroke-dashoffset: 187;
-    transform: rotate(450deg);
+    stroke-dashoffset: 280;
+    transform: rotate(360deg);
   }
 }
 
@@ -64,6 +72,6 @@
     transform: rotate(0deg);
   }
   100% {
-    transform: rotate(270deg);
+    transform: rotate(360deg);
   }
 }

--- a/packages/elements/src/components/ui/spinner/spinner-large.svg
+++ b/packages/elements/src/components/ui/spinner/spinner-large.svg
@@ -1,3 +1,3 @@
-<svg class="spinner" width="65px" height="65px" viewBox="0 0 66 66" xmlns="http://www.w3.org/2000/svg">
-  <circle class="path" fill="none" stroke-width="6" stroke-linecap="round" cx="33" cy="33" r="30"></circle>
+<svg class="spinner" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <circle class="path" fill="none" stroke-width="6" stroke-linecap="round" cx="50" cy="50" r="45"></circle>
 </svg>


### PR DESCRIPTION
Getting rid of these messages in the console:

![image](https://user-images.githubusercontent.com/2521318/123226873-55a58c00-d4d4-11eb-895c-81fa4db9a9c7.png)

Also, I updated the spinner animation to get rid of the janky behaviour (top one is new):

https://user-images.githubusercontent.com/2521318/123227600-06ac2680-d4d5-11eb-877f-f48caa63780d.mov


