### PR TITLE
Calendar popovers update position when changing size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,10 @@
 
 ### Calendar inputs
 
-All calendar inputs are now using Tippyjs internal implementation for
-listening for clicks outside.
+- All calendar inputs are now using Tippyjs internal implementation for
+  listening for clicks outside.
+- Fix problem with calendar input popovers. They did not update position
+  when calendar changed size.
 
 ### Drawer
 

--- a/examples/stories/calendar/DrawerWithCalendar.stories.tsx
+++ b/examples/stories/calendar/DrawerWithCalendar.stories.tsx
@@ -1,0 +1,18 @@
+import { Column } from "@stenajs-webui/core";
+import { DateTextInput } from "../../../packages/calendar/src";
+import * as React from "react";
+import { useState } from "react";
+
+export default {
+  title: "examples/Calendar",
+};
+
+export const Centered = () => {
+  const [value, setValue] = useState("");
+
+  return (
+    <Column alignItems={"center"} justifyContent={"center"} height={"800px"}>
+      <DateTextInput value={value} onValueChange={setValue} />
+    </Column>
+  );
+};

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { useDateRangeSelection } from "./hooks/UseDateRangeSelection";
-import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
+import { InternalPanelAndFocusStateProps } from "../../../types/InternalPanelAndFocusStateProps";
 
 export type DateRangeFocusedInput = "startDate" | "endDate" | undefined;
 
@@ -11,7 +11,7 @@ export interface DateRangeCalendarOnChangeValue {
 }
 
 export interface DateRangeCalendarProps<T>
-  extends CalendarWithInternalPanelAndFocusStateProps<T> {
+  extends InternalPanelAndFocusStateProps<T> {
   startDate: Date | undefined;
   endDate: Date | undefined;
   focusedInput?: DateRangeFocusedInput;

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.tsx
@@ -1,10 +1,7 @@
 import * as React from "react";
-import {
-  CalendarWithMonthSwitcher,
-  CalendarWithMonthSwitcherProps,
-} from "../../../features/month-switcher/CalendarWithMonthSwitcher";
-
+import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { useDateRangeSelection } from "./hooks/UseDateRangeSelection";
+import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
 
 export type DateRangeFocusedInput = "startDate" | "endDate" | undefined;
 
@@ -14,10 +11,7 @@ export interface DateRangeCalendarOnChangeValue {
 }
 
 export interface DateRangeCalendarProps<T>
-  extends Omit<
-    CalendarWithMonthSwitcherProps<T>,
-    "currentPanel" | "setCurrentPanel" | "dateInFocus" | "setDateInFocus"
-  > {
+  extends CalendarWithInternalPanelAndFocusStateProps<T> {
   startDate: Date | undefined;
   endDate: Date | undefined;
   focusedInput?: DateRangeFocusedInput;
@@ -30,7 +24,7 @@ export interface DateRangeCalendarProps<T>
 
 export function DateRangeCalendar<T extends {}>(
   props: DateRangeCalendarProps<T>
-): React.ReactElement<T> {
+) {
   const dateRangeSelectionProps = useDateRangeSelection(props);
   return (
     <CalendarWithMonthSwitcher<T> {...props} {...dateRangeSelectionProps} />

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/hooks/UseDateRangeSelection.ts
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/hooks/UseDateRangeSelection.ts
@@ -3,8 +3,8 @@ import { useDateRangeOnClickDayHandler } from "../../../../features/date-range/h
 import { DateRangeCalendarProps } from "../DateRangeCalendar";
 import { toggleDatesIfEndIsEarlierThanStart } from "../util/IntervalSwitcher";
 import { CalendarWithMonthSwitcherProps } from "../../../../features/month-switcher/CalendarWithMonthSwitcher";
-import { CalendarPanelType } from "../../../../features/calendar-with-month-year-pickers/CalendarPanelType";
 import { buildDayStateForDateRange } from "../../../../util/calendar/StateModifier";
+import { useInternalPanelState } from "../../../../features/internal-panel-state/UseInternalPanelState";
 
 export const useDateRangeSelection = <T>({
   focusedInput,
@@ -15,9 +15,10 @@ export const useDateRangeSelection = <T>({
   onChange,
   setFocusedInput,
   statePerMonth,
+  onChangePanel,
 }: DateRangeCalendarProps<T>): CalendarWithMonthSwitcherProps<T> => {
-  const [currentPanel, setCurrentPanel] = useState<CalendarPanelType>(
-    "calendar"
+  const { currentPanel, setCurrentPanel } = useInternalPanelState(
+    onChangePanel
   );
   const [dateInFocus, setDateInFocus] = useState(() => new Date());
 

--- a/packages/calendar/src/components/calendar-types/date-range-exclusion-calendar/DateRangeExclusionCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/date-range-exclusion-calendar/DateRangeExclusionCalendar.tsx
@@ -1,16 +1,12 @@
 import * as React from "react";
-import {
-  CalendarWithMonthSwitcher,
-  CalendarWithMonthSwitcherProps,
-} from "../../../features/month-switcher/CalendarWithMonthSwitcher";
-
+import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { useDateRangeExclusionSelection } from "./UseDateRangeExclusionSelection";
+import { UseInternalPanelStateArgs } from "../../../features/internal-panel-state/UseInternalPanelState";
+import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
 
 export interface DateRangeExclusionCalendarProps<T>
-  extends Omit<
-    CalendarWithMonthSwitcherProps<T>,
-    "currentPanel" | "setCurrentPanel" | "dateInFocus" | "setDateInFocus"
-  > {
+  extends CalendarWithInternalPanelAndFocusStateProps<T>,
+    UseInternalPanelStateArgs {
   value?: Array<Date>;
   onChange?: (value: Array<Date>) => void;
 }

--- a/packages/calendar/src/components/calendar-types/date-range-exclusion-calendar/DateRangeExclusionCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/date-range-exclusion-calendar/DateRangeExclusionCalendar.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { useDateRangeExclusionSelection } from "./UseDateRangeExclusionSelection";
-import { UseInternalPanelStateArgs } from "../../../features/internal-panel-state/UseInternalPanelState";
-import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
+import { UseInternalPanelStateProps } from "../../../features/internal-panel-state/UseInternalPanelState";
+import { InternalPanelAndFocusStateProps } from "../../../types/InternalPanelAndFocusStateProps";
 
 export interface DateRangeExclusionCalendarProps<T>
-  extends CalendarWithInternalPanelAndFocusStateProps<T>,
-    UseInternalPanelStateArgs {
+  extends InternalPanelAndFocusStateProps<T>,
+    UseInternalPanelStateProps {
   value?: Array<Date>;
   onChange?: (value: Array<Date>) => void;
 }

--- a/packages/calendar/src/components/calendar-types/date-range-exclusion-calendar/UseDateRangeExclusionSelection.ts
+++ b/packages/calendar/src/components/calendar-types/date-range-exclusion-calendar/UseDateRangeExclusionSelection.ts
@@ -13,20 +13,21 @@ import {
 } from "../date-range-calendar/DateRangeCalendar";
 import { DateRangeExclusionCalendarProps } from "./DateRangeExclusionCalendar";
 import { CalendarWithMonthSwitcherProps } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
-import { CalendarPanelType } from "../../../features/calendar-with-month-year-pickers/CalendarPanelType";
+import { useInternalPanelState } from "../../../features/internal-panel-state/UseInternalPanelState";
 
 export const useDateRangeExclusionSelection = <T>({
   onChange,
   value,
   statePerMonth,
+  onChangePanel,
 }: DateRangeExclusionCalendarProps<T>): CalendarWithMonthSwitcherProps<T> => {
   const [startDate, setStartDate] = useState<Date | undefined>();
   const [endDate, setEndDate] = useState<Date | undefined>();
   const [focusedInput, setFocusedInput] = useState<DateRangeFocusedInput>(
     "startDate"
   );
-  const [currentPanel, setCurrentPanel] = useState<CalendarPanelType>(
-    "calendar"
+  const { currentPanel, setCurrentPanel } = useInternalPanelState(
+    onChangePanel
   );
 
   const [dateInFocus, setDateInFocus] = useState(

--- a/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { useMultiDateSelection } from "./UseMultiDateSelection";
-import { UseInternalPanelStateArgs } from "../../../features/internal-panel-state/UseInternalPanelState";
-import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
+import { UseInternalPanelStateProps } from "../../../features/internal-panel-state/UseInternalPanelState";
+import { InternalPanelAndFocusStateProps } from "../../../types/InternalPanelAndFocusStateProps";
 
 export interface MultiDateCalendarProps<T>
-  extends CalendarWithInternalPanelAndFocusStateProps<T>,
-    UseInternalPanelStateArgs {
+  extends InternalPanelAndFocusStateProps<T>,
+    UseInternalPanelStateProps {
   value?: Array<Date>;
   onChange?: (value: Array<Date>) => void;
 }

--- a/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/multi-date-calendar/MultiDateCalendar.tsx
@@ -1,16 +1,12 @@
 import * as React from "react";
-import {
-  CalendarWithMonthSwitcher,
-  CalendarWithMonthSwitcherProps,
-} from "../../../features/month-switcher/CalendarWithMonthSwitcher";
-
+import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { useMultiDateSelection } from "./UseMultiDateSelection";
+import { UseInternalPanelStateArgs } from "../../../features/internal-panel-state/UseInternalPanelState";
+import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
 
 export interface MultiDateCalendarProps<T>
-  extends Omit<
-    CalendarWithMonthSwitcherProps<T>,
-    "currentPanel" | "setCurrentPanel" | "dateInFocus" | "setDateInFocus"
-  > {
+  extends CalendarWithInternalPanelAndFocusStateProps<T>,
+    UseInternalPanelStateArgs {
   value?: Array<Date>;
   onChange?: (value: Array<Date>) => void;
 }

--- a/packages/calendar/src/components/calendar-types/multi-date-calendar/UseMultiDateSelection.ts
+++ b/packages/calendar/src/components/calendar-types/multi-date-calendar/UseMultiDateSelection.ts
@@ -4,15 +4,16 @@ import { OnClickDay } from "../../../types/CalendarTypes";
 import { addDayStateHighlights } from "../../../util/calendar/StateModifier";
 import { MultiDateCalendarProps } from "./MultiDateCalendar";
 import { CalendarWithMonthSwitcherProps } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
-import { CalendarPanelType } from "../../../features/calendar-with-month-year-pickers/CalendarPanelType";
+import { useInternalPanelState } from "../../../features/internal-panel-state/UseInternalPanelState";
 
 export const useMultiDateSelection = <T>({
   onChange,
   value,
   statePerMonth,
+  onChangePanel,
 }: MultiDateCalendarProps<T>): CalendarWithMonthSwitcherProps<T> => {
-  const [currentPanel, setCurrentPanel] = useState<CalendarPanelType>(
-    "calendar"
+  const { currentPanel, setCurrentPanel } = useInternalPanelState(
+    onChangePanel
   );
 
   const [dateInFocus, setDateInFocus] = useState(() => new Date());

--- a/packages/calendar/src/components/calendar-types/single-date-calendar/SingleDateCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/single-date-calendar/SingleDateCalendar.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 
 import { useSingleDateSelection } from "./UseSingleDateSelection";
-import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
+import { InternalPanelAndFocusStateProps } from "../../../types/InternalPanelAndFocusStateProps";
 
 export interface SingleDateCalendarProps<T>
-  extends CalendarWithInternalPanelAndFocusStateProps<T> {
+  extends InternalPanelAndFocusStateProps<T> {
   value: Date | undefined;
   onChange: (value: Date | undefined) => void;
 }

--- a/packages/calendar/src/components/calendar-types/single-date-calendar/SingleDateCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/single-date-calendar/SingleDateCalendar.tsx
@@ -1,16 +1,11 @@
 import * as React from "react";
-import {
-  CalendarWithMonthSwitcher,
-  CalendarWithMonthSwitcherProps,
-} from "../../../features/month-switcher/CalendarWithMonthSwitcher";
+import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 
 import { useSingleDateSelection } from "./UseSingleDateSelection";
+import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
 
 export interface SingleDateCalendarProps<T>
-  extends Omit<
-    CalendarWithMonthSwitcherProps<T>,
-    "currentPanel" | "setCurrentPanel" | "dateInFocus" | "setDateInFocus"
-  > {
+  extends CalendarWithInternalPanelAndFocusStateProps<T> {
   value: Date | undefined;
   onChange: (value: Date | undefined) => void;
 }

--- a/packages/calendar/src/components/calendar-types/single-date-calendar/UseSingleDateSelection.ts
+++ b/packages/calendar/src/components/calendar-types/single-date-calendar/UseSingleDateSelection.ts
@@ -3,15 +3,16 @@ import { OnClickDay } from "../../../types/CalendarTypes";
 import { addDayStateHighlights } from "../../../util/calendar/StateModifier";
 import { SingleDateCalendarProps } from "./SingleDateCalendar";
 import { CalendarWithMonthSwitcherProps } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
-import { CalendarPanelType } from "../../../features/calendar-with-month-year-pickers/CalendarPanelType";
+import { useInternalPanelState } from "../../../features/internal-panel-state/UseInternalPanelState";
 
 export const useSingleDateSelection = <T>({
   onChange,
   value,
   statePerMonth,
+  onChangePanel,
 }: SingleDateCalendarProps<T>): CalendarWithMonthSwitcherProps<T> => {
-  const [currentPanel, setCurrentPanel] = useState<CalendarPanelType>(
-    "calendar"
+  const { currentPanel, setCurrentPanel } = useInternalPanelState(
+    onChangePanel
   );
 
   const [dateInFocus, setDateInFocus] = useState(() => value ?? new Date());

--- a/packages/calendar/src/components/calendar-types/single-week-calendar/SingleWeekCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/single-week-calendar/SingleWeekCalendar.tsx
@@ -1,18 +1,12 @@
 import * as React from "react";
-import {
-  CalendarWithMonthSwitcher,
-  CalendarWithMonthSwitcherProps,
-} from "../../../features/month-switcher/CalendarWithMonthSwitcher";
-
+import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { useSingleWeekSelection } from "./UseSingleWeekSelection";
+import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
 
 export type SingleWeekValue = string;
 
 export interface SingleWeekCalendarProps<T>
-  extends Omit<
-    CalendarWithMonthSwitcherProps<T>,
-    "currentPanel" | "setCurrentPanel" | "dateInFocus" | "setDateInFocus"
-  > {
+  extends CalendarWithInternalPanelAndFocusStateProps<T> {
   value: SingleWeekValue | undefined;
   onChange: (value: SingleWeekValue | undefined) => void;
 }

--- a/packages/calendar/src/components/calendar-types/single-week-calendar/SingleWeekCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/single-week-calendar/SingleWeekCalendar.tsx
@@ -1,12 +1,12 @@
 import * as React from "react";
 import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { useSingleWeekSelection } from "./UseSingleWeekSelection";
-import { CalendarWithInternalPanelAndFocusStateProps } from "../../../types/CalendarWithInternalPanelAndFocusStateProps";
+import { InternalPanelAndFocusStateProps } from "../../../types/InternalPanelAndFocusStateProps";
 
 export type SingleWeekValue = string;
 
 export interface SingleWeekCalendarProps<T>
-  extends CalendarWithInternalPanelAndFocusStateProps<T> {
+  extends InternalPanelAndFocusStateProps<T> {
   value: SingleWeekValue | undefined;
   onChange: (value: SingleWeekValue | undefined) => void;
 }

--- a/packages/calendar/src/components/calendar-types/single-week-calendar/UseSingleWeekSelection.ts
+++ b/packages/calendar/src/components/calendar-types/single-week-calendar/UseSingleWeekSelection.ts
@@ -6,14 +6,14 @@ import {
   WeekData,
 } from "../../../util/calendar/CalendarDataFactory";
 import { addWeekRangeHighlights } from "../../../util/calendar/StateModifier";
-
 import { SingleWeekCalendarProps } from "./SingleWeekCalendar";
-import { CalendarPanelType } from "../../../features/calendar-with-month-year-pickers/CalendarPanelType";
+import { useInternalPanelState } from "../../../features/internal-panel-state/UseInternalPanelState";
 
 export const useSingleWeekSelection = <T>({
   onChange,
   value,
   statePerMonth,
+  onChangePanel,
 }: SingleWeekCalendarProps<T>): CalendarWithMonthSwitcherProps<T> => {
   const [dateInFocus, setDateInFocus] = useState(() => {
     const week = getWeekDataFromWeekString(value);
@@ -22,8 +22,8 @@ export const useSingleWeekSelection = <T>({
     }
     return week.days[0].date;
   });
-  const [currentPanel, setCurrentPanel] = useState<CalendarPanelType>(
-    "calendar"
+  const { currentPanel, setCurrentPanel } = useInternalPanelState(
+    onChangePanel
   );
 
   const onClickDay = useCallback(

--- a/packages/calendar/src/components/input-types/date-input/DateInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-input/DateInput.stories.tsx
@@ -1,3 +1,4 @@
+import { Column } from "@stenajs-webui/core";
 import { addDays, addMonths } from "date-fns";
 import * as React from "react";
 import { useState } from "react";
@@ -30,6 +31,12 @@ export const Standard = () => {
     </div>
   );
 };
+
+export const Centered = () => (
+  <Column alignItems={"center"} justifyContent={"center"} height={"800px"}>
+    <Standard />
+  </Column>
+);
 
 export const WithDisabledDateTomorrow = () => {
   const [value, setValue] = useState<Date | undefined>(undefined);

--- a/packages/calendar/src/components/input-types/date-input/DateInput.tsx
+++ b/packages/calendar/src/components/input-types/date-input/DateInput.tsx
@@ -4,7 +4,7 @@ import { TextInput, TextInputProps } from "@stenajs-webui/forms";
 import { Popover } from "@stenajs-webui/tooltip";
 import { format } from "date-fns";
 import * as React from "react";
-import { usePopoverCalendar } from "../../../features/internal-panel-state/UsePopoverCalendar";
+import { useCalendarPopoverUpdater } from "../../../features/internal-panel-state/UseCalendarPopoverUpdater";
 import { DateFormats } from "../../../util/date/DateFormats";
 import { SingleDateCalendar } from "../../calendar-types/single-date-calendar/SingleDateCalendar";
 import {
@@ -78,7 +78,7 @@ export const DateInput: React.FC<DateInputProps> = ({
     showCalendar,
   } = useDateInput(onChange, onClose, openOnMount);
 
-  const { tippyRef, onChangePanel } = usePopoverCalendar();
+  const { tippyRef, onChangePanel } = useCalendarPopoverUpdater();
 
   return (
     <Box width={width}>

--- a/packages/calendar/src/components/input-types/date-input/DateInput.tsx
+++ b/packages/calendar/src/components/input-types/date-input/DateInput.tsx
@@ -4,6 +4,7 @@ import { TextInput, TextInputProps } from "@stenajs-webui/forms";
 import { Popover } from "@stenajs-webui/tooltip";
 import { format } from "date-fns";
 import * as React from "react";
+import { defaultPopoverPlacement } from "../../../config/DefaultPopoverPlacement";
 import { useCalendarPopoverUpdater } from "../../../features/internal-panel-state/UseCalendarPopoverUpdater";
 import { DateFormats } from "../../../util/date/DateFormats";
 import { SingleDateCalendar } from "../../calendar-types/single-date-calendar/SingleDateCalendar";
@@ -87,7 +88,7 @@ export const DateInput: React.FC<DateInputProps> = ({
         lazy
         visible={showingCalendar}
         onClickOutside={hideCalendar}
-        placement={"bottom"}
+        placement={defaultPopoverPlacement}
         zIndex={zIndex}
         appendTo={portalTarget ?? "parent"}
         tippyRef={tippyRef}

--- a/packages/calendar/src/components/input-types/date-input/DateInput.tsx
+++ b/packages/calendar/src/components/input-types/date-input/DateInput.tsx
@@ -4,6 +4,7 @@ import { TextInput, TextInputProps } from "@stenajs-webui/forms";
 import { Popover } from "@stenajs-webui/tooltip";
 import { format } from "date-fns";
 import * as React from "react";
+import { usePopoverCalendar } from "../../../features/internal-panel-state/UsePopoverCalendar";
 import { DateFormats } from "../../../util/date/DateFormats";
 import { SingleDateCalendar } from "../../calendar-types/single-date-calendar/SingleDateCalendar";
 import {
@@ -77,6 +78,8 @@ export const DateInput: React.FC<DateInputProps> = ({
     showCalendar,
   } = useDateInput(onChange, onClose, openOnMount);
 
+  const { tippyRef, onChangePanel } = usePopoverCalendar();
+
   return (
     <Box width={width}>
       <Popover
@@ -84,14 +87,17 @@ export const DateInput: React.FC<DateInputProps> = ({
         lazy
         visible={showingCalendar}
         onClickOutside={hideCalendar}
+        placement={"bottom"}
         zIndex={zIndex}
         appendTo={portalTarget ?? "parent"}
+        tippyRef={tippyRef}
         content={
           <SingleDateCalendar
             {...calendarProps}
             onChange={onSelectDate}
             value={value}
             theme={calendarTheme}
+            onChangePanel={onChangePanel}
           />
         }
       >

--- a/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.stories.tsx
@@ -1,10 +1,11 @@
+import { Column } from "@stenajs-webui/core";
+import { Story } from "@storybook/react";
 import { addDays } from "date-fns";
 import * as React from "react";
 import { useState } from "react";
 import { DateRangeOnChangeValue } from "../../../features/date-range/hooks/UseDateRangeOnClickDayHandler";
-import { DateRangeDualTextInput } from "./DateRangeDualTextInput";
 import { useDateRangeCalendarState } from "../../calendar-types/date-range-calendar/hooks/UseDateRangeCalendarState";
-import { Story } from "@storybook/react";
+import { DateRangeDualTextInput } from "./DateRangeDualTextInput";
 
 export default {
   title: "calendar/Input/DateRangeDualTextInput",
@@ -34,6 +35,12 @@ export const Standard = () => {
     </div>
   );
 };
+
+export const Centered = () => (
+  <Column alignItems={"center"} justifyContent={"center"} height={"800px"}>
+    <Standard />
+  </Column>
+);
 
 export const StartSelected = () => {
   const [value, setValue] = useState<DateRangeOnChangeValue | undefined>({

--- a/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.tsx
+++ b/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.tsx
@@ -8,6 +8,7 @@ import { Popover } from "@stenajs-webui/tooltip";
 import { isAfter } from "date-fns";
 import * as React from "react";
 import { useMemo, useRef } from "react";
+import { defaultPopoverPlacement } from "../../../config/DefaultPopoverPlacement";
 import { DateRangeOnChangeValue } from "../../../features/date-range/hooks/UseDateRangeOnClickDayHandler";
 import { DualTextInput } from "../../../features/dual-text-input/DualTextInput";
 import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
@@ -99,7 +100,7 @@ export const DateRangeDualTextInput: React.FC<DateRangeDualTextInputProps> = ({
       <Popover
         arrow={false}
         lazy
-        placement={"bottom"}
+        placement={defaultPopoverPlacement}
         onClickOutside={hideCalendar}
         visible={isCalendarVisible}
         content={

--- a/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.stories.tsx
@@ -1,9 +1,10 @@
+import { Column } from "@stenajs-webui/core";
+import { Story } from "@storybook/react";
 import { addDays, subDays } from "date-fns";
 import * as React from "react";
 import { useState } from "react";
 import { DateRangeCalendarOnChangeValue } from "../../calendar-types/date-range-calendar/DateRangeCalendar";
 import { DateRangeInput } from "./DateRangeInput";
-import { Story } from "@storybook/react";
 
 export default {
   title: "calendar/Input/DateRangeInput",
@@ -29,6 +30,12 @@ export const Standard = () => {
     </div>
   );
 };
+
+export const Centered = () => (
+  <Column alignItems={"center"} justifyContent={"center"} height={"800px"}>
+    <Standard />
+  </Column>
+);
 
 export const Empty = () => (
   <div style={{ display: "inline-block" }}>

--- a/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
+++ b/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
@@ -129,6 +129,7 @@ export const DateRangeInput = <T extends {}>({
       lazy
       visible={showingCalendar}
       zIndex={zIndex}
+      placement={"bottom"}
       appendTo={portalTarget ?? "parent"}
       onClickOutside={hideCalendar}
       content={

--- a/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
+++ b/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
@@ -4,6 +4,7 @@ import { TextInput } from "@stenajs-webui/forms";
 import { format } from "date-fns";
 import * as React from "react";
 import { useMemo, useState } from "react";
+import { defaultPopoverPlacement } from "../../../config/DefaultPopoverPlacement";
 import { DateFormats } from "../../../util/date/DateFormats";
 import {
   DateRangeCalendarOnChangeValue,
@@ -129,7 +130,7 @@ export const DateRangeInput = <T extends {}>({
       lazy
       visible={showingCalendar}
       zIndex={zIndex}
-      placement={"bottom"}
+      placement={defaultPopoverPlacement}
       appendTo={portalTarget ?? "parent"}
       onClickOutside={hideCalendar}
       content={

--- a/packages/calendar/src/components/input-types/date-text-input/DateTextInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-text-input/DateTextInput.stories.tsx
@@ -1,3 +1,4 @@
+import { Column } from "@stenajs-webui/core";
 import { DateTextInput } from "./DateTextInput";
 import * as React from "react";
 import { useState } from "react";
@@ -20,6 +21,12 @@ export const Standard = () => {
 
   return <DateTextInput value={value} onValueChange={setValue} />;
 };
+
+export const Centered = () => (
+  <Column alignItems={"center"} justifyContent={"center"} height={"800px"}>
+    <Standard />
+  </Column>
+);
 
 export const EnglishDateFormat = () => {
   const [value, setValue] = useState<string | undefined>(undefined);

--- a/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
+++ b/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
@@ -6,6 +6,7 @@ import { Popover } from "@stenajs-webui/tooltip";
 import { format, isValid, parse } from "date-fns";
 import * as React from "react";
 import { useCallback, useState } from "react";
+import { usePopoverCalendar } from "../../../features/internal-panel-state/UsePopoverCalendar";
 import { DateFormats } from "../../../util/date/DateFormats";
 import {
   SingleDateCalendar,
@@ -15,17 +16,10 @@ import {
   CalendarTheme,
   defaultCalendarTheme,
 } from "../../calendar/CalendarTheme";
-import { usePopoverCalendar } from "../../../features/internal-panel-state/UsePopoverCalendar";
 
 export type DateTextInputCalendarProps<T> = Omit<
   SingleDateCalendarProps<T>,
-  | "value"
-  | "onChange"
-  | "theme"
-  | "dateInFocus"
-  | "setDateInFocus"
-  | "currentPanel"
-  | "setCurrentPanel"
+  "value" | "onChange" | "theme"
 >;
 
 export interface DateTextInputProps<T>

--- a/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
+++ b/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
@@ -15,6 +15,7 @@ import {
   CalendarTheme,
   defaultCalendarTheme,
 } from "../../calendar/CalendarTheme";
+import { usePopoverCalendar } from "../../../features/internal-panel-state/UsePopoverCalendar";
 
 export type DateTextInputCalendarProps<T> = Omit<
   SingleDateCalendarProps<T>,
@@ -65,6 +66,7 @@ export const DateTextInput: React.FC<DateTextInputProps<{}>> = ({
   ...props
 }) => {
   const [open, setOpen] = useState(false);
+  const { tippyRef, onChangePanel } = usePopoverCalendar();
 
   const toggleCalendar = useCallback(() => {
     setOpen(!open);
@@ -112,11 +114,15 @@ export const DateTextInput: React.FC<DateTextInputProps<{}>> = ({
         visible={open}
         zIndex={zIndex}
         appendTo={portalTarget ?? "parent"}
+        placement={"bottom"}
         onClickOutside={hideCalendar}
+        sticky={"popper"}
+        tippyRef={tippyRef}
         content={
           <SingleDateCalendar
             {...calendarProps}
             onChange={onCalendarSelectDate}
+            onChangePanel={onChangePanel}
             value={
               value && dateIsValid
                 ? parse(value, dateFormat, new Date())

--- a/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
+++ b/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
@@ -6,6 +6,7 @@ import { Popover } from "@stenajs-webui/tooltip";
 import { format, isValid, parse } from "date-fns";
 import * as React from "react";
 import { useCallback, useState } from "react";
+import { defaultPopoverPlacement } from "../../../config/DefaultPopoverPlacement";
 import { useCalendarPopoverUpdater } from "../../../features/internal-panel-state/UseCalendarPopoverUpdater";
 import { DateFormats } from "../../../util/date/DateFormats";
 import {
@@ -108,7 +109,7 @@ export const DateTextInput: React.FC<DateTextInputProps<{}>> = ({
         visible={open}
         zIndex={zIndex}
         appendTo={portalTarget ?? "parent"}
-        placement={"bottom"}
+        placement={defaultPopoverPlacement}
         onClickOutside={hideCalendar}
         sticky={"popper"}
         tippyRef={tippyRef}

--- a/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
+++ b/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
@@ -6,7 +6,7 @@ import { Popover } from "@stenajs-webui/tooltip";
 import { format, isValid, parse } from "date-fns";
 import * as React from "react";
 import { useCallback, useState } from "react";
-import { usePopoverCalendar } from "../../../features/internal-panel-state/UsePopoverCalendar";
+import { useCalendarPopoverUpdater } from "../../../features/internal-panel-state/UseCalendarPopoverUpdater";
 import { DateFormats } from "../../../util/date/DateFormats";
 import {
   SingleDateCalendar,
@@ -60,7 +60,7 @@ export const DateTextInput: React.FC<DateTextInputProps<{}>> = ({
   ...props
 }) => {
   const [open, setOpen] = useState(false);
-  const { tippyRef, onChangePanel } = usePopoverCalendar();
+  const { tippyRef, onChangePanel } = useCalendarPopoverUpdater();
 
   const toggleCalendar = useCallback(() => {
     setOpen(!open);

--- a/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.stories.tsx
@@ -1,5 +1,5 @@
 import { faTrash } from "@fortawesome/free-solid-svg-icons/faTrash";
-import { Indent, Row } from "@stenajs-webui/core";
+import { Column, Indent, Row } from "@stenajs-webui/core";
 import { FlatButton } from "@stenajs-webui/elements";
 import { Story } from "@storybook/react";
 import * as React from "react";
@@ -27,6 +27,19 @@ export const Standard = () => {
       <Indent />
       <FlatButton leftIcon={faTrash} onClick={() => setValue(null)} />
     </Row>
+  );
+};
+
+export const Centered = () => {
+  return (
+    <Column
+      alignItems={"center"}
+      justifyContent={"center"}
+      height={"800px"}
+      width={"800px"}
+    >
+      <Standard />
+    </Column>
   );
 };
 

--- a/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.tsx
+++ b/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.tsx
@@ -8,6 +8,7 @@ import {
 import { Popover } from "@stenajs-webui/tooltip";
 import * as React from "react";
 import { useCallback, useMemo, useRef } from "react";
+import { defaultPopoverPlacement } from "../../../config/DefaultPopoverPlacement";
 import { DualTextInput } from "../../../features/dual-text-input/DualTextInput";
 import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { TimePicker } from "../../../features/time-picker/TimePicker";
@@ -106,7 +107,7 @@ export const DateTimeInput: React.FC<DateTimeInputProps> = ({
       <Popover
         arrow={false}
         lazy
-        placement={"bottom"}
+        placement={defaultPopoverPlacement}
         visible={isCalendarVisible || isTimePickerVisible}
         onClickOutside={hideAll}
         content={

--- a/packages/calendar/src/config/DefaultPopoverPlacement.ts
+++ b/packages/calendar/src/config/DefaultPopoverPlacement.ts
@@ -1,0 +1,3 @@
+import { Placement } from "tippy.js";
+
+export const defaultPopoverPlacement: Placement = "bottom";

--- a/packages/calendar/src/config/DefaultPopoverPlacement.ts
+++ b/packages/calendar/src/config/DefaultPopoverPlacement.ts
@@ -1,3 +1,3 @@
-import { Placement } from "tippy.js";
+import { PopoverPlacement } from "@stenajs-webui/tooltip";
 
-export const defaultPopoverPlacement: Placement = "bottom";
+export const defaultPopoverPlacement: PopoverPlacement = "bottom";

--- a/packages/calendar/src/features/internal-panel-state/UseCalendarPopoverUpdater.ts
+++ b/packages/calendar/src/features/internal-panel-state/UseCalendarPopoverUpdater.ts
@@ -1,7 +1,7 @@
 import { useTippyInstance } from "@stenajs-webui/tooltip";
 import { useCallback } from "react";
 
-export const usePopoverCalendar = () => {
+export const useCalendarPopoverUpdater = () => {
   const [tippyRef, tippyInstanceRef] = useTippyInstance();
 
   const onChangePanel = useCallback(() => {

--- a/packages/calendar/src/features/internal-panel-state/UseInternalPanelState.tsx
+++ b/packages/calendar/src/features/internal-panel-state/UseInternalPanelState.tsx
@@ -3,7 +3,7 @@ import { useCallback, useState } from "react";
 
 export type OnChangePanel = (panel: CalendarPanelType) => void;
 
-export interface UseInternalPanelStateArgs {
+export interface UseInternalPanelStateProps {
   onChangePanel?: OnChangePanel;
 }
 

--- a/packages/calendar/src/features/internal-panel-state/UseInternalPanelState.tsx
+++ b/packages/calendar/src/features/internal-panel-state/UseInternalPanelState.tsx
@@ -1,0 +1,29 @@
+import { CalendarPanelType } from "../calendar-with-month-year-pickers/CalendarPanelType";
+import { useCallback, useState } from "react";
+
+export type OnChangePanel = (panel: CalendarPanelType) => void;
+
+export interface UseInternalPanelStateArgs {
+  onChangePanel?: OnChangePanel;
+}
+
+export const useInternalPanelState = (
+  onChangePanel: OnChangePanel | undefined
+) => {
+  const [currentPanel, _setCurrentPanel] = useState<CalendarPanelType>(
+    "calendar"
+  );
+
+  const setCurrentPanel = useCallback(
+    (currentPanel: CalendarPanelType) => {
+      _setCurrentPanel(currentPanel);
+      onChangePanel?.(currentPanel);
+    },
+    [onChangePanel]
+  );
+
+  return {
+    currentPanel,
+    setCurrentPanel,
+  };
+};

--- a/packages/calendar/src/features/internal-panel-state/UsePopoverCalendar.ts
+++ b/packages/calendar/src/features/internal-panel-state/UsePopoverCalendar.ts
@@ -1,0 +1,15 @@
+import { useTippyInstance } from "@stenajs-webui/tooltip";
+import { useCallback } from "react";
+
+export const usePopoverCalendar = () => {
+  const [tippyRef, tippyInstanceRef] = useTippyInstance();
+
+  const onChangePanel = useCallback(() => {
+    tippyInstanceRef.current?.popperInstance?.update();
+  }, [tippyInstanceRef]);
+
+  return {
+    onChangePanel,
+    tippyRef,
+  };
+};

--- a/packages/calendar/src/types/CalendarWithInternalPanelAndFocusStateProps.ts
+++ b/packages/calendar/src/types/CalendarWithInternalPanelAndFocusStateProps.ts
@@ -1,0 +1,8 @@
+import { CalendarWithMonthSwitcherProps } from "../features/month-switcher/CalendarWithMonthSwitcher";
+import { UseInternalPanelStateArgs } from "../features/internal-panel-state/UseInternalPanelState";
+
+export type CalendarWithInternalPanelAndFocusStateProps<T> = Omit<
+  CalendarWithMonthSwitcherProps<T>,
+  "currentPanel" | "setCurrentPanel" | "dateInFocus" | "setDateInFocus"
+> &
+  UseInternalPanelStateArgs;

--- a/packages/calendar/src/types/InternalPanelAndFocusStateProps.ts
+++ b/packages/calendar/src/types/InternalPanelAndFocusStateProps.ts
@@ -1,8 +1,8 @@
+import { UseInternalPanelStateProps } from "../features/internal-panel-state/UseInternalPanelState";
 import { CalendarWithMonthSwitcherProps } from "../features/month-switcher/CalendarWithMonthSwitcher";
-import { UseInternalPanelStateArgs } from "../features/internal-panel-state/UseInternalPanelState";
 
-export type CalendarWithInternalPanelAndFocusStateProps<T> = Omit<
+export type InternalPanelAndFocusStateProps<T> = Omit<
   CalendarWithMonthSwitcherProps<T>,
   "currentPanel" | "setCurrentPanel" | "dateInFocus" | "setDateInFocus"
 > &
-  UseInternalPanelStateArgs;
+  UseInternalPanelStateProps;

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -3,3 +3,4 @@ export * from "./components/popover/Popover";
 export * from "./components/button-with-popover/ButtonWithPopover";
 export * from "./components/tooltip/Tooltip";
 export * from "./hooks/UseTippyInstance";
+export * from "./types";

--- a/packages/tooltip/src/index.ts
+++ b/packages/tooltip/src/index.ts
@@ -2,3 +2,4 @@ export * from "./components/popover/ActionPrompt";
 export * from "./components/popover/Popover";
 export * from "./components/button-with-popover/ButtonWithPopover";
 export * from "./components/tooltip/Tooltip";
+export * from "./hooks/UseTippyInstance";

--- a/packages/tooltip/src/types.ts
+++ b/packages/tooltip/src/types.ts
@@ -1,0 +1,3 @@
+import { Placement } from "tippy.js";
+
+export type PopoverPlacement = Placement;


### PR DESCRIPTION
Calendar popover for calendar inputs are now always centered.

![image](https://user-images.githubusercontent.com/1266041/136191114-e90a63fd-b157-47bc-b046-50e8c75af60f.png)
