### PR TITLE
Fix StandardTable content not having correct colSpan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Next
+
+### StandardTable
+
+- Fix invalid content width for loading when using rowIndent.
+
 ## 14.0.0
 
 ### Calendar inputs

--- a/packages/grid/src/features/standard-table/stories/States.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/States.stories.tsx
@@ -27,7 +27,7 @@ export const MissingItemsCustomBanner = () => (
 export const Loading = () => (
   <StandardTable
     items={mockedItems}
-    config={standardTableConfigForStories}
+    config={{ ...standardTableConfigForStories, rowIndent: 2 }}
     loading
   />
 );

--- a/packages/grid/src/features/standard-table/util/ColumnCounter.ts
+++ b/packages/grid/src/features/standard-table/util/ColumnCounter.ts
@@ -7,6 +7,7 @@ export const getTotalNumColumns = <
 >(
   config: StandardTableConfig<TItem, TColumnKey, TColumnGroupKey>
 ): number =>
+  (config.rowIndent ? 2 : 0) +
   (config.enableExpandCollapse ? 1 : 0) +
   (config.showRowCheckbox ? 1 : 0) +
   getNumUserColumns(config);


### PR DESCRIPTION
### Before

Notice border missing under header of the last column.

![image](https://user-images.githubusercontent.com/1266041/136764557-89cf0795-0dee-4edb-8569-fe2cee88cecd.png)

### After

![image](https://user-images.githubusercontent.com/1266041/136764729-7368c563-57d2-4be1-b248-de0735023d28.png)
