### PR TITLE
Move td out of StandardTableCellUi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+### StandardTable
+
+- Slight refactoring to make `StandardTableCellUi` more backward compatible.
+
 ## 13.0.1
 
 ### StandardTable

--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -223,6 +223,7 @@ export const StandardTable = function StandardTable<
       style={
         {
           width: "100%",
+          isolation: "isolate",
           "--current-left-offset":
             enableExpandCollapse && stickyCheckboxColumn
               ? "calc(var(--swui-expand-cell-width) + var(--swui-checkbox-cell-width))"

--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -1,5 +1,10 @@
 import * as React from "react";
-import { KeyboardEventHandler, useCallback, useMemo } from "react";
+import {
+  CSSProperties,
+  KeyboardEventHandler,
+  useCallback,
+  useMemo,
+} from "react";
 import { useGridCell } from "../../grid-cell/hooks/UseGridCell";
 import { useOnKeyDownContext } from "../context/OnKeyDownContext";
 import { useStickyPropsPerColumnContext } from "../context/StickyPropsPerColumnContext";
@@ -140,40 +145,43 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
 
   const stickyProps = stickyPropsPerColumnContext[columnId];
 
+  const shadow =
+    stickyProps.sticky &&
+    stickyProps.type === "last-group" &&
+    stickyProps.isFirstColumnInLastGroup
+      ? "var(--swui-sticky-column-shadow-left)"
+      : stickyProps.sticky && stickyProps.type === "column" && stickyProps.right
+      ? "var(--swui-sticky-column-shadow-left)"
+      : stickyProps.sticky
+      ? "var(--swui-sticky-column-shadow-right)"
+      : undefined;
+
   return (
-    <StandardTableCellUi
-      enableGridCell={enableGridCell && !disableGridCell}
-      gridCellRequiredProps={gridCell.requiredProps}
-      isEditing={gridCell.isEditing}
-      width={width}
-      minWidth={minWidth}
-      justifyContent={justifyContentCell}
-      borderLeft={activeBorderLeft}
-      background={currentBackground}
-      sticky={stickyProps.sticky}
-      zIndex={
-        zIndex ?? stickyProps.sticky
-          ? "var(--swui-sticky-column-z-index)"
-          : undefined
-      }
-      left={stickyProps.left}
-      right={stickyProps.right}
-      shadow={
-        stickyProps.sticky &&
-        stickyProps.type === "last-group" &&
-        stickyProps.isFirstColumnInLastGroup
-          ? "var(--swui-sticky-column-shadow-left)"
-          : stickyProps.sticky &&
-            stickyProps.type === "column" &&
-            stickyProps.right
-          ? "var(--swui-sticky-column-shadow-left)"
-          : stickyProps.sticky
-          ? "var(--swui-sticky-column-shadow-right)"
-          : undefined
-      }
-      onKeyDown={onKeyDownHandler}
+    <td
+      style={{
+        borderLeft: activeBorderLeft,
+        position: stickyProps.sticky ? "sticky" : undefined,
+        left: stickyProps.sticky ? stickyProps.left : undefined,
+        right: stickyProps.sticky ? stickyProps.right : undefined,
+        boxShadow: shadow,
+        zIndex: (stickyProps.sticky
+          ? zIndex ?? "var(--swui-sticky-column-z-index)"
+          : zIndex ?? 1) as CSSProperties["zIndex"],
+        height: "var(--swui-standard-table-height)",
+      }}
     >
-      {content}
-    </StandardTableCellUi>
+      <StandardTableCellUi
+        enableGridCell={enableGridCell && !disableGridCell}
+        gridCellRequiredProps={gridCell.requiredProps}
+        isEditing={gridCell.isEditing}
+        width={width}
+        minWidth={minWidth}
+        justifyContent={justifyContentCell}
+        background={currentBackground}
+        onKeyDown={onKeyDownHandler}
+      >
+        {content}
+      </StandardTableCellUi>
+    </td>
   );
 });

--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -167,7 +167,8 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
         zIndex: (stickyProps.sticky
           ? zIndex ?? "var(--swui-sticky-column-z-index)"
           : zIndex ?? 1) as CSSProperties["zIndex"],
-        height: "var(--swui-standard-table-height)",
+        height: "var(--current-row-height)",
+        background: currentBackground,
       }}
     >
       <StandardTableCellUi
@@ -177,7 +178,6 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
         width={width}
         minWidth={minWidth}
         justifyContent={justifyContentCell}
-        background={currentBackground}
         onKeyDown={onKeyDownHandler}
       >
         {content}

--- a/packages/grid/src/features/standard-table/components/StandardTableCellUi.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCellUi.tsx
@@ -1,7 +1,6 @@
 import { BoxProps, Row } from "@stenajs-webui/core";
 import * as React from "react";
-import { CSSProperties, ReactNode } from "react";
-import { tableBorder } from "../../../config/TableConfig";
+import { ReactNode } from "react";
 import { GridCellRequiredProps } from "../../grid-cell/hooks/UseGridCell";
 import styles from "./StandardTableCellUi.module.css";
 
@@ -13,20 +12,13 @@ interface Props {
   isEditing: boolean;
   gridCellRequiredProps?: GridCellRequiredProps;
   background?: string;
-  borderLeft?: string | boolean;
   children: ReactNode;
-  sticky?: boolean;
-  zIndex?: number | string;
-  left?: string;
-  right?: string;
-  shadow?: string;
   onKeyDown?: BoxProps["onKeyDown"];
 }
 
 export const StandardTableCellUi = React.memo<Props>(
   function StandardTableCellUi({
     enableGridCell,
-    borderLeft,
     children,
     background,
     gridCellRequiredProps,
@@ -34,31 +26,15 @@ export const StandardTableCellUi = React.memo<Props>(
     justifyContent,
     width,
     minWidth,
-    sticky,
-    left,
-    right,
-    zIndex,
-    shadow,
     onKeyDown,
   }) {
     return (
-      <td
-        style={{
-          width: width,
-          minWidth: minWidth ?? width ?? "20px",
-          background: background,
-          borderLeft:
-            borderLeft === true ? tableBorder : borderLeft || undefined,
-          overflow: "hidden",
-          height: "var(--current-row-height)",
-          position: sticky ? "sticky" : undefined,
-          left: sticky ? left : undefined,
-          right: sticky ? right : undefined,
-          boxShadow: shadow,
-          zIndex: (sticky
-            ? zIndex ?? "var(--swui-sticky-column-z-index)"
-            : zIndex ?? 1) as CSSProperties["zIndex"],
-        }}
+      <Row
+        width={width}
+        minWidth={minWidth ?? width ?? "20px"}
+        height={"100%"}
+        background={background}
+        overflow={"hidden"}
         onKeyDown={onKeyDown}
       >
         <Row
@@ -84,7 +60,7 @@ export const StandardTableCellUi = React.memo<Props>(
         >
           {children}
         </Row>
-      </td>
+      </Row>
     );
   }
 );


### PR DESCRIPTION
Move td and sticky from StandardTableCellUi into StandardTableCell, 
so that StandardTableCellUi is only UI for the cell content.

This makes StandardTableCellUi reusable.