### PR TITLE
Checkbox fixes in StandardTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 ### StandardTable
 
-- New feature, summary row.
+#### Checkbox fixes
+
+Disabled checkboxes are not checked when
+
+1) Clicking checkbox in table header
+2) Shift-clicking row checkboxes
+
+#### New feature, summary row.
 
 A column config can now specify a summary cell at the bottom of the table.
 

--- a/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
@@ -29,7 +29,7 @@ import { TrWithHoverBackground } from "./TrWithHoverBackground";
 
 export interface StandardTableRowProps<TItem> {
   item: TItem;
-  itemIdList: Array<string>;
+  enabledItemsIdList: Array<string>;
   rowIndex: number;
   numRows: number;
   colIndexOffset: number;
@@ -39,7 +39,7 @@ export interface StandardTableRowProps<TItem> {
 
 export const StandardTableRow = React.memo(function StandardTableRow<TItem>({
   item,
-  itemIdList,
+  enabledItemsIdList,
   rowIndex,
   numRows,
   colIndexOffset,
@@ -63,7 +63,7 @@ export const StandardTableRow = React.memo(function StandardTableRow<TItem>({
   const { isExpanded } = useExpandCollapseActions(item);
   const { isSelected, toggleSelected, shiftAndToggleSelected } = useRowCheckbox(
     item,
-    itemIdList
+    enabledItemsIdList
   );
 
   const visible = useOnScreen(trRef, {

--- a/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
@@ -29,7 +29,7 @@ import { TrWithHoverBackground } from "./TrWithHoverBackground";
 
 export interface StandardTableRowProps<TItem> {
   item: TItem;
-  enabledItemsIdList: Array<string>;
+  idListForEnabledItems: Array<string>;
   rowIndex: number;
   numRows: number;
   colIndexOffset: number;
@@ -39,7 +39,7 @@ export interface StandardTableRowProps<TItem> {
 
 export const StandardTableRow = React.memo(function StandardTableRow<TItem>({
   item,
-  enabledItemsIdList,
+  idListForEnabledItems,
   rowIndex,
   numRows,
   colIndexOffset,
@@ -63,7 +63,7 @@ export const StandardTableRow = React.memo(function StandardTableRow<TItem>({
   const { isExpanded } = useExpandCollapseActions(item);
   const { isSelected, toggleSelected, shiftAndToggleSelected } = useRowCheckbox(
     item,
-    enabledItemsIdList
+    idListForEnabledItems
   );
 
   const visible = useOnScreen(trRef, {

--- a/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
@@ -9,6 +9,7 @@ import {
 import { StandardTableVariant } from "./StandardTable";
 import { StandardTableRow } from "./StandardTableRow";
 import { SummaryRowSwitcher } from "../features/summary-row/components/SummaryRowSwitcher";
+import { filterItemsOnEnabledCheckboxes } from "../util/FilterItemsOnEnabledCheckboxes";
 
 interface StandardTableContentProps<TItem> {
   items?: Array<TItem>;
@@ -66,7 +67,7 @@ export const StandardTableRowList = React.memo(function StandardTableRowList<
   const idListForEnabledItems = useMemo(
     () =>
       sortedItems
-        .filter((l) => (checkboxDisabledResolver?.(l) ? false : true ?? true))
+        .filter(filterItemsOnEnabledCheckboxes(checkboxDisabledResolver))
         .map((l) => keyResolver(l)),
     [sortedItems, checkboxDisabledResolver, keyResolver]
   );
@@ -99,7 +100,7 @@ export const StandardTableRowList = React.memo(function StandardTableRowList<
           alwaysVisible={disableInfiniteList || sortedItems.length < 30}
           item={item}
           idListForEnabledItems={idListForEnabledItems}
-          key={idListForEnabledItems[index]}
+          key={keyResolver(item)}
           colIndexOffset={colIndexOffset}
           rowIndex={index + rowIndexOffset}
           numRows={sortedItems.length}

--- a/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
@@ -63,7 +63,7 @@ export const StandardTableRowList = React.memo(function StandardTableRowList<
     return sortedList;
   }, [items, valueResolver, desc]);
 
-  const enabledItemsIdList = useMemo(
+  const idListForEnabledItems = useMemo(
     () =>
       sortedItems
         .filter((l) => (checkboxDisabledResolver?.(l) ? false : true ?? true))
@@ -98,8 +98,8 @@ export const StandardTableRowList = React.memo(function StandardTableRowList<
         <StandardTableRow
           alwaysVisible={disableInfiniteList || sortedItems.length < 30}
           item={item}
-          enabledItemsIdList={enabledItemsIdList}
-          key={enabledItemsIdList[index]}
+          idListForEnabledItems={idListForEnabledItems}
+          key={idListForEnabledItems[index]}
           colIndexOffset={colIndexOffset}
           rowIndex={index + rowIndexOffset}
           numRows={sortedItems.length}

--- a/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
@@ -33,7 +33,11 @@ export const StandardTableRowList = React.memo(function StandardTableRowList<
 
   const shiftPressedRef = useRef(false);
 
-  const { keyResolver, disableInfiniteList } = useStandardTableConfig();
+  const {
+    keyResolver,
+    disableInfiniteList,
+    checkboxDisabledResolver,
+  } = useStandardTableConfig();
   const {
     sortOrder: { sortBy, desc },
   } = useStandardTableState();
@@ -59,10 +63,13 @@ export const StandardTableRowList = React.memo(function StandardTableRowList<
     return sortedList;
   }, [items, valueResolver, desc]);
 
-  const itemIdList = useMemo(() => sortedItems.map((l) => keyResolver(l)), [
-    sortedItems,
-    keyResolver,
-  ]);
+  const enabledItemsIdList = useMemo(
+    () =>
+      sortedItems
+        .filter((l) => (checkboxDisabledResolver?.(l) ? false : true ?? true))
+        .map((l) => keyResolver(l)),
+    [sortedItems, checkboxDisabledResolver, keyResolver]
+  );
 
   useEffect(() => {
     const keyUp = (ev: KeyboardEvent) => {
@@ -91,8 +98,8 @@ export const StandardTableRowList = React.memo(function StandardTableRowList<
         <StandardTableRow
           alwaysVisible={disableInfiniteList || sortedItems.length < 30}
           item={item}
-          itemIdList={itemIdList}
-          key={itemIdList[index]}
+          enabledItemsIdList={enabledItemsIdList}
+          key={enabledItemsIdList[index]}
           colIndexOffset={colIndexOffset}
           rowIndex={index + rowIndexOffset}
           numRows={sortedItems.length}

--- a/packages/grid/src/features/standard-table/features/checkboxes/UseRowCheckbox.ts
+++ b/packages/grid/src/features/standard-table/features/checkboxes/UseRowCheckbox.ts
@@ -9,7 +9,7 @@ import { getIdsBetweenSelected } from "../../util/IdListPartial";
 
 export const useRowCheckbox = <TItem>(
   item: TItem,
-  enabledItemsIdList: Array<string>
+  idListForEnabledItems: Array<string>
 ) => {
   const { keyResolver } = useStandardTableConfig();
 
@@ -35,9 +35,9 @@ export const useRowCheckbox = <TItem>(
   );
 
   const shiftAndToggleSelected = useCallback(() => {
-    if (enabledItemsIdList && lastSelectedId) {
+    if (idListForEnabledItems && lastSelectedId) {
       const idList = getIdsBetweenSelected(
-        enabledItemsIdList,
+        idListForEnabledItems,
         lastSelectedId,
         itemKey
       );
@@ -55,7 +55,7 @@ export const useRowCheckbox = <TItem>(
     }
     dispatch(setLastSelectedId(itemKey));
   }, [
-    enabledItemsIdList,
+    idListForEnabledItems,
     lastSelectedId,
     dispatch,
     setLastSelectedId,

--- a/packages/grid/src/features/standard-table/features/checkboxes/UseRowCheckbox.ts
+++ b/packages/grid/src/features/standard-table/features/checkboxes/UseRowCheckbox.ts
@@ -9,7 +9,7 @@ import { getIdsBetweenSelected } from "../../util/IdListPartial";
 
 export const useRowCheckbox = <TItem>(
   item: TItem,
-  itemIdList: Array<string>
+  enabledItemsIdList: Array<string>
 ) => {
   const { keyResolver } = useStandardTableConfig();
 
@@ -35,8 +35,12 @@ export const useRowCheckbox = <TItem>(
   );
 
   const shiftAndToggleSelected = useCallback(() => {
-    if (itemIdList && lastSelectedId) {
-      const idList = getIdsBetweenSelected(itemIdList, lastSelectedId, itemKey);
+    if (enabledItemsIdList && lastSelectedId) {
+      const idList = getIdsBetweenSelected(
+        enabledItemsIdList,
+        lastSelectedId,
+        itemKey
+      );
       if (idList?.length) {
         if (isSelected) {
           removeMultiple(idList);
@@ -51,7 +55,7 @@ export const useRowCheckbox = <TItem>(
     }
     dispatch(setLastSelectedId(itemKey));
   }, [
-    itemIdList,
+    enabledItemsIdList,
     lastSelectedId,
     dispatch,
     setLastSelectedId,

--- a/packages/grid/src/features/standard-table/features/checkboxes/UseTableHeadCheckbox.ts
+++ b/packages/grid/src/features/standard-table/features/checkboxes/UseTableHeadCheckbox.ts
@@ -4,6 +4,7 @@ import {
   useStandardTableConfig,
   useStandardTableState,
 } from "../../hooks/UseStandardTableConfig";
+import { filterItemsOnEnabledCheckboxes } from "../../util/FilterItemsOnEnabledCheckboxes";
 
 export const useTableHeadCheckbox = <TItem>(
   items: Array<TItem> | undefined
@@ -29,9 +30,7 @@ export const useTableHeadCheckbox = <TItem>(
         dispatch(
           setSelectedIds(
             items
-              .filter((item) =>
-                checkboxDisabledResolver?.(item) ? false : true ?? true
-              )
+              .filter(filterItemsOnEnabledCheckboxes(checkboxDisabledResolver))
               .map((item) => keyResolver(item))
           )
         );

--- a/packages/grid/src/features/standard-table/features/checkboxes/UseTableHeadCheckbox.ts
+++ b/packages/grid/src/features/standard-table/features/checkboxes/UseTableHeadCheckbox.ts
@@ -8,7 +8,7 @@ import {
 export const useTableHeadCheckbox = <TItem>(
   items: Array<TItem> | undefined
 ) => {
-  const { keyResolver } = useStandardTableConfig();
+  const { keyResolver, checkboxDisabledResolver } = useStandardTableConfig();
   const {
     selectedIds: { selectedIds },
   } = useStandardTableState();
@@ -26,18 +26,27 @@ export const useTableHeadCheckbox = <TItem>(
   const onClickCheckbox = useCallback(() => {
     if (items) {
       if (selectionIsEmpty) {
-        dispatch(setSelectedIds(items.map((item) => keyResolver(item))));
+        dispatch(
+          setSelectedIds(
+            items
+              .filter((item) =>
+                checkboxDisabledResolver?.(item) ? false : true ?? true
+              )
+              .map((item) => keyResolver(item))
+          )
+        );
       } else {
         dispatch(clearSelection());
       }
     }
   }, [
-    selectionIsEmpty,
-    clearSelection,
-    dispatch,
     items,
-    keyResolver,
+    selectionIsEmpty,
+    dispatch,
     setSelectedIds,
+    checkboxDisabledResolver,
+    keyResolver,
+    clearSelection,
   ]);
 
   return {

--- a/packages/grid/src/features/standard-table/features/summary-row/SummaryRowVisibilityCalculator.ts
+++ b/packages/grid/src/features/standard-table/features/summary-row/SummaryRowVisibilityCalculator.ts
@@ -1,12 +1,11 @@
-import { StandardTableConfig } from "../../config/StandardTableConfig";
 import { StandardTableColumnOptions } from "../../config/StandardTableColumnConfig";
 
 export const isSummaryRowVisible = <TColumnKey extends string>(
-  columns: StandardTableConfig<unknown, TColumnKey>["columns"]
+  columns: Record<TColumnKey, StandardTableColumnOptions<unknown, unknown>>
 ): boolean =>
-  Object.keys(columns).some((columnId) =>
-    columnHasSummaryCell(columns[columnId])
-  );
+  (Object.values(columns) as Array<
+    StandardTableColumnOptions<unknown, unknown>
+  >).some((columnConfig) => columnHasSummaryCell(columnConfig));
 
 export const columnHasSummaryCell = (
   columnConfig: StandardTableColumnOptions<unknown, unknown>

--- a/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
@@ -33,6 +33,7 @@ export const Overview = () => {
 
   const config: StandardTableConfig<ListItem, keyof ListItem> = {
     ...standardTableConfigForStories,
+    checkboxDisabledResolver: (item) => item.id === "125",
     columns: {
       ...standardTableConfigForStories.columns,
       numPassengers: {

--- a/packages/grid/src/features/standard-table/util/FilterItemsOnEnabledCheckboxes.ts
+++ b/packages/grid/src/features/standard-table/util/FilterItemsOnEnabledCheckboxes.ts
@@ -1,0 +1,6 @@
+export type ItemFilterFunc<TItem> = (item: TItem) => boolean;
+
+export const filterItemsOnEnabledCheckboxes = <TItem>(
+  checkboxDisabledResolver?: (item: TItem) => boolean
+): ItemFilterFunc<TItem> => (item: TItem) =>
+  checkboxDisabledResolver?.(item) ? false : true ?? true;


### PR DESCRIPTION
Disabled checkboxes are not checked when
1) Clicking checkbox in table header
2) Shift-clicking row checkboxes