### PR TITLE
Wrong number of tds in summary row in StandardTable

### DIFF
--- a/packages/grid/src/features/standard-table/features/summary-row/components/StandardTableSummaryRow.module.css
+++ b/packages/grid/src/features/standard-table/features/summary-row/components/StandardTableSummaryRow.module.css
@@ -1,6 +1,5 @@
 .summaryRow {
   td {
-    border-top: 1px solid var(--lhds-color-ui-500);
-    border-bottom: 1px solid var(--lhds-color-ui-500);
+    border-top: 1px solid var(--lhds-color-ui-400);
   }
 }

--- a/packages/grid/src/features/standard-table/features/summary-row/components/StandardTableSummaryRow.tsx
+++ b/packages/grid/src/features/standard-table/features/summary-row/components/StandardTableSummaryRow.tsx
@@ -5,6 +5,7 @@ import styles from "./StandardTableSummaryRow.module.css";
 import { getCellBorderFromGroup } from "../../../util/CellBorderCalculator";
 import { SummaryCell } from "./SummaryCell";
 import { getColumnsLimitedWithColSpan } from "../SummaryCellColSpanCalculator";
+import { Indent } from "@stenajs-webui/core";
 
 interface StandardTableSummaryRowProps<TItem> {
   items: Array<TItem>;
@@ -19,10 +20,16 @@ export const StandardTableSummaryRow = React.memo(
       showRowCheckbox,
       enableExpandCollapse,
       columns,
+      rowIndent,
     } = useStandardTableConfig();
 
     return (
       <tr className={styles.summaryRow}>
+        {rowIndent && (
+          <td>
+            <Indent num={rowIndent} />
+          </td>
+        )}
         {enableExpandCollapse && <td />}
         {showRowCheckbox && <td />}
         {groupConfigsAndIds.map(({ groupConfig, groupId }, groupIndex) => (
@@ -47,6 +54,12 @@ export const StandardTableSummaryRow = React.memo(
             )}
           </React.Fragment>
         ))}
+        {rowIndent && (
+          <td>
+            <Indent num={rowIndent} />
+          </td>
+        )}
+        <td />
       </tr>
     );
   }


### PR DESCRIPTION
- Fix number of tds in summary row. Now matches other rows.
- Remove bottom border in summary row, and make upper border lighter.