### PR TITLE
Sticky column see-through fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+### StandardTable
+
+- When `backgroundResolver` returned undefined for a sticky column, it became see-through.
+
 ## 13.0.2
 
 ### StandardTable

--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -124,6 +124,10 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
   const background =
     useCellBackgroundByColumnId(columnId, item) ?? fallbackBackground;
 
+  const currentZIndex = stickyProps.sticky
+    ? zIndex ?? "var(--swui-sticky-column-z-index)"
+    : zIndex ?? 1;
+
   const content = useMemo(
     () =>
       renderCell ? (
@@ -134,11 +138,21 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
           gridCell,
           isEditable: editable,
           isSelected,
+          zIndex: currentZIndex,
         })
       ) : (
         <TextCell label={label} />
       ),
-    [renderCell, label, itemValue, item, gridCell, editable, isSelected]
+    [
+      renderCell,
+      label,
+      itemValue,
+      item,
+      gridCell,
+      editable,
+      isSelected,
+      currentZIndex,
+    ]
   );
 
   const activeBorderLeft = getCellBorder(
@@ -166,9 +180,7 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
         left: stickyProps.sticky ? stickyProps.left : undefined,
         right: stickyProps.sticky ? stickyProps.right : undefined,
         boxShadow: shadow,
-        zIndex: (stickyProps.sticky
-          ? zIndex ?? "var(--swui-sticky-column-z-index)"
-          : zIndex ?? 1) as CSSProperties["zIndex"],
+        zIndex: currentZIndex as CSSProperties["zIndex"],
         height: "var(--current-row-height)",
         background: background,
       }}

--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -118,7 +118,11 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
     ...gridCellOptionsForColumn,
   });
 
-  const currentBackground = useCellBackgroundByColumnId(columnId, item);
+  const stickyProps = stickyPropsPerColumnContext[columnId];
+
+  const fallbackBackground = stickyProps.sticky ? "white" : "inherit";
+  const background =
+    useCellBackgroundByColumnId(columnId, item) ?? fallbackBackground;
 
   const content = useMemo(
     () =>
@@ -143,8 +147,6 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
     borderLeft
   );
 
-  const stickyProps = stickyPropsPerColumnContext[columnId];
-
   const shadow =
     stickyProps.sticky &&
     stickyProps.type === "last-group" &&
@@ -168,7 +170,7 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
           ? zIndex ?? "var(--swui-sticky-column-z-index)"
           : zIndex ?? 1) as CSSProperties["zIndex"],
         height: "var(--current-row-height)",
-        background: currentBackground,
+        background: background,
       }}
     >
       <StandardTableCellUi

--- a/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
@@ -149,6 +149,10 @@ export interface StandardTableCellRendererArgObject<TItemValue, TItem> {
   gridCell: UseGridCellResult<string>;
   isEditable?: boolean;
   isSelected: boolean;
+  /**
+   * The z-index used for that cell. Usable if the cell has a popover which should get same z-index for example.
+   */
+  zIndex?: number | string;
 }
 
 export type BackgroundResolver<TItem> = (item: TItem) => string | undefined;

--- a/packages/grid/src/features/standard-table/hooks/UseCellBackground.ts
+++ b/packages/grid/src/features/standard-table/hooks/UseCellBackground.ts
@@ -9,20 +9,24 @@ const getBackgroundColor = <TItem>(
   backgroundResolver: BackgroundResolver<TItem> | undefined,
   item: TItem,
   background: string | undefined
-) => (backgroundResolver ? backgroundResolver(item) : background) ?? "inherit";
+): string | undefined =>
+  backgroundResolver ? backgroundResolver(item) : background;
 
 const useBackground = <TItem>(
   backgroundResolver: BackgroundResolver<TItem> | undefined,
   item: TItem,
   background: string | undefined
-) =>
+): string | undefined =>
   useMemo(() => getBackgroundColor(backgroundResolver, item, background), [
     backgroundResolver,
     item,
     background,
   ]);
 
-export const useCellBackgroundByColumnId = <T>(columnId: string, item: T) => {
+export const useCellBackgroundByColumnId = <T>(
+  columnId: string,
+  item: T
+): string | undefined => {
   const { background, backgroundResolver } = useColumnConfigById(columnId);
   return useBackground(backgroundResolver, item, background);
 };
@@ -30,7 +34,7 @@ export const useCellBackgroundByColumnId = <T>(columnId: string, item: T) => {
 export const useCellBackgroundByColumnConfig = <TItem, TItemValue>(
   columnConfig: StandardTableColumnConfig<TItem, TItemValue> | undefined,
   item: TItem
-) => {
+): string | undefined => {
   const { background, backgroundResolver } = columnConfig ?? {};
   return useBackground(backgroundResolver, item, background);
 };


### PR DESCRIPTION
- When `backgroundResolver` returned undefined for a sticky column, it became see-through.

![image](https://user-images.githubusercontent.com/1266041/124744794-6962e080-df1f-11eb-8d94-907a9cc5daec.png)

- Add zIndex as argument to renderCell.