### PR TITLE
Fix width problem in ChipMultiSelect.

### DIFF
--- a/packages/select/src/components/ui/ChipMultiSelect/ChipMultiSelect.tsx
+++ b/packages/select/src/components/ui/ChipMultiSelect/ChipMultiSelect.tsx
@@ -1,13 +1,9 @@
 import { ValueAndOnValueChangeProps } from "@stenajs-webui/forms";
 import * as React from "react";
 import { MultiSelect, MultiSelectProps } from "../MultiSelect";
-import {
-  CommonChipMultiSelect,
-  CommonChipMultiSelectSelectValue,
-} from "./CommonChipMultiSelect";
+import { ChipRow, ChipRowItem } from "./ChipRow";
 
-export interface ChipMultiSelectValue
-  extends CommonChipMultiSelectSelectValue {}
+export interface ChipMultiSelectValue extends ChipRowItem {}
 
 export interface ChipMultiSelectProps
   extends Omit<MultiSelectProps, "value" | "onChange" | "isLoading">,
@@ -30,7 +26,7 @@ export const ChipMultiSelect = React.memo<ChipMultiSelectProps>(
     ...selectProps
   }) => {
     return (
-      <CommonChipMultiSelect
+      <ChipRow
         noneSelectedLabel={noneSelectedLabel}
         onValueChange={onValueChange}
         value={value}
@@ -48,7 +44,7 @@ export const ChipMultiSelect = React.memo<ChipMultiSelectProps>(
           inputValue={inputValue}
           onInputChange={onInputChange}
         />
-      </CommonChipMultiSelect>
+      </ChipRow>
     );
   }
 );

--- a/packages/select/src/components/ui/ChipMultiSelect/ChipRow.tsx
+++ b/packages/select/src/components/ui/ChipMultiSelect/ChipRow.tsx
@@ -4,26 +4,24 @@ import { ValueAndOnValueChangeProps } from "@stenajs-webui/forms";
 import * as React from "react";
 import { PropsWithChildren } from "react";
 
-export interface CommonChipMultiSelectSelectValue {
+export interface ChipRowItem {
   label: string;
   value: string;
 }
 
-export interface CommonChipMultiSelectProps<TValue>
+export interface ChipRowProps<TValue>
   extends ValueAndOnValueChangeProps<TValue> {
   noneSelectedLabel?: string;
 }
 
-export function CommonChipMultiSelect<
-  TValue extends CommonChipMultiSelectSelectValue
->({
+export function ChipRow<TValue extends ChipRowItem>({
   value,
   onValueChange,
   noneSelectedLabel = "None",
   children,
-}: PropsWithChildren<CommonChipMultiSelectProps<Array<TValue>>>) {
+}: PropsWithChildren<ChipRowProps<Array<TValue>>>) {
   return (
-    <Column>
+    <Column flex={1}>
       <Row flexWrap={"wrap"}>
         {value?.map((v) => (
           <Row key={v.value}>

--- a/packages/select/src/components/ui/ChipMultiSelect/GroupedChipMultiSelect.tsx
+++ b/packages/select/src/components/ui/ChipMultiSelect/GroupedChipMultiSelect.tsx
@@ -5,7 +5,7 @@ import {
   GroupedMultiSelectProps,
 } from "../GroupedMultiSelect";
 import { DropdownOption } from "../GroupedMultiSelectTypes";
-import { CommonChipMultiSelect } from "./CommonChipMultiSelect";
+import { ChipRow } from "./ChipRow";
 
 type StringGroupedMultiSelectProps = GroupedMultiSelectProps<string>;
 
@@ -32,7 +32,7 @@ export const GroupedChipMultiSelect = React.memo<GroupedChipMultiSelectProps>(
     ...selectProps
   }) => {
     return (
-      <CommonChipMultiSelect
+      <ChipRow
         noneSelectedLabel={noneSelectedLabel}
         onValueChange={onValueChange}
         value={value}
@@ -50,7 +50,7 @@ export const GroupedChipMultiSelect = React.memo<GroupedChipMultiSelectProps>(
           inputValue={inputValue}
           onInputChange={onInputChange}
         />
-      </CommonChipMultiSelect>
+      </ChipRow>
     );
   }
 );


### PR DESCRIPTION
- Set `ChipRow` wrapping div to flex=1, so that it expands to use full width.
- This fixes ChipMultiSelect being too narrow in filter section.
- Rename internal component `CommonChipMultiSelect` to `ChipRow`.

### Before
<img width="503" alt="Screenshot 2021-11-22 at 08 26 25" src="https://user-images.githubusercontent.com/1266041/142821220-a9bc28ea-61e4-429e-bc38-810403d3cc15.png">

### After
![image](https://user-images.githubusercontent.com/1266041/142821319-9dc14efe-5ba1-4f1f-a865-76ebfd97fc62.png)
