### PR TITLE
Widen date range fields and make width customisable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# Next
+
+## DateRangeDualTextInput
+
+- The width of the two fields can be customised using `widthLeft` and `widthRight`
+- The default width of the input fields is slightly larger to make room for the text in Firefox
+
 # 15.0.0-alpha.9
 
 ## Box

--- a/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.stories.tsx
@@ -1,4 +1,4 @@
-import { Column } from "@stenajs-webui/core";
+import { Column, Txt } from "@stenajs-webui/core";
 import { Story } from "@storybook/react";
 import { addDays, format } from "date-fns";
 import * as React from "react";
@@ -124,5 +124,32 @@ export const MinMaxDates = () => {
         {...props}
       />
     </div>
+  );
+};
+
+export const FieldWidth = () => {
+  const [value, setValue] = useState<DateRange | undefined>({
+    startDate: new Date(),
+  });
+  const props = useDateRangeCalendarState();
+
+  return (
+    <Column gap={1} alignItems={"flex-start"}>
+      <DateRangeDualTextInput
+        value={value}
+        onValueChange={setValue}
+        widthLeft={104}
+        widthRight={104}
+        {...props}
+      />
+      <Txt>
+        Notice: Firefox adds a 'remove' icon that might cover your date if the
+        input field is too short.
+      </Txt>
+      <Txt>
+        Also, Open Sans is wider than Stena Sans, so use that to measure until
+        Stena Sans is published.
+      </Txt>
+    </Column>
   );
 };

--- a/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.tsx
+++ b/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.tsx
@@ -9,7 +9,10 @@ import { isAfter } from "date-fns";
 import * as React from "react";
 import { useMemo, useRef } from "react";
 import { defaultPopoverPlacement } from "../../../config/DefaultPopoverPlacement";
-import { DualTextInput } from "../../../features/dual-text-input/DualTextInput";
+import {
+  DualTextInput,
+  DualTextInputProps,
+} from "../../../features/dual-text-input/DualTextInput";
 import { CalendarWithMonthSwitcher } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
 import { buildDayStateForSingleMonth } from "../../../util/calendar/StateModifier";
 import { useDateRangeEffects } from "./hooks/UseDateRangeEffects";
@@ -23,7 +26,8 @@ import { defaultMaxDate } from "../../../config/DefaultMaxDate";
 
 export interface DateRangeDualTextInputProps<TData = unknown>
   extends ValueAndOnValueChangeProps<DateRange>,
-    OptionalMinMaxDatesAsString {
+    OptionalMinMaxDatesAsString,
+    Pick<DualTextInputProps, "widthLeft" | "widthRight"> {
   onEsc?: () => void;
   onEnter?: () => void;
   onBlur?: () => void;
@@ -41,6 +45,8 @@ export const DateRangeDualTextInput = <TData extends {}>({
   minDate,
   maxDate = defaultMaxDate,
   calendarProps,
+  widthLeft = 128,
+  widthRight = 128,
 }: DateRangeDualTextInputProps<TData>) => {
   const { startDate, endDate } = value || {};
 
@@ -153,8 +159,8 @@ export const DateRangeDualTextInput = <TData extends {}>({
           inputRefLeft={startDateInputRef}
           inputRefRight={endDateInputRef}
           variant={startDateIsAfterEnd ? "error" : undefined}
-          widthLeft={"104px"}
-          widthRight={"104px"}
+          widthLeft={widthLeft}
+          widthRight={widthRight}
           minLeft={minDate}
           maxLeft={maxDate}
           minRight={minDate}


### PR DESCRIPTION
A first solution to the problem.

Before / After:
![Screenshot 2022-01-28 at 10 24 27](https://user-images.githubusercontent.com/6987939/151521297-00d7d05f-8a97-4898-b846-6ee18168fe41.png)
![Screenshot 2022-01-28 at 10 24 41](https://user-images.githubusercontent.com/6987939/151521295-0ce06148-948a-490c-96ee-20fd1cd2b4fe.png)
