### PR TITLE
Add ability to not open the cell editor when typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Next
 
+### useEditableCell
+
+New option `none` for option `allowedInputType`.
+This disables the ability to automatically open the editor when the user starts typing in an editable table cell.
+
+This is usable when the editor is not a text input field.
+
 ### Design changes
 
 - Updated styling for `Collapsible`.

--- a/packages/grid/src/features/grid-cell/hooks/UseEditableCell.ts
+++ b/packages/grid/src/features/grid-cell/hooks/UseEditableCell.ts
@@ -2,7 +2,12 @@ import * as React from "react";
 import { useCallback, useMemo, useState } from "react";
 import { RevertableValue, useRevertableValue } from "./UseRevertableValue";
 
-export type AllowedInputType = "all" | "numeric" | "alphanumeric" | "letters";
+export type AllowedInputType =
+  | "all"
+  | "numeric"
+  | "alphanumeric"
+  | "letters"
+  | "none";
 
 type OnStartEditingFunc = (keyEvent?: KeyDownEvent) => void;
 type TransformEnteredValueFunc<TValue> = (value?: string) => TValue;


### PR DESCRIPTION
- In editable cells, the user can just start entering numbers or characters, and the editor will show up with the press character prefilled in the field.
- Add ability to disable this.