### PR TITLE
Update DateRangeDualTextInput behaviour

### DIFF
--- a/packages/calendar/src/components/input-types/date-range-dual-text-input/hooks/UseUserInputHandlers.ts
+++ b/packages/calendar/src/components/input-types/date-range-dual-text-input/hooks/UseUserInputHandlers.ts
@@ -57,25 +57,45 @@ export const useUserInputHandlers = (
   const onClickDay = useCallback(
     (day: DayData) => {
       if (focusedInput === "startDate") {
-        onValueChange?.({
-          startDate: day.date,
-          endDate,
-        });
-        if (firstFocusedInput === "startDate") {
+        if (endDate != null && isAfter(day.date, endDate)) {
+          onValueChange?.({
+            startDate: day.date,
+            endDate: undefined,
+          });
           setFocusedInput("endDate");
           endDateInputRef.current?.focus();
         } else {
-          setTimeout(hideCalendar, 50);
+          onValueChange?.({
+            startDate: day.date,
+            endDate,
+          });
+          if (firstFocusedInput === "startDate") {
+            setFocusedInput("endDate");
+            endDateInputRef.current?.focus();
+          } else {
+            setTimeout(hideCalendar, 50);
+          }
         }
       } else if (focusedInput === "endDate") {
-        onValueChange?.({
-          startDate,
-          endDate: day.date,
-        });
-        if (!startDate || isAfter(startDate, day.date)) {
+        if (!startDate) {
+          onValueChange?.({
+            startDate,
+            endDate: day.date,
+          });
           setFocusedInput("startDate");
           startDateInputRef.current?.focus();
+        } else if (isAfter(startDate, day.date)) {
+          onValueChange?.({
+            startDate: day.date,
+            endDate: undefined,
+          });
+          setFocusedInput("endDate");
+          endDateInputRef.current?.focus();
         } else {
+          onValueChange?.({
+            startDate,
+            endDate: day.date,
+          });
           setTimeout(hideCalendar, 50);
         }
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,6 +64,6 @@
   "dependencies": {
     "@emotion/is-prop-valid": "^1.1.0",
     "@stenajs-webui/theme": "14.1.1",
-    "classnames": "^2.2.6"
+    "classnames": "^2.3.1"
   }
 }

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -31,7 +31,7 @@
     "@react-aria/focus": "3.3.0",
     "@stenajs-webui/core": "14.1.1",
     "@stenajs-webui/theme": "14.1.1",
-    "classnames": "^2.2.6"
+    "classnames": "^2.3.1"
   },
   "peerDependencies": {
     "@emotion/react": ">=11.1.5",
@@ -52,7 +52,6 @@
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@types/classnames": "^2.2.10",
     "@types/jest": "^23.1.5",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.3",

--- a/packages/elements/src/components/ui/tag/Tag.stories.tsx
+++ b/packages/elements/src/components/ui/tag/Tag.stories.tsx
@@ -25,6 +25,7 @@ export const Overview = () => (
       "warning",
       "success",
       "passive",
+      "turquoise",
     ] as Array<TagVariant>).map((variant) => (
       <>
         <Text size={"large"}>{variant}</Text>

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -30,8 +30,7 @@
   "dependencies": {
     "@stenajs-webui/core": "14.1.1",
     "@stenajs-webui/elements": "14.1.1",
-    "@types/classnames": "^2.2.10",
-    "classnames": "^2.2.6",
+    "classnames": "^2.3.1",
     "date-fns": "2.16.1"
   },
   "peerDependencies": {

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -35,7 +35,7 @@
     "@stenajs-webui/redux": "14.1.1",
     "@stenajs-webui/theme": "14.1.1",
     "@stenajs-webui/tooltip": "14.1.1",
-    "classnames": "^2.2.6"
+    "classnames": "^2.3.1"
   },
   "peerDependencies": {
     "@emotion/styled": ">=11.3.0",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -32,7 +32,7 @@
     "@stenajs-webui/elements": "14.1.1",
     "@stenajs-webui/theme": "14.1.1",
     "@types/react-modal": "^3.13.1",
-    "classnames": "^2.2.6",
+    "classnames": "^2.3.1",
     "react-draggable": "^4.4.2",
     "react-modal": "^3.14.3"
   },
@@ -51,7 +51,6 @@
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@types/classnames": "^2.2.10",
     "@types/jest": "^23.1.5",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.3",

--- a/packages/panels/package.json
+++ b/packages/panels/package.json
@@ -33,7 +33,7 @@
     "@stenajs-webui/forms": "14.1.1",
     "@stenajs-webui/theme": "14.1.1",
     "@stenajs-webui/tooltip": "14.1.1",
-    "classnames": "^2.2.6",
+    "classnames": "^2.3.1",
     "date-fns": "2.16.1",
     "react-transition-group": "^4.3.0",
     "tippy.js": "^6.2.6"
@@ -55,7 +55,6 @@
     "@emotion/styled": "^11.3.0",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
-    "@types/classnames": "^2.2.10",
     "@types/jest": "^23.1.5",
     "@types/react": "^17.0.5",
     "@types/react-dom": "^17.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4444,11 +4444,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/classnames@^2.2.10":
-  version "2.2.11"
-  resolved "https://registry.yarnpkg.com/@types/classnames/-/classnames-2.2.11.tgz#2521cc86f69d15c5b90664e4829d84566052c1cf"
-  integrity sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==
-
 "@types/color-convert@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/color-convert/-/color-convert-2.0.0.tgz#8f5ee6b9e863dcbee5703f5a517ffb13d3ea4e22"
@@ -6637,10 +6632,15 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.5, classnames@^2.2.6:
+classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
+classnames@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 clean-css@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
When selecting an invalid date range, it now clears the other input and focuses on it, instead of closing the calendar popover.