### PR TITLE
StandardTable column, ability to handle focus manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Next
+
+### StandardTable
+
+#### Disable automatic focus highlight on cells
+
+New column config: `disableGridCellFocus`
+
+If this setting is enabled, the cell must add the focus highlight and onKeyDown on an element manually.
+
+This makes it possible to let arrow navigation move focus to for example a checkbox in the cell, instead of the cell itself.
+
+#### Example
+
+Adding this is easy, just spread `requiredProps` from `gridCell` into the HTML element.
+
+```
+    active: createColumnConfig((item) => item.active, {
+      disableGridCellFocus: true,
+      renderCell: ({ item, gridCell: { requiredProps } }) => (
+        <Indent>
+          <Checkbox value={item.active} {...requiredProps} />
+        </Indent>
+      ),
+    })
+```
+
 ## 14.0.2
 
 - `Drawer` prop `zIndex` has been added back.

--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -69,6 +69,7 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
     isEditable,
     onChange,
     disableGridCell,
+    disableGridCellFocus,
     zIndex,
   } = useColumnConfigById(columnId);
 
@@ -184,7 +185,9 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
       }}
     >
       <StandardTableCellUi
-        enableGridCell={enableGridCell && !disableGridCell}
+        enableGridCell={
+          enableGridCell && !disableGridCell && !disableGridCellFocus
+        }
         gridCellRequiredProps={gridCell.requiredProps}
         isEditing={gridCell.isEditing}
         width={width}

--- a/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
@@ -114,8 +114,17 @@ export interface StandardTableColumnOptions<TItem, TItemValue> {
 
   /**
    * Disables the grid cell functionality for this column.
+   * If enable, the user can no longer navigate to or from this column with arrow keys.
+   * Focus highlight on the cell is also disabled.
    */
   disableGridCell?: boolean;
+
+  /**
+   * Grid cell is enabled, but arrow key logic and focus highlight must be applied manually.
+   * This makes it possible to move focus to an element inside the cell, instead of on the cell itself.
+   * For example, if the cell contains a checkbox, we user can arrow key navigate to the checkbox.
+   */
+  disableGridCellFocus?: boolean;
 
   /**
    * Grid cell options, if you need custom behaviour.

--- a/packages/grid/src/features/standard-table/stories/StandardTableStoryHelper.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTableStoryHelper.tsx
@@ -1,8 +1,11 @@
 import { addDays, format } from "date-fns";
+import * as React from "react";
 import { useCallback, useState } from "react";
 import { createColumnConfig } from "../config/StandardTableColumnConfig";
 import { StandardTableConfig } from "../config/StandardTableConfig";
 import { createStandardEditableTextCell } from "../helpers/cell-renderers/editable-text-cell/EditableTextCell";
+import { Indent } from "@stenajs-webui/core";
+import { Checkbox } from "@stenajs-webui/forms";
 
 export interface ListItem {
   id: string;
@@ -204,7 +207,12 @@ export const standardTableConfigForStories: StandardTableConfig<
       sortOrderIconVariant: "numeric",
     }),
     active: createColumnConfig((item) => item.active, {
-      itemLabelFormatter: (value) => (value ? "Y" : ""),
+      disableGridCellFocus: true,
+      renderCell: ({ item, gridCell: { requiredProps } }) => (
+        <Indent>
+          <Checkbox value={item.active} {...requiredProps} />
+        </Indent>
+      ),
       infoIconTooltipText: "Active means out on the sea.",
     }),
     name: createColumnConfig((item) => item.name, {


### PR DESCRIPTION
# StandardTable

## Disable automatic focus highlight on cells

New column config: `disableGridCellFocus`

If this setting is enabled, the cell must add the focus highlight and onKeyDown on an element manually.

This makes it possible to let arrow navigation move focus to for example a checkbox in the cell, instead of the cell itself.

### Example

Adding this is easy, just spread `requiredProps` from `gridCell` into the HTML element.

```
    active: createColumnConfig((item) => item.active, {
      disableGridCellFocus: true,
      renderCell: ({ item, gridCell: { requiredProps } }) => (
        <Indent>
          <Checkbox value={item.active} {...requiredProps} />
        </Indent>
      ),
    })
```

![image](https://user-images.githubusercontent.com/1266041/138249725-f7739bcb-25ea-4360-8b65-f6ff28554872.png)
