### PR TITLE
Fix columns getting wider than specified when table is wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - A combination of `ChipMultiSelect` and `GroupedMultiSelect`
 
+### StandardTable
+
+- When all columns had fixed width, they would still get wider than specified when table was wider.
+
 ### Modal
 
 - `ModalHeader` is once again draggable by default.

--- a/packages/core/src/components/layout/box/Box.tsx
+++ b/packages/core/src/components/layout/box/Box.tsx
@@ -46,6 +46,7 @@ import {
   ZIndexProps,
 } from "styled-system";
 import { DivProps } from "../../../types/ElementProps";
+import { booleanOrNumberToNumber } from "../../../utils/BooleanOrNumberToNumber";
 
 interface StyledSystemProps
   extends BorderRadiusProps,
@@ -152,16 +153,6 @@ const excludedProps = [
 const isExcludedWebUiProp = (propName: string) =>
   excludedProps.includes(propName);
 
-const numberOrZero = (num: number | boolean | undefined): number => {
-  if (num == null) {
-    return 0;
-  }
-  if (typeof num === "boolean") {
-    return num ? 1 : 0;
-  }
-  return num;
-};
-
 const box = system({
   row: {
     property: "flexDirection",
@@ -170,12 +161,12 @@ const box = system({
   indent: {
     // @ts-ignore
     property: "--current-indent",
-    transform: numberOrZero,
+    transform: booleanOrNumberToNumber,
   },
   spacing: {
     // @ts-ignore
     property: "--current-spacing",
-    transform: numberOrZero,
+    transform: booleanOrNumberToNumber,
   },
   shadow: {
     property: "boxShadow",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,3 +45,4 @@ export * from "./hooks/UseTimeoutState";
 
 export * from "./utils/SwitchCaseExhauster";
 export * from "./utils/parsers/NumberParser";
+export { booleanOrNumberToNumber } from "./utils/BooleanOrNumberToNumber";

--- a/packages/core/src/utils/BooleanOrNumberToNumber.ts
+++ b/packages/core/src/utils/BooleanOrNumberToNumber.ts
@@ -1,0 +1,11 @@
+export const booleanOrNumberToNumber = (
+  num: number | boolean | undefined
+): number => {
+  if (num == null) {
+    return 0;
+  }
+  if (typeof num === "boolean") {
+    return num ? 1 : 0;
+  }
+  return num;
+};

--- a/packages/grid/src/features/standard-table/components/ColGroups.tsx
+++ b/packages/grid/src/features/standard-table/components/ColGroups.tsx
@@ -9,9 +9,6 @@ export const ColGroups: React.FC<ColsProps> = () => {
   const config = useStandardTableConfig();
   const groupConfigs = useGroupConfigsForRows();
 
-  console.log("groupConfigs", groupConfigs);
-  console.log("config", config);
-
   const hasExtraColGroup =
     config.enableExpandCollapse || config.showRowCheckbox;
 

--- a/packages/grid/src/features/standard-table/components/ColGroups.tsx
+++ b/packages/grid/src/features/standard-table/components/ColGroups.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+import { useStandardTableConfig } from "../hooks/UseStandardTableConfig";
+import { useGroupConfigsForRows } from "../context/GroupConfigsForRowsContext";
+import { booleanOrNumberToNumber } from "@stenajs-webui/core";
+
+interface ColsProps {}
+
+export const ColGroups: React.FC<ColsProps> = () => {
+  const config = useStandardTableConfig();
+  const groupConfigs = useGroupConfigsForRows();
+
+  console.log("groupConfigs", groupConfigs);
+  console.log("config", config);
+
+  const hasExtraColGroup =
+    config.enableExpandCollapse || config.showRowCheckbox;
+
+  const rowIndent = booleanOrNumberToNumber(config.rowIndent);
+
+  return (
+    <>
+      {rowIndent ? (
+        <colgroup>
+          <col
+            style={{ width: `calc(var(--swui-metrics-indent) * ${rowIndent})` }}
+          />
+        </colgroup>
+      ) : null}
+      {hasExtraColGroup && (
+        <colgroup>
+          {config.enableExpandCollapse && (
+            <col style={{ width: "var(--swui-expand-cell-width)" }} />
+          )}
+          {config.showRowCheckbox && (
+            <col style={{ width: "var(--swui-checkbox-cell-width)" }} />
+          )}
+        </colgroup>
+      )}
+      {groupConfigs.map((group) => (
+        <colgroup>
+          {group.columnOrder.map((columnId) => (
+            <col
+              style={{
+                width: config.columns[columnId].width,
+                minWidth: config.columns[columnId].minWidth,
+              }}
+            />
+          ))}
+        </colgroup>
+      ))}
+      {rowIndent ? (
+        <colgroup>
+          <col
+            style={{ width: `calc(var(--swui-metrics-indent) * ${rowIndent})` }}
+          />
+        </colgroup>
+      ) : null}
+    </>
+  );
+};

--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -34,6 +34,7 @@ import { getTotalNumColumns } from "../util/ColumnCounter";
 import styles from "./StandardTable.module.css";
 import { StandardTableContent } from "./StandardTableContent";
 import { StandardTableHeadRow } from "./StandardTableHeadRow";
+import { ColGroups } from "./ColGroups";
 
 export interface StandardTableProps<
   TItem,
@@ -260,6 +261,7 @@ export const StandardTable = function StandardTable<
                                 : columnGroupOrder
                             }
                           >
+                            <ColGroups />
                             <OnKeyDownContext.Provider value={onKeyDown}>
                               <thead>
                                 {(columnGroupOrder ||

--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -181,8 +181,6 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
         zIndex: currentZIndex as CSSProperties["zIndex"],
         height: "var(--current-row-height)",
         background: background,
-        width: width,
-        minWidth: minWidth ?? width ?? "20px",
       }}
     >
       <StandardTableCellUi

--- a/packages/grid/src/features/standard-table/components/StandardTableCellUi.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCellUi.tsx
@@ -25,10 +25,13 @@ export const StandardTableCellUi = React.memo<Props>(
     isEditing,
     justifyContent,
     onKeyDown,
+    width,
+    minWidth,
   }) {
     return (
       <Row
-        width={"inherit"}
+        width={width}
+        minWidth={minWidth}
         height={"inherit"}
         background={background}
         overflow={"hidden"}

--- a/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
@@ -183,6 +183,7 @@ export const StandardTableHeadRow = React.memo(function StandardTableHeadRow<
           <Row indent={rowIndent} />
         </th>
       )}
+      <th />
     </TrWithHoverBackground>
   );
 });

--- a/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
@@ -215,6 +215,7 @@ export const StandardTableRow = React.memo(function StandardTableRow<TItem>({
               <Indent num={rowIndent} />
             </td>
           )}
+          <td />
         </>
       </>
     ),

--- a/packages/grid/src/features/standard-table/stories/FewColumns.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/FewColumns.stories.tsx
@@ -1,0 +1,83 @@
+import { ListItem, mockedItems } from "./StandardTableStoryHelper";
+import { StandardTableConfig } from "../config/StandardTableConfig";
+import { StandardTable } from "../components/StandardTable";
+import * as React from "react";
+import { createColumnConfig } from "../config/StandardTableColumnConfig";
+import { Spacing } from "@stenajs-webui/core";
+import { Banner } from "@stenajs-webui/elements";
+
+export default {
+  title: "grid/StandardTable/FewColumns",
+};
+
+export const FixedWidthColumns = () => {
+  const config: StandardTableConfig<ListItem, "id" | "name"> = {
+    keyResolver: (item) => item.id,
+    showHeaderCheckbox: true,
+    showRowCheckbox: true,
+    enableGridCell: true,
+    columns: {
+      id: createColumnConfig((item) => item.id, {
+        sortOrderIconVariant: "numeric",
+        width: "100px",
+      }),
+      name: createColumnConfig((item) => item.name, {
+        justifyContentHeader: "flex-end",
+        justifyContentCell: "flex-end",
+        infoIconTooltipText: "Ohoh",
+        sortOrderIconVariant: "alpha",
+        width: "100px",
+      }),
+    },
+    columnOrder: ["id", "name"],
+  };
+
+  return (
+    <div>
+      <StandardTable items={mockedItems} config={config} />
+      <Spacing />
+      <Banner
+        headerText={"Two columns with width=100px"}
+        text={
+          "They should be 100px wide and align to the left in the table. The table should still fill out the fill width of the browser, with row border all the way to the right. "
+        }
+      />
+    </div>
+  );
+};
+
+export const MinWidthColumns = () => {
+  const config: StandardTableConfig<ListItem, "id" | "name"> = {
+    keyResolver: (item) => item.id,
+    showHeaderCheckbox: true,
+    showRowCheckbox: true,
+    enableGridCell: true,
+    columns: {
+      id: createColumnConfig((item) => item.id, {
+        sortOrderIconVariant: "numeric",
+        minWidth: "500px",
+      }),
+      name: createColumnConfig((item) => item.name, {
+        justifyContentHeader: "flex-end",
+        justifyContentCell: "flex-end",
+        infoIconTooltipText: "Ohoh",
+        sortOrderIconVariant: "alpha",
+        minWidth: "500px",
+      }),
+    },
+    columnOrder: ["id", "name"],
+  };
+
+  return (
+    <div style={{ overflow: "scroll" }}>
+      <StandardTable items={mockedItems} config={config} />
+      <Spacing />
+      <Banner
+        headerText={"Two columns with minWidth=500px"}
+        text={
+          "Reduce browser width to verify that they don't get less wide than 500px."
+        }
+      />
+    </div>
+  );
+};

--- a/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
@@ -342,15 +342,13 @@ const createSalesPerformanceStandardTableConfig = (
     flags: createColumnConfig((item) => item.automation, {
       renderCell: () => (
         <Indent>
-          <Indent>
-            <Popover content={<Box indent={1} spacing={1} />}>
-              <Icon
-                icon={faCoffee}
-                color={cssColor("--lhds-color-blue-300")}
-                size={14}
-              />
-            </Popover>
-          </Indent>
+          <Popover content={<Box indent={1} spacing={1} />}>
+            <Icon
+              icon={faCoffee}
+              color={cssColor("--lhds-color-blue-300")}
+              size={14}
+            />
+          </Popover>
         </Indent>
       ),
     }),
@@ -595,6 +593,8 @@ const createSalesPerformanceStandardTableConfig = (
         columnLabel: "-45",
         width: smallTableRowWidth,
         minWidth: smallTableRowWidth,
+        justifyContentCell: "center",
+        justifyContentHeader: "center",
         backgroundResolver: (item) =>
           item.tableColors.guestsHistory.minus45?.bgColor,
         renderCell: ({ label, item }) => (


### PR DESCRIPTION
- Add `colgroup` elements to `StandardTable`. Widths of the columns are set here. We could probably move more styling here later.
- Removed width and minWidth from the `td` elements.
- Add a trailing `td` and `th` after the columns. This empty column can expand when table is wider than the sum of the columns, when all columns are fixed width.