### PR TITLE
Task 90903: Drawer slide from top and bottom (AB#90903)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export * from "./components/heading/Heading";
 
 export * from "./types/ElementProps";
 export * from "./types/DeepPartial";
+export * from "./types/FlattenUnion";
 export * from "./types/Omit";
 export * from "./types/PickByValue";
 

--- a/packages/core/src/types/FlattenUnion.ts
+++ b/packages/core/src/types/FlattenUnion.ts
@@ -1,0 +1,17 @@
+type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
+  k: infer I
+) => void
+  ? I
+  : never;
+
+// Flattens two union types into a single type with optional values
+// i.e. FlattenUnion<{ a: number, c: number } | { b: string, c: number }> = { a?: number, b?: string, c: number }
+export type FlattenUnion<T> = {
+  [K in keyof UnionToIntersection<T>]: K extends keyof T
+    ? T[K] extends any[]
+      ? T[K]
+      : T[K] extends object
+      ? FlattenUnion<T[K]>
+      : T[K]
+    : UnionToIntersection<T>[K] | undefined;
+};

--- a/packages/modal/src/components/drawer/Drawer.module.css
+++ b/packages/modal/src/components/drawer/Drawer.module.css
@@ -6,29 +6,64 @@
 
   .content {
     box-shadow: var(--swui-shadow-modal);
+    background: white;
     position: absolute;
-    bottom: 0;
-    top: 0;
     transition: transform var(--swui-animation-time-medium) ease-in-out;
-    transform: translateX(var(--translate-x-outside-screen, 0));
-    overflow-y: auto;
+
+    &.slideFromLeft,
+    &.slideFromRight {
+      transform: translateX(var(--translate-x-outside-screen, 0));
+      overflow-y: auto;
+      top: 0;
+      bottom: 0;
+
+      &.afterOpen {
+        transform: translateX(0);
+      }
+
+      &.beforeClose {
+        transform: translateX(var(--translate-x-outside-screen));
+      }
+    }
+
+    &.slideFromTop,
+    &.slideFromBottom {
+      transform: translateY(var(--translate-y-outside-screen, 0));
+      overflow-x: auto;
+      left: 0;
+      right: 0;
+
+      &.afterOpen {
+        transform: translateY(0);
+      }
+
+      &.beforeClose {
+        transform: translateY(var(--translate-y-outside-screen));
+      }
+    }
 
     &.slideFromLeft {
       --translate-x-outside-screen: -100%;
+      width: 370px;
       left: 0;
     }
 
     &.slideFromRight {
       --translate-x-outside-screen: 100%;
+      width: 370px;
       right: 0;
     }
 
-    &.afterOpen {
-      transform: translateX(0);
+    &.slideFromTop {
+      --translate-y-outside-screen: -100%;
+      height: 370px;
+      top: 0;
     }
 
-    &.beforeClose {
-      transform: translateX(var(--translate-x-outside-screen));
+    &.slideFromBottom {
+      --translate-y-outside-screen: 100%;
+      height: 370px;
+      bottom: 0;
     }
   }
 }

--- a/packages/modal/src/components/drawer/Drawer.stories.tsx
+++ b/packages/modal/src/components/drawer/Drawer.stories.tsx
@@ -85,6 +85,65 @@ export const FromRight = () => {
   );
 };
 
