### PR TITLE
Remove static references to CSS properties for LHDS colors

### DIFF
--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -31,6 +31,7 @@
     "@stenajs-webui/core": "14.0.0",
     "@stenajs-webui/elements": "14.0.0",
     "@stenajs-webui/forms": "14.0.0",
+    "@stenajs-webui/theme": "14.0.0",
     "@stenajs-webui/tooltip": "14.0.0",
     "date-fns": "2.16.1"
   },

--- a/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
+++ b/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
@@ -4,6 +4,7 @@ import { TextInput } from "@stenajs-webui/forms";
 import { format } from "date-fns";
 import * as React from "react";
 import { useMemo, useState } from "react";
+import { cssColor } from "@stenajs-webui/theme";
 import { defaultPopoverPlacement } from "../../../config/DefaultPopoverPlacement";
 import { DateFormats } from "../../../util/date/DateFormats";
 import {
@@ -160,7 +161,7 @@ export const DateRangeInput = <T extends {}>({
         <Space />
         <Icon
           icon={faLongArrowAltRight}
-          color={"var(--lhds-color-ui-500)"}
+          color={cssColor("--lhds-color-ui-500")}
           size={14}
         />
         <Space />

--- a/packages/calendar/src/features/dual-text-input/DualTextInput.tsx
+++ b/packages/calendar/src/features/dual-text-input/DualTextInput.tsx
@@ -19,6 +19,7 @@ import {
 import { debounce } from "lodash";
 import * as React from "react";
 import { useCallback, useMemo, useRef } from "react";
+import { cssColor } from "@stenajs-webui/theme";
 
 export interface DualTextInputProps {
   onEsc?: TextInputProps["onEsc"];
@@ -200,7 +201,7 @@ export const DualTextInput: React.FC<DualTextInputProps> = ({
           <Icon
             icon={separatorIcon}
             size={12}
-            color={"var(--lhds-color-ui-500)"}
+            color={cssColor("--lhds-color-ui-500")}
           />
         </Row>
         <Box width={widthRight}>

--- a/packages/elements/src/components/ui/value-table/ValueTableItem.tsx
+++ b/packages/elements/src/components/ui/value-table/ValueTableItem.tsx
@@ -26,7 +26,11 @@ export const ValueTableItem: React.FC<ValueTableItemProps> = ({
     if (typeof value === "boolean") {
       if (value) {
         return (
-          <Icon icon={faCheck} size={14} color={"var(--lhds-color-ui-700)"} />
+          <Icon
+            icon={faCheck}
+            size={14}
+            color={cssColor("--lhds-color-ui-700")}
+          />
         );
       } else {
         return "-";

--- a/packages/forms/src/components/ui/text-input/TextInputBox.stories.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInputBox.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Icon, stenaArrowRight } from "@stenajs-webui/elements";
 import { Box, Space } from "@stenajs-webui/core";
+import { cssColor } from "@stenajs-webui/theme";
 import { TextInput } from "./TextInput";
 import { TextInputBox } from "./TextInputBox";
 
@@ -16,7 +17,7 @@ export const Standard = () => (
       <Icon
         icon={stenaArrowRight}
         size={12}
-        color={"var(--lhds-color-ui-500)"}
+        color={cssColor("--lhds-color-ui-500")}
       />
       <Space />
       <TextInput hideBorder />

--- a/packages/grid/src/features/table-ui/components/CrudStatusIndicator.tsx
+++ b/packages/grid/src/features/table-ui/components/CrudStatusIndicator.tsx
@@ -1,8 +1,9 @@
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExclamationTriangle";
 import { Icon, InputSpinner } from "@stenajs-webui/elements";
+import { CrudStatus } from "@stenajs-webui/redux";
+import { cssColor } from "@stenajs-webui/theme";
 import { Tooltip } from "@stenajs-webui/tooltip";
 import * as React from "react";
-import { CrudStatus } from "@stenajs-webui/redux";
 
 interface Props {
   crudStatus?: CrudStatus;
@@ -28,14 +29,14 @@ export const CrudStatusIndicator: React.FC<Props> = ({ crudStatus }) => {
   } = crudStatus;
 
   if (loading || creating || deleting || updating) {
-    return <InputSpinner color={"var(--lhds-color-ui-500)"} />;
+    return <InputSpinner color={cssColor("--lhds-color-ui-500")} />;
   }
 
   if (hasError) {
     const icon = (
       <Icon
         icon={faExclamationTriangle}
-        color={"var(--lhds-color-orange-600)"}
+        color={cssColor("--lhds-color-orange-600")}
         size={14}
       />
     );

--- a/packages/grid/src/features/table-ui/components/ModifiedField.tsx
+++ b/packages/grid/src/features/table-ui/components/ModifiedField.tsx
@@ -2,6 +2,7 @@ import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons/faExcla
 import { Indent, Space, Text } from "@stenajs-webui/core";
 import { Icon, stenaArrowRight } from "@stenajs-webui/elements";
 import { EntityCrudStatus, ModifiedFieldItemState } from "@stenajs-webui/redux";
+import { cssColor } from "@stenajs-webui/theme";
 import { Tooltip } from "@stenajs-webui/tooltip";
 import * as React from "react";
 import {
@@ -54,7 +55,7 @@ export const ModifiedField: React.FC<Props> = ({
         <Tooltip label={warningOnEmpty!} zIndex={100}>
           <Icon
             icon={faExclamationTriangle}
-            color={"var(--lhds-color-orange-600)"}
+            color={cssColor("--lhds-color-orange-600")}
             size={14}
           />
         </Tooltip>

--- a/packages/panels/src/components/action-menu-button/ActionMenuButton.stories.tsx
+++ b/packages/panels/src/components/action-menu-button/ActionMenuButton.stories.tsx
@@ -22,12 +22,13 @@ import {
   PrimaryButton,
   SecondaryButton,
 } from "@stenajs-webui/elements";
+import { cssColor } from "@stenajs-webui/theme";
+import { action } from "@storybook/addon-actions";
 import * as React from "react";
+import { useState } from "react";
 import { ActionMenuFlatButton } from "./ActionMenuFlatButton";
 import { ActionMenuPrimaryButton } from "./ActionMenuPrimaryButton";
 import { ActionMenuSecondaryButton } from "./ActionMenuSecondaryButton";
-import { action } from "@storybook/addon-actions";
-import { useState } from "react";
 
 export default {
   title: "panels/ActionMenuButton",
@@ -192,7 +193,7 @@ export const CustomContent = () => (
           <Txt
             size={"smaller"}
             variant={"bold"}
-            color={"var(--lhds-color-orange-300)"}
+            color={cssColor("--lhds-color-orange-300")}
           >
             So custom!
           </Txt>
@@ -207,7 +208,7 @@ export const CustomContent = () => (
           <Txt
             size={"smaller"}
             variant={"bold"}
-            color={"var(--lhds-color-orange-300)"}
+            color={cssColor("--lhds-color-orange-300")}
           >
             So custom!
           </Txt>

--- a/packages/panels/src/components/collapsible/CollapsibleEmptyContent.tsx
+++ b/packages/panels/src/components/collapsible/CollapsibleEmptyContent.tsx
@@ -1,6 +1,7 @@
 import { faInbox } from "@fortawesome/free-solid-svg-icons/faInbox";
-import { Column, Text, Space } from "@stenajs-webui/core";
+import { Column, Space, Text } from "@stenajs-webui/core";
 import { Icon } from "@stenajs-webui/elements";
+import { cssColor } from "@stenajs-webui/theme";
 import * as React from "react";
 
 interface Props {}
@@ -8,9 +9,9 @@ interface Props {}
 export const CollapsibleEmptyContent: React.FC<Props> = () => {
   return (
     <Column indent spacing flex={1} alignItems={"center"}>
-      <Icon icon={faInbox} color={"var(--lhds-color-ui-500)"} />
+      <Icon icon={faInbox} color={cssColor("--lhds-color-ui-500")} />
       <Space />
-      <Text size={"small"} color={"var(--lhds-color-ui-500)"}>
+      <Text size={"small"} color={cssColor("--lhds-color-ui-500")}>
         No content
       </Text>
     </Column>

--- a/packages/panels/src/components/sidebar-menu/SidebarMenu.tsx
+++ b/packages/panels/src/components/sidebar-menu/SidebarMenu.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import {
   Box,
   BoxProps,
@@ -6,8 +5,10 @@ import {
   SeparatorLine,
   Space,
 } from "@stenajs-webui/core";
-import styles from "./SidebarMenu.module.css";
+import { cssColor } from "@stenajs-webui/theme";
 import cx from "classnames";
+import * as React from "react";
+import styles from "./SidebarMenu.module.css";
 import {
   SidebarMenuCloseButton,
   SidebarMenuCloseButtonProps,
@@ -30,7 +31,7 @@ export const SidebarMenu: React.FC<SidebarMenuProps> = ({
       <Box alignItems={"flex-start"} justifyContent={"center"}>
         <SidebarMenuCloseButton onClick={onCloseClick} variant={"dark"} />
       </Box>
-      <SeparatorLine color={"var(--lhds-color-blue-700)"} />
+      <SeparatorLine color={cssColor("--lhds-color-blue-700")} />
       <Space />
       <Box
         className={styles.sidebarMenuContent}

--- a/packages/panels/src/components/sidebar-menu/SidebarMenuSeparator.tsx
+++ b/packages/panels/src/components/sidebar-menu/SidebarMenuSeparator.tsx
@@ -1,9 +1,10 @@
-import * as React from "react";
 import {
   SeparatorLine,
   SeparatorLineProps,
   Spacing,
 } from "@stenajs-webui/core";
+import { cssColor } from "@stenajs-webui/theme";
+import * as React from "react";
 
 export interface SidebarMenuSeparatorProps extends SeparatorLineProps {}
 
@@ -13,7 +14,7 @@ export const SidebarMenuSeparator: React.FC<SidebarMenuSeparatorProps> = (
   return (
     <Spacing>
       <SeparatorLine
-        color={"var(--lhds-color-blue-700)"}
+        color={cssColor("--lhds-color-blue-700")}
         {...separatorLineProps}
       />
     </Spacing>


### PR DESCRIPTION
Replace with `cssColor()` calls.