### PR TITLE
Some column width fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Next
+
+- Cell content can no longer expand the column width.
+- Table heads get correct width set.
+
 ## 13.0.4
 
 - Fix some cases where cell did not align left/right properly.

--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -223,6 +223,7 @@ export const StandardTable = function StandardTable<
       style={
         {
           width: "100%",
+          tableLayout: "fixed",
           isolation: "isolate",
           "--current-left-offset":
             enableExpandCollapse && stickyCheckboxColumn

--- a/packages/grid/src/features/standard-table/components/StandardTableHeadItem.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableHeadItem.tsx
@@ -86,11 +86,13 @@ export const StandardTableHeadItem = React.memo(
             : stickyProps.sticky
             ? "var(--swui-sticky-group-header-z-index)"
             : zIndex) as CSSProperties["zIndex"],
+          width,
+          minWidth,
         }}
       >
         <TableHeadItem
-          width={width}
-          minWidth={minWidth}
+          width={"100%"}
+          minWidth={"100%"}
           arrow={!disableSorting && label ? arrow : undefined}
           onClick={!disableSorting ? onClickColumnHead : undefined}
           label={label}


### PR DESCRIPTION
Set table-layout: fixed, so cell content cannot make the column wider.
Add width to all th so that width is applied correctly.