### PR TITLE
Change import style of react-modal

### DIFF
--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -31,10 +31,10 @@
     "@stenajs-webui/core": "14.1.1",
     "@stenajs-webui/elements": "14.1.1",
     "@stenajs-webui/theme": "14.1.1",
-    "@types/react-modal": "^3.10.6",
+    "@types/react-modal": "^3.13.1",
     "classnames": "^2.2.6",
     "react-draggable": "^4.4.2",
-    "react-modal": "^3.11.1"
+    "react-modal": "^3.14.3"
   },
   "peerDependencies": {
     "@emotion/react": ">=11.1.5",

--- a/packages/modal/src/components/center-modal/CenterModal.tsx
+++ b/packages/modal/src/components/center-modal/CenterModal.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as ReactModal from "react-modal";
+import ReactModal from "react-modal";
 
 import styles from "../modal/Modal.module.css";
 

--- a/packages/modal/src/components/drawer/Drawer.tsx
+++ b/packages/modal/src/components/drawer/Drawer.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as ReactModal from "react-modal";
+import ReactModal from "react-modal";
 import cx from "classnames";
 
 import styles from "./Drawer.module.css";

--- a/packages/modal/src/components/loading-modal/LoadingModal.tsx
+++ b/packages/modal/src/components/loading-modal/LoadingModal.tsx
@@ -9,7 +9,7 @@ import {
 } from "@stenajs-webui/core";
 import { Icon, Spinner } from "@stenajs-webui/elements";
 import * as React from "react";
-import * as ReactModal from "react-modal";
+import ReactModal from "react-modal";
 import styles from "./LoadingModal.module.css";
 
 export interface LoadingModalProps extends Omit<ReactModal.Props, "isOpen"> {

--- a/packages/modal/src/components/modal/BaseModal.tsx
+++ b/packages/modal/src/components/modal/BaseModal.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import * as ReactModal from "react-modal";
+import ReactModal from "react-modal";
 import Draggable from "react-draggable";
 import cx from "classnames";
 

--- a/packages/modal/src/components/modal/Modal.stories.tsx
+++ b/packages/modal/src/components/modal/Modal.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from "@stenajs-webui/elements";
 import * as React from "react";
 import { useState } from "react";
-import * as ReactModal from "react-modal";
+import ReactModal from "react-modal";
 import { BaseModal, DRAGGABLE_CANCEL_CLASSNAME } from "./BaseModal";
 import { Modal } from "./Modal";
 import { cssColor } from "@stenajs-webui/theme";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,8 @@
     "noEmit": true,
     "jsx": "react",
     "declaration": true,
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4696,10 +4696,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-modal@^3.10.6":
-  version "3.10.6"
-  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.10.6.tgz#76717220f32bc72769190692147814a540053c7e"
-  integrity sha512-XpshhwVYir1TRZ2HS5EfmNotJjB8UEC2IkT3omNtiQzROOXSzVLz5xsjwEpACP8U+PctkpfZepX+WT5oDf0a9g==
+"@types/react-modal@^3.13.1":
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/@types/react-modal/-/react-modal-3.13.1.tgz#5b9845c205fccc85d9a77966b6e16dc70a60825a"
+  integrity sha512-iY/gPvTDIy6Z+37l+ibmrY+GTV4KQTHcCyR5FIytm182RQS69G5ps4PH2FxtC7bAQ2QRHXMevsBgck7IQruHNg==
   dependencies:
     "@types/react" "*"
 
@@ -14656,7 +14656,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -15032,13 +15032,13 @@ react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-modal@^3.11.1:
-  version "3.12.1"
-  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.12.1.tgz#38c33f70d81c33d02ff1ed115530443a3dc2afd3"
-  integrity sha512-WGuXn7Fq31PbFJwtWmOk+jFtGC7E9tJVbFX0lts8ZoS5EPi9+WWylUJWLKKVm3H4GlQ7ZxY7R6tLlbSIBQ5oZA==
+react-modal@^3.14.3:
+  version "3.14.3"
+  resolved "https://registry.yarnpkg.com/react-modal/-/react-modal-3.14.3.tgz#7eb7c5ec85523e5843e2d4737cc17fc3f6aeb1c0"
+  integrity sha512-+C2KODVKyu20zHXPJxfOOcf571L1u/EpFlH+oS/3YDn8rgVE51QZuxuuIwabJ8ZFnOEHaD+r6XNjqwtxZnXO0g==
   dependencies:
     exenv "^1.2.0"
-    prop-types "^15.5.10"
+    prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.0"
     warning "^4.0.3"
 


### PR DESCRIPTION
From what I understand, the reason is this line in `@types/react-modal` https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-modal/index.d.ts#L18

`export = ReactModal` 

It gives an error when using other build tools than `create-react-app`, such as [`vite`](https://vitejs.dev/).