### PR TITLE
Sticky header shadow fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+### StandardTable
+
+- Shadow under sticky header now shows under header where there are no columns.
+
 ## 13.0.6
 
 ### New component `GroupedChipMultiSelect`

--- a/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
@@ -183,7 +183,7 @@ export const StandardTableHeadRow = React.memo(function StandardTableHeadRow<
           <Row indent={rowIndent} />
         </th>
       )}
-      <th />
+      <th style={stickyHeaderStyle} />
     </TrWithHoverBackground>
   );
 });

--- a/packages/grid/src/features/standard-table/stories/FewColumns.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/FewColumns.stories.tsx
@@ -46,6 +46,43 @@ export const FixedWidthColumns = () => {
   );
 };
 
+export const FixedWidthColumnsWithStickyHeader = () => {
+  const config: StandardTableConfig<ListItem, "id" | "name"> = {
+    keyResolver: (item) => item.id,
+    showHeaderCheckbox: true,
+    showRowCheckbox: true,
+    enableGridCell: true,
+    stickyHeader: true,
+    columns: {
+      id: createColumnConfig((item) => item.id, {
+        sortOrderIconVariant: "numeric",
+        width: "100px",
+      }),
+      name: createColumnConfig((item) => item.name, {
+        justifyContentHeader: "flex-end",
+        justifyContentCell: "flex-end",
+        infoIconTooltipText: "Ohoh",
+        sortOrderIconVariant: "alpha",
+        width: "100px",
+      }),
+    },
+    columnOrder: ["id", "name"],
+  };
+
+  return (
+    <div>
+      <StandardTable items={mockedItems} config={config} />
+      <Spacing />
+      <Banner
+        headerText={"With sticky header"}
+        text={
+          "Shadow under sticky header should show under header where there are no columns."
+        }
+      />
+    </div>
+  );
+};
+
 export const MinWidthColumns = () => {
   const config: StandardTableConfig<ListItem, "id" | "name"> = {
     keyResolver: (item) => item.id,


### PR DESCRIPTION
- Shadow under sticky header now shows under header where there are no columns.

Before:
![image](https://user-images.githubusercontent.com/1266041/129340194-8e202ab1-adff-4289-bbf9-1890b0f4175d.png)

After:
![image](https://user-images.githubusercontent.com/1266041/129340240-3b227dcf-0325-44f7-b662-741865bdacac.png)