+export const FromTop = () => {
+  const [isOpen, open, close] = useBoolean(false);
+
+  return (
+    <div>
+      <Drawer isOpen={isOpen} onRequestClose={close} slideFrom={"top"}>
+        <Box background={"#9198e5"} flexGrow={1} spacing={2} indent={2}>
+          Drawer content
+        </Box>
+      </Drawer>
+      <PrimaryButton label={"Open"} onClick={open} />
+      <Row justifyContent={"center"} spacing={8}>
+        <Heading>This will be below the overlay.</Heading>
+      </Row>
+    </div>
+  );
+};
+
+export const FromBottom = () => {
+  const [isOpen, open, close] = useBoolean(false);
+
+  return (
+    <div>
+      <Drawer isOpen={isOpen} onRequestClose={close} slideFrom={"bottom"}>
+        <Box background={"#9198e5"} flexGrow={1} spacing={2} indent={2}>
+          Drawer content
+        </Box>
+      </Drawer>
+      <PrimaryButton label={"Open"} onClick={open} />
+      <Row justifyContent={"center"} spacing={8}>
+        <Heading>This will be below the overlay.</Heading>
+      </Row>
+    </div>
+  );
+};
+
+export const CustomHeight = () => {
+  const [isOpen, open, close] = useBoolean(false);
+
+  return (
+    <div>
+      <Drawer
+        isOpen={isOpen}
+        onRequestClose={close}
+        slideFrom={"bottom"}
+        height={"100px"}
+      >
+        <Box background={"#9198e5"} flexGrow={1} spacing={2} indent={2}>
+          Drawer content
+        </Box>
+      </Drawer>
+      <PrimaryButton label={"Open"} onClick={open} />
+      <Row justifyContent={"center"} spacing={8}>
+        <Heading>This will be below the overlay.</Heading>
+      </Row>
+    </div>
+  );
+};
+
 export const WithScroll = () => {
   const [isOpen, open, close] = useBoolean(false);
 

--- a/packages/modal/src/components/drawer/Drawer.tsx
+++ b/packages/modal/src/components/drawer/Drawer.tsx
@@ -1,12 +1,36 @@
 import * as React from "react";
 import ReactModal from "react-modal";
 import cx from "classnames";
-
 import styles from "./Drawer.module.css";
+import { exhaustSwitchCase } from "@stenajs-webui/core";
 
-export type SlideFrom = "left" | "right";
+export type SlideFrom = SlideFromLeftRight | SlideFromTopBottom;
+export type SlideFromLeftRight = "left" | "right";
+export type SlideFromTopBottom = "top" | "bottom";
 
-export interface DrawerProps
+export type DrawerProps = DrawerBaseLeftRight | DrawerBaseTopBottom;
+
+interface DrawerBaseLeftRight extends DrawerBaseProps {
+  width?: string;
+  /**
+   * Which direction the drawer will appear from.
+   * @default left
+   * @param {String('left'|'right')}
+   */
+  slideFrom?: SlideFromLeftRight;
+}
+
+interface DrawerBaseTopBottom extends DrawerBaseProps {
+  height?: string;
+  /**
+   * Which direction the drawer will appear from.
+   * @default left
+   * @param {String('top'|'bottom')}
+   */
+  slideFrom?: SlideFromTopBottom;
+}
+
+interface DrawerBaseProps
   extends Omit<
     ReactModal.Props,
     | "closeTimeoutMS"
@@ -16,16 +40,9 @@ export interface DrawerProps
     | "style"
     | "parentSelector"
   > {
-  width?: string;
   background?: string;
   zIndex?: number;
   onRequestClose?: () => void;
-  /**
-   * Which direction the drawer will appear from.
-   * @default left
-   * @param {String('left'|'right')}
-   */
-  slideFrom?: SlideFrom;
   /**
    * Portal target, HTML element. If not set, portal is not used.
    */
@@ -33,7 +50,6 @@ export interface DrawerProps
 }
 
 export const Drawer: React.FC<DrawerProps> = ({
-  width = "370px",
   background,
   zIndex,
   children,
@@ -41,6 +57,10 @@ export const Drawer: React.FC<DrawerProps> = ({
   portalTarget,
   ...reactModalProps
 }) => {
+  const height =
+    "height" in reactModalProps ? reactModalProps.height : undefined;
+  const width = "width" in reactModalProps ? reactModalProps.width : undefined;
+
   return (
     <ReactModal
       closeTimeoutMS={250}
@@ -51,18 +71,30 @@ export const Drawer: React.FC<DrawerProps> = ({
         beforeClose: styles.beforeClose,
       }}
       className={{
-        base: cx(
-          styles.content,
-          slideFrom === "left" ? styles.slideFromLeft : styles.slideFromRight
-        ),
+        base: cx(styles.content, getClassNameForSlide(slideFrom)),
         afterOpen: styles.afterOpen,
         beforeClose: styles.beforeClose,
       }}
-      style={{ content: { width, background }, overlay: { zIndex } }}
+      style={{ content: { width, height, background }, overlay: { zIndex } }}
       parentSelector={portalTarget ? () => portalTarget : undefined}
       {...reactModalProps}
     >
       {children}
     </ReactModal>
   );
+};
+
+const getClassNameForSlide = (slideFrom: SlideFrom): string => {
+  switch (slideFrom) {
+    case "left":
+      return styles.slideFromLeft;
+    case "right":
+      return styles.slideFromRight;
+    case "top":
+      return styles.slideFromTop;
+    case "bottom":
+      return styles.slideFromBottom;
+    default:
+      return exhaustSwitchCase(slideFrom, styles.slideFromLeft);
+  }
 };

--- a/packages/modal/src/components/drawer/Drawer.tsx
+++ b/packages/modal/src/components/drawer/Drawer.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import ReactModal from "react-modal";
 import cx from "classnames";
 import styles from "./Drawer.module.css";
-import { exhaustSwitchCase } from "@stenajs-webui/core";
+import { exhaustSwitchCase, FlattenUnion } from "@stenajs-webui/core";
 
 export type SlideFrom = SlideFromLeftRight | SlideFromTopBottom;
 export type SlideFromLeftRight = "left" | "right";
@@ -57,9 +57,7 @@ export const Drawer: React.FC<DrawerProps> = ({
   portalTarget,
   ...reactModalProps
 }) => {
-  const height =
-    "height" in reactModalProps ? reactModalProps.height : undefined;
-  const width = "width" in reactModalProps ? reactModalProps.width : undefined;
+  const { height, width } = reactModalProps as FlattenUnion<DrawerProps>;
 
   return (
     <ReactModal


### PR DESCRIPTION
- Add support for `top` and `bottom` values for `slideFrom`.
- Add stories that showcase this.
- `height` can only be set when using `top` or `bottom`, `width` can only be set when using `left` or `right`.
- Drawer background defaults to white instead of transparent.

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/1266041/161504256-a7e0d7d7-ec87-4b5c-b2bc-939c8205edb6.png">
