### PR TITLE
Fix event propagation bug in onKeyDown in StandardTable

### DIFF
--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -102,12 +102,8 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
 
   const onKeyDownHandler = useCallback<KeyboardEventHandler<HTMLDivElement>>(
     (ev) => {
-      onKeyDownTable?.(ev, { columnId, item });
       onKeyDownCell?.(ev, { columnId, item });
-      if (ev.key !== "Tab" && (onKeyDownTable || onKeyDownCell)) {
-        ev.preventDefault();
-        ev.stopPropagation();
-      }
+      onKeyDownTable?.(ev, { columnId, item });
     },
     [onKeyDownTable, columnId, item, onKeyDownCell]
   );

--- a/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
@@ -107,7 +107,9 @@ export const BackgroundResolver = () => {
 };
 
 export const CellOnKeyDown = () => {
-  const { items, onChangeActive } = useListState(mockedItems);
+  const { items, onChangeActive, onChangeNumPassengers } = useListState(
+    mockedItems
+  );
 
   const config: StandardTableConfig<ListItem, keyof ListItem> = {
     ...standardTableConfigForStories,
@@ -128,6 +130,15 @@ export const CellOnKeyDown = () => {
           </Indent>
         ),
       }),
+      numPassengers: {
+        ...standardTableConfigForStories.columns.numPassengers,
+        onKeyDown: (ev, { item }) => {
+          if (ev.key === "Delete") {
+            onChangeNumPassengers(item, undefined);
+          }
+        },
+        onChange: onChangeNumPassengers,
+      },
     },
   };
   return <StandardTable items={items} config={config} />;


### PR DESCRIPTION
- No longer stopping propagation and default for onKeyDown events in StandardTable, since it breaks input fields in the table.