### PR TITLE
New StandardTable feature: Summary rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Next
 
+### StandardTable
+
+- New feature, summary row.
+
+A column config can now specify a summary cell at the bottom of the table.
+
+```
+summaryText: ({ items }) =>
+  String(sumBy(items, (item) => item.numPassengers ?? 0)),
+```
+
+```
+        renderSummaryCell: () => (
+          <Indent>
+            <Tag label={"Jedi knights"} />
+          </Indent>
+        )
+```
+
+See grid package [README.md](packages/grid/README.md) for more info.
+
 ### Minor changes
 
 - Darker shade for success color

--- a/packages/grid/README.md
+++ b/packages/grid/README.md
@@ -1,9 +1,56 @@
 # @stenajs-webui/grid
 
-This package contain hooks that can help create grids that can be navigated similar to Excel.
+This package contains hooks and components that can help create grids that can be navigated similar to Excel.
 
-### Hooks only
+# StandardTable
 
-@stenajs-webui/grid does not provide any components, only hooks.
+## Summary rows
 
-This might change in the future.
+Column configs has three options for summary rows:
+
+- `renderSummaryCell`
+- `summaryText`
+- `summaryCellColSpan`
+
+### renderSummaryCell and summaryText
+
+If `renderSummaryCell` or `summaryText` is set for any column,
+the table will get a summary row at the bottom.
+
+#### `summaryText`
+
+Receives `items` in argument object, and must return a string.
+
+#### `renderSummaryCell`
+
+Receives `items` and `text` in argument object.
+If no `summaryText` was specified, then `text` will be undefined.
+
+If no `renderSummaryCell` is specified, then a default renderer for summary
+will be used.
+
+Examples:
+
+```
+summaryText: ({ items }) =>
+  String(sumBy(items, (item) => item.numPassengers ?? 0)),
+```
+
+```
+renderSummaryCell: ({ items, text }) => (
+  <Indent>
+    <Tag label={text} />
+  </Indent>
+)
+```
+
+### summaryCellColSpan
+
+`summaryCellColSpan` can be set to make the cell span multiple columns.
+
+If any columns after the spanning column has summary options, they will be ignored.
+
+If there are column groups, a column can only span over columns of that column group.
+
+If `summaryCellColSpan` is too high and won't fit into the table (or column group) then
+the col span will be limited so that it fits.

--- a/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
@@ -8,6 +8,7 @@ import {
 } from "../hooks/UseStandardTableConfig";
 import { StandardTableVariant } from "./StandardTable";
 import { StandardTableRow } from "./StandardTableRow";
+import { SummaryRowSwitcher } from "../features/summary-row/components/SummaryRowSwitcher";
 
 interface StandardTableContentProps<TItem> {
   items?: Array<TItem>;
@@ -98,6 +99,7 @@ export const StandardTableRowList = React.memo(function StandardTableRowList<
           shiftPressedRef={shiftPressedRef}
         />
       ))}
+      <SummaryRowSwitcher items={sortedItems} />
     </React.Fragment>
   );
 });

