### PR TITLE
Improve spacing in PageHeader when there are no tabs

### DIFF
--- a/packages/panels/src/components/page-header/PageHeader.stories.tsx
+++ b/packages/panels/src/components/page-header/PageHeader.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { PageHeader, PageHeaderRow } from "./PageHeader";
+import { Fragment, useState } from "react";
+import { PageHeader } from "./PageHeader";
 import {
   BreadCrumbs,
   Chip,
@@ -12,11 +13,11 @@ import {
 } from "@stenajs-webui/elements";
 import { PageHeading, PageHeadingVariant } from "./PageHeading";
 import { Box, Heading, Row, Space } from "@stenajs-webui/core";
-import { Fragment, useState } from "react";
 import { TextInput } from "@stenajs-webui/forms";
 import { faSlidersH } from "@fortawesome/free-solid-svg-icons/faSlidersH";
 import { NavBar } from "../nav-bar/NavBar";
 import { cssColor } from "@stenajs-webui/theme";
+import { PageHeaderRow } from "./PageHeaderRow";
 
 export default {
   title: "panels/PageHeader",
@@ -80,6 +81,28 @@ export const Demo = () => {
   );
 };
 
+export const NoTabsOrHeadingContent = () => {
+  return (
+    <PageHeader
+      renderBreadCrumbs={() => (
+        <BreadCrumbs>
+          <Crumb label={"Home"} />
+          <Crumb label={"Customer"} />
+          <Crumb label={"Booking"} />
+        </BreadCrumbs>
+      )}
+      renderPageHeading={() => <PageHeading heading={"Page Header"} />}
+    >
+      <PageHeaderRow gap={2}>
+        <Box>
+          <TextInput />
+        </Box>
+        <PrimaryButton label={"Action"} />
+      </PageHeaderRow>
+    </PageHeader>
+  );
+};
+
 export const Variants = () => {
   const variants: PageHeadingVariant[] = ["compact", "default", "relaxed"];
   const [tabId, setTabId] = useState(0);
@@ -128,6 +151,32 @@ export const Variants = () => {
           </TabMenu>
         )}
       />
+      <Space num={4} />
+    </Fragment>
+  ));
+};
+
+export const VariantsWithNoHeadingContent = () => {
+  const variants: PageHeadingVariant[] = ["compact", "default", "relaxed"];
+
+  return variants.map((variant) => (
+    <Fragment key={variant}>
+      <PageHeader
+        renderBreadCrumbs={() => (
+          <BreadCrumbs>
+            <Crumb label={"Home"} />
+            <Crumb label={"Customer"} />
+            <Crumb label={"Booking"} />
+          </BreadCrumbs>
+        )}
+        renderPageHeading={() => (
+          <PageHeading heading={variant} variant={variant} />
+        )}
+      >
+        <PageHeaderRow>
+          <TextInput />
+        </PageHeaderRow>
+      </PageHeader>
       <Space num={4} />
     </Fragment>
   ));

--- a/packages/panels/src/components/page-header/PageHeader.stories.tsx
+++ b/packages/panels/src/components/page-header/PageHeader.stories.tsx
@@ -104,7 +104,7 @@ export const NoTabsOrHeadingContent = () => {
 };
 
 export const Variants = () => {
-  const variants: PageHeadingVariant[] = ["compact", "default", "relaxed"];
+  const variants: PageHeadingVariant[] = ["compact", "standard", "relaxed"];
   const [tabId, setTabId] = useState(0);
 
   return variants.map((variant) => (
@@ -157,7 +157,7 @@ export const Variants = () => {
 };
 
 export const VariantsWithNoHeadingContent = () => {
-  const variants: PageHeadingVariant[] = ["compact", "default", "relaxed"];
+  const variants: PageHeadingVariant[] = ["compact", "standard", "relaxed"];
 
   return variants.map((variant) => (
     <Fragment key={variant}>

--- a/packages/panels/src/components/page-header/PageHeader.tsx
+++ b/packages/panels/src/components/page-header/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { Box, BoxProps, Row, SeparatorLine } from "@stenajs-webui/core";
+import { Box, Row, SeparatorLine, Space } from "@stenajs-webui/core";
 import * as React from "react";
 import { ReactNode } from "react";
 
@@ -7,10 +7,6 @@ export interface PageHeaderProps {
   renderPageHeading?: () => ReactNode;
   renderTabs?: () => ReactNode;
 }
-
-export const PageHeaderRow: React.FC<BoxProps> = (props) => (
-  <Row indent={3} spacing {...props} />
-);
 
 export const PageHeader: React.FC<PageHeaderProps> = ({
   renderBreadCrumbs,
@@ -27,6 +23,7 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
       </Box>
       {children && (
         <>
+          {!renderTabs && <Space />}
           <SeparatorLine />
           {children}
         </>

--- a/packages/panels/src/components/page-header/PageHeaderRow.tsx
+++ b/packages/panels/src/components/page-header/PageHeaderRow.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+import { BoxProps, Row } from "@stenajs-webui/core";
+
+export interface PageHeaderRowProps extends BoxProps {}
+
+export const PageHeaderRow: React.FC<PageHeaderRowProps> = (props) => (
+  <Row indent={3} spacing {...props} />
+);

--- a/packages/panels/src/components/page-header/PageHeading.tsx
+++ b/packages/panels/src/components/page-header/PageHeading.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { ReactNode } from "react";
 import { Heading, Row } from "@stenajs-webui/core";
 
-export type PageHeadingVariant = "compact" | "default" | "relaxed";
+export type PageHeadingVariant = "compact" | "standard" | "relaxed";
 
 interface PageHeadingProps {
   contentLeft?: ReactNode;
@@ -13,13 +13,13 @@ interface PageHeadingProps {
 
 const variantToSpacing: Record<PageHeadingVariant, number> = {
   compact: 1,
-  default: 1.5,
+  standard: 1.5,
   relaxed: 2,
 };
 
 export const PageHeading: React.VFC<PageHeadingProps> = ({
   heading,
-  variant = "default",
+  variant = "standard",
   contentLeft,
   contentRight,
 }) => (

--- a/packages/panels/src/index.ts
+++ b/packages/panels/src/index.ts
@@ -20,6 +20,7 @@ export * from "./components/error-panel/ErrorScreen";
 export * from "./components/loading-panel/LoadingPanel";
 export * from "./components/loading-panel/LoadingScreen";
 export * from "./components/page-header/PageHeader";
+export * from "./components/page-header/PageHeaderRow";
 export * from "./components/page-header/PageHeading";
 export * from "./components/sidebar-menu/SidebarMenu";
 export * from "./components/sidebar-menu/SidebarMenuHeading";


### PR DESCRIPTION
- Improve spacing between children and heading when there are no tabs.
- Extract PageHeaderRow into own file.

## Before

<img width="281" alt="image" src="https://user-images.githubusercontent.com/1266041/162805653-a61614b4-7f24-43fd-892c-4535462eea97.png">


## After

<img width="415" alt="image" src="https://user-images.githubusercontent.com/1266041/162805547-fda627d5-5b9c-4332-89d9-88cabcd54ee7.png">