--- a/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
@@ -136,6 +136,40 @@ export interface StandardTableColumnOptions<TItem, TItemValue> {
    * The icon variant to use when displaying sort order.
    */
   sortOrderIconVariant?: SortOrderIconVariant;
+
+  /**
+   * Render summary cell at the bottom of the table.
+   * If this is not provided for any columns, the summary row will not be rendered at all.
+   */
+  renderSummaryCell?: StandardTableSummaryCellRenderer<TItem>;
+
+  /**
+   * Render summary cell at the bottom of the table.
+   * If this is not provided for any columns, the summary row will not be rendered at all.
+   */
+  summaryText?: StandardTableSummaryTextProvider<TItem>;
+
+  /**
+   * Col span for the summary cell.
+   */
+  summaryCellColSpan?: number;
+}
+
+export type StandardTableSummaryTextProvider<TItem> = (
+  arg: StandardTableSummaryTextProviderArgObject<TItem>
+) => string;
+
+export interface StandardTableSummaryTextProviderArgObject<TItem> {
+  items: Array<TItem>;
+}
+
+export type StandardTableSummaryCellRenderer<TItem> = (
+  arg: StandardTableSummaryCellRendererArgObject<TItem>
+) => ReactNode;
+
+export interface StandardTableSummaryCellRendererArgObject<TItem> {
+  items: Array<TItem>;
+  text?: string;
 }
 
 export type StandardTableCellRenderer<TItemValue, TItem> = (

--- a/packages/grid/src/features/standard-table/features/summary-row/SummaryCellColSpanCalculator.ts
+++ b/packages/grid/src/features/standard-table/features/summary-row/SummaryCellColSpanCalculator.ts
@@ -1,0 +1,24 @@
+export interface ColumnIdAndColSpan<TColumnKey extends string> {
+  columnId: TColumnKey;
+  colSpan: number;
+}
+
+export const getColumnsLimitedWithColSpan = <TColumnKey extends string>(
+  columnOrder: Array<TColumnKey>,
+  columns: Record<TColumnKey, { summaryCellColSpan?: number }>
+): Array<ColumnIdAndColSpan<TColumnKey>> => {
+  const list: Array<ColumnIdAndColSpan<TColumnKey>> = [];
+  for (let i = 0; i < columnOrder.length; i++) {
+    const { summaryCellColSpan } = columns[columnOrder[i]];
+    const realColSpan = Math.min(
+      summaryCellColSpan ?? 1,
+      columnOrder.length - i
+    );
+    list.push({ columnId: columnOrder[i], colSpan: realColSpan });
+    const colSpan = summaryCellColSpan ?? 1;
+    if (colSpan > 1) {
+      i += colSpan - 1;
+    }
+  }
+  return list;
+};

--- a/packages/grid/src/features/standard-table/features/summary-row/SummaryRowVisibilityCalculator.ts
+++ b/packages/grid/src/features/standard-table/features/summary-row/SummaryRowVisibilityCalculator.ts
@@ -1,0 +1,14 @@
+import { StandardTableConfig } from "../../config/StandardTableConfig";
+import { StandardTableColumnOptions } from "../../config/StandardTableColumnConfig";
+
+export const isSummaryRowVisible = <TColumnKey extends string>(
+  columns: StandardTableConfig<unknown, TColumnKey>["columns"]
+): boolean =>
+  Object.keys(columns).some((columnId) =>
+    columnHasSummaryCell(columns[columnId])
+  );
+
+export const columnHasSummaryCell = (
+  columnConfig: StandardTableColumnOptions<unknown, unknown>
+): boolean =>
+  Boolean(columnConfig.renderSummaryCell || columnConfig.summaryText);

--- a/packages/grid/src/features/standard-table/features/summary-row/__tests__/SummaryCellColSpanCalculator.test.ts
+++ b/packages/grid/src/features/standard-table/features/summary-row/__tests__/SummaryCellColSpanCalculator.test.ts
@@ -1,0 +1,66 @@
+import { getColumnsLimitedWithColSpan } from "../SummaryCellColSpanCalculator";
+
+describe("SummaryCellColSpanCalculator", () => {
+  describe("getColumnsLimitedWithColSpan", () => {
+    describe("when column has colSpan=2", () => {
+      it("skips one column after", () => {
+        expect(
+          getColumnsLimitedWithColSpan(["a", "b", "c", "d"], {
+            a: {},
+            b: { summaryCellColSpan: 2 },
+            c: {},
+            d: {},
+          })
+        ).toEqual([
+          { columnId: "a", colSpan: 1 },
+          { columnId: "b", colSpan: 2 },
+          { columnId: "d", colSpan: 1 },
+        ]);
+      });
+    });
+    describe("when column has colSpan=3", () => {
+      it("skips two column after", () => {
+        expect(
+          getColumnsLimitedWithColSpan(["a", "b", "c", "d"], {
+            a: { summaryCellColSpan: 3 },
+            b: {},
+            c: {},
+            d: {},
+          })
+        ).toEqual([
+          { columnId: "a", colSpan: 3 },
+          { columnId: "d", colSpan: 1 },
+        ]);
+      });
+    });
+    describe("when colSpan goes out of bounds", () => {
+      it("it limits the colSpan", () => {
+        expect(
+          getColumnsLimitedWithColSpan(["a", "b", "c", "d"], {
+            a: {},
+            b: {},
+            c: { summaryCellColSpan: 3 },
+            d: {},
+          })
+        ).toEqual([
+          { columnId: "a", colSpan: 1 },
+          { columnId: "b", colSpan: 1 },
+          { columnId: "c", colSpan: 2 },
+        ]);
+        expect(
+          getColumnsLimitedWithColSpan(["a", "b", "c", "d", "e"], {
+            a: {},
+            b: {},
+            c: { summaryCellColSpan: 8 },
+            d: {},
+            e: {},
+          })
+        ).toEqual([
+          { columnId: "a", colSpan: 1 },
+          { columnId: "b", colSpan: 1 },
+          { columnId: "c", colSpan: 3 },
+        ]);
+      });
+    });
+  });
+});

--- a/packages/grid/src/features/standard-table/features/summary-row/components/StandardTableSummaryRow.module.css
+++ b/packages/grid/src/features/standard-table/features/summary-row/components/StandardTableSummaryRow.module.css
@@ -1,0 +1,6 @@
+.summaryRow {
+  td {
+    border-top: 1px solid var(--lhds-color-ui-500);
+    border-bottom: 1px solid var(--lhds-color-ui-500);
+  }
+}

--- a/packages/grid/src/features/standard-table/features/summary-row/components/StandardTableSummaryRow.tsx
+++ b/packages/grid/src/features/standard-table/features/summary-row/components/StandardTableSummaryRow.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { useGroupConfigsAndIdsForRows } from "../../../context/GroupConfigsAndIdsForRowsContext";
+import { useStandardTableConfig } from "../../../hooks/UseStandardTableConfig";
+import styles from "./StandardTableSummaryRow.module.css";
+import { getCellBorderFromGroup } from "../../../util/CellBorderCalculator";
+import { SummaryCell } from "./SummaryCell";
+import { getColumnsLimitedWithColSpan } from "../SummaryCellColSpanCalculator";
+
+interface StandardTableSummaryRowProps<TItem> {
+  items: Array<TItem>;
+}
+
+export const StandardTableSummaryRow = React.memo(
+  function StandardTableSummaryRow<TItem>({
+    items,
+  }: StandardTableSummaryRowProps<TItem>) {
+    const groupConfigsAndIds = useGroupConfigsAndIdsForRows();
+    const {
+      showRowCheckbox,
+      enableExpandCollapse,
+      columns,
+    } = useStandardTableConfig();
+
+    return (
+      <tr className={styles.summaryRow}>
+        {enableExpandCollapse && <td />}
+        {showRowCheckbox && <td />}
+        {groupConfigsAndIds.map(({ groupConfig, groupId }, groupIndex) => (
+          <React.Fragment key={groupId}>
+            {getColumnsLimitedWithColSpan(groupConfig.columnOrder, columns).map(
+              ({ columnId, colSpan }, index) => {
+                return (
+                  <SummaryCell
+                    key={columnId}
+                    colSpan={colSpan}
+                    columnId={columnId}
+                    items={items}
+                    borderFromGroup={getCellBorderFromGroup(
+                      groupIndex,
+                      index,
+                      groupConfig.borderLeft
+                    )}
+                    disableBorderLeft={groupIndex === 0 && index === 0}
+                  />
+                );
+              }
+            )}
+          </React.Fragment>
+        ))}
+      </tr>
+    );
+  }
+);

--- a/packages/grid/src/features/standard-table/features/summary-row/components/SummaryCell.tsx
+++ b/packages/grid/src/features/standard-table/features/summary-row/components/SummaryCell.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { CSSProperties, useMemo } from "react";
+import { Indent, Row, Text } from "@stenajs-webui/core";
+import { getCellBorder } from "../../../util/CellBorderCalculator";
+import { useColumnConfigById } from "../../../hooks/UseColumnConfigById";
+import { useStickyPropsPerColumnContext } from "../../../context/StickyPropsPerColumnContext";
+
+interface SummaryCellProps<TItem> {
+  items: Array<TItem>;
+  columnId: string;
+  borderFromGroup?: boolean | string;
+  disableBorderLeft: boolean;
+  colSpan: number;
+}
+
+export const SummaryCell = React.memo(function SummaryCell<TItem>({
+  columnId,
+  items,
+  disableBorderLeft,
+  borderFromGroup,
+  colSpan,
+}: SummaryCellProps<TItem>) {
+  const stickyPropsPerColumnContext = useStickyPropsPerColumnContext();
+  const {
+    renderSummaryCell,
+    summaryText,
+    borderLeft,
+    zIndex,
+    width,
+    minWidth,
+    justifyContentCell,
+  } = useColumnConfigById(columnId);
+
+  const activeBorderLeft = getCellBorder(
+    borderFromGroup,
+    disableBorderLeft,
+    borderLeft
+  );
+
+  const stickyProps = stickyPropsPerColumnContext[columnId];
+
+  const currentZIndex = stickyProps.sticky
+    ? zIndex ?? "var(--swui-sticky-column-z-index)"
+    : zIndex ?? 1;
+
+  const shadow =
+    stickyProps.sticky &&
+    stickyProps.type === "last-group" &&
+    stickyProps.isFirstColumnInLastGroup
+      ? "var(--swui-sticky-column-shadow-left)"
+      : stickyProps.sticky && stickyProps.type === "column" && stickyProps.right
+      ? "var(--swui-sticky-column-shadow-left)"
+      : stickyProps.sticky
+      ? "var(--swui-sticky-column-shadow-right)"
+      : undefined;
+
+  const text = useMemo(() => summaryText?.({ items }), [items, summaryText]);
+  const renderResult = useMemo(() => renderSummaryCell?.({ items, text }), [
+    items,
+    renderSummaryCell,
+    text,
+  ]);
+
+  return (
+    <td
+      colSpan={colSpan}
+      style={{
+        borderLeft: activeBorderLeft,
+        position: stickyProps.sticky ? "sticky" : undefined,
+        left: stickyProps.sticky ? stickyProps.left : undefined,
+        right: stickyProps.sticky ? stickyProps.right : undefined,
+        boxShadow: shadow,
+        zIndex: currentZIndex as CSSProperties["zIndex"],
+        height: "var(--current-row-height)",
+      }}
+    >
+      <Row
+        width={width}
+        minWidth={minWidth}
+        height={"inherit"}
+        overflow={"hidden"}
+        justifyContent={justifyContentCell}
+        alignItems={"center"}
+      >
+        {renderSummaryCell ? (
+          renderResult
+        ) : (
+          <Indent>
+            <Text variant={"bold"}>{text}</Text>
+          </Indent>
+        )}
+      </Row>
+    </td>
+  );
+});

--- a/packages/grid/src/features/standard-table/features/summary-row/components/SummaryRowSwitcher.tsx
+++ b/packages/grid/src/features/standard-table/features/summary-row/components/SummaryRowSwitcher.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+import { useMemo } from "react";
+import { isSummaryRowVisible } from "../SummaryRowVisibilityCalculator";
+import { useStandardTableConfig } from "../../../hooks/UseStandardTableConfig";
+import { StandardTableSummaryRow } from "./StandardTableSummaryRow";
+
+interface SummaryRowSwitcherProps<TItem> {
+  items: Array<TItem>;
+}
+
+export const SummaryRowSwitcher = function SummaryRowSwitcher<TItem>({
+  items,
+}: SummaryRowSwitcherProps<TItem>) {
+  const { columns } = useStandardTableConfig();
+  const visible = useMemo(() => isSummaryRowVisible(columns), [columns]);
+
+  if (!visible) {
+    return null;
+  }
+
+  return <StandardTableSummaryRow items={items} />;
+};

--- a/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
@@ -1,4 +1,11 @@
-import { Box, Column, Heading, Spacing, Text } from "@stenajs-webui/core";
+import {
+  Box,
+  Column,
+  Heading,
+  Indent,
+  Spacing,
+  Text,
+} from "@stenajs-webui/core";
 import { TextInput } from "@stenajs-webui/forms";
 import { cssColor } from "@stenajs-webui/theme";
 import * as React from "react";
@@ -14,6 +21,8 @@ import {
   standardTableConfigForStories,
   useListState,
 } from "./StandardTableStoryHelper";
+import { sumBy } from "lodash";
+import { Tag } from "@stenajs-webui/elements";
 
 export default {
   title: "grid/StandardTable",
@@ -164,4 +173,45 @@ export const OnKeyDown = () => {
       </Box>
     </Column>
   );
+};
+
+export const SummaryRow = () => {
+  const { items, onChangeNumPassengers } = useListState(mockedItems);
+
+  const config: StandardTableConfig<ListItem, keyof ListItem> = {
+    ...standardTableConfigForStories,
+    columns: {
+      ...standardTableConfigForStories.columns,
+      id: {
+        ...standardTableConfigForStories.columns.id,
+        summaryText: () => "Total",
+      },
+      name: {
+        ...standardTableConfigForStories.columns.name,
+        summaryText: () => "This is a very long text.",
+        summaryCellColSpan: 2,
+      },
+      active: {
+        ...standardTableConfigForStories.columns.active,
+        summaryText: ({ items }) =>
+          `${sumBy(items, (item) => (item.active ? 1 : 0))} active`,
+      },
+      numPassengers: {
+        ...standardTableConfigForStories.columns.numPassengers,
+        onChange: onChangeNumPassengers,
+        summaryText: ({ items }) =>
+          String(sumBy(items, (item) => item.numPassengers ?? 0)),
+      },
+      departure: {
+        ...standardTableConfigForStories.columns.departure,
+        renderSummaryCell: () => (
+          <Indent>
+            <Tag label={"Jedi knights"} />
+          </Indent>
+        ),
+      },
+    },
+  };
+
+  return <StandardTable items={items} config={config} />;
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1266041/135094554-4e25f9b7-a9a9-451e-a634-e9343fefbf37.png)

```
    columns: {
      ...standardTableConfigForStories.columns,
      id: {
        ...standardTableConfigForStories.columns.id,
        summaryText: () => "Total",
      },
      name: {
        ...standardTableConfigForStories.columns.name,
        summaryText: () => "This is a very long text.",
        summaryCellColSpan: 2,
      },
      active: {
        ...standardTableConfigForStories.columns.active,
        summaryText: ({ items }) =>
          `${sumBy(items, (item) => (item.active ? 1 : 0))} active`,
      },
      numPassengers: {
        ...standardTableConfigForStories.columns.numPassengers,
        onChange: onChangeNumPassengers,
        summaryText: ({ items }) =>
          String(sumBy(items, (item) => item.numPassengers ?? 0)),
      },
      departure: {
        ...standardTableConfigForStories.columns.departure,
        renderSummaryCell: () => (
          <Indent>
            <Tag label={"Jedi knights"} />
          </Indent>
        ),
      },
    }
```