### PR TITLE
Accessible font-sizes using `rem` instead of `px`

### DIFF
--- a/packages/core/src/components/heading/Heading.module.css
+++ b/packages/core/src/components/heading/Heading.module.css
@@ -8,35 +8,35 @@
   font-weight: var(--swui-font-weight-text);
 
   &.h1 {
-    --swui-heading-font-size: 28px;
-    --swui-heading-line-height: 40px;
+    --swui-heading-font-size: 2.8rem;
+    --swui-heading-line-height: 4.0rem;
   }
 
   &.h2 {
-    --swui-heading-font-size: 24px;
-    --swui-heading-line-height: 32px;
+    --swui-heading-font-size: 2.4rem;
+    --swui-heading-line-height: 3.2rem;
   }
 
   &.h3 {
-    --swui-heading-font-size: 20px;
-    --swui-heading-line-height: 24px;
+    --swui-heading-font-size: 2.0rem;
+    --swui-heading-line-height: 2.4rem;
   }
 
   &.h4 {
-    --swui-heading-font-size: 16px;
-    --swui-heading-line-height: 24px;
+    --swui-heading-font-size: 1.6rem;
+    --swui-heading-line-height: 2.4rem;
     font-weight: var(--swui-font-weight-text-bold);
   }
 
   &.h5 {
-    --swui-heading-font-size: 14px;
-    --swui-heading-line-height: 16px;
+    --swui-heading-font-size: 1.4rem;
+    --swui-heading-line-height: 1.6rem;
     font-weight: var(--swui-font-weight-text-bold);
   }
 
   &.h6 {
-    --swui-heading-font-size: 12px;
-    --swui-heading-line-height: 16px;
+    --swui-heading-font-size: 1.2rem;
+    --swui-heading-line-height: 1.6rem;
     font-weight: var(--swui-font-weight-text-bold);
   }
 }

--- a/packages/core/src/components/heading/Heading.module.css
+++ b/packages/core/src/components/heading/Heading.module.css
@@ -9,7 +9,7 @@
 
   &.h1 {
     --swui-heading-font-size: 2.8rem;
-    --swui-heading-line-height: 4.0rem;
+    --swui-heading-line-height: 4rem;
   }
 
   &.h2 {
@@ -18,7 +18,7 @@
   }
 
   &.h3 {
-    --swui-heading-font-size: 2.0rem;
+    --swui-heading-font-size: 2rem;
     --swui-heading-line-height: 2.4rem;
   }
 

--- a/packages/core/src/components/text/Text.module.css
+++ b/packages/core/src/components/text/Text.module.css
@@ -41,7 +41,7 @@
     --current-line-height: var(--swui-line-height-smaller);
     --current-color: var(--swui-text-color-overline);
     --current-font-weight: var(--swui-font-weight-text-bold);
-    --current-letter-spacing: 1px;
+    --current-letter-spacing: 0.1rem;
     text-transform: uppercase;
   }
 

--- a/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
+++ b/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
@@ -3,7 +3,7 @@
   font-size: 1rem;
   font-family: var(--swui-font-primary);
   font-weight: var(--swui-font-weight-text-bold);
-  letter-spacing: 1px;
+  letter-spacing: 0.1rem;
   text-decoration: none;
   cursor: pointer;
 }

--- a/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
+++ b/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
@@ -1,6 +1,6 @@
 .crumb {
   color: var(--swui-text-action-color);
-  font-size: 1.0rem;
+  font-size: 1rem;
   font-family: var(--swui-font-primary);
   font-weight: var(--swui-font-weight-text-bold);
   letter-spacing: 1px;

--- a/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
+++ b/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
@@ -1,6 +1,6 @@
 .crumb {
   color: var(--swui-text-action-color);
-  font-size: 10px;
+  font-size: 1.0rem;
   font-family: var(--swui-font-primary);
   font-weight: var(--swui-font-weight-text-bold);
   letter-spacing: 1px;

--- a/packages/elements/src/components/ui/buttons/Button.module.css
+++ b/packages/elements/src/components/ui/buttons/Button.module.css
@@ -28,8 +28,8 @@
   );
 
   /* Icon */
-  --swui-button-icon-height: 1.6em;
-  --swui-button-icon-height-large: 2.4em;
+  --swui-button-icon-height: 1.6rem;
+  --swui-button-icon-height-large: 2.4rem;
 
   --swui-button-icon-color: var(--swui-white);
   --swui-button-icon-color-focus: var(--swui-button-icon-color);

--- a/packages/elements/src/components/ui/buttons/Button.module.css
+++ b/packages/elements/src/components/ui/buttons/Button.module.css
@@ -1,8 +1,7 @@
 .button {
   /* Theme vars */
-  --swui-button-line-height: 16px;
+  --swui-button-line-height: 1.6rem;
   --swui-button-font-weight: 400;
-  --swui-button-icon-color: var(--swui-white);
   --swui-button-text-size: var(--swui-font-size-medium);
   --swui-button-text-color: var(--swui-white);
   --swui-button-text-decoration: none;
@@ -29,6 +28,10 @@
   );
 
   /* Icon */
+  --swui-button-icon-height: 1.6em;
+  --swui-button-icon-height-large: 2.4em;
+
+  --swui-button-icon-color: var(--swui-white);
   --swui-button-icon-color-focus: var(--swui-button-icon-color);
   --swui-button-icon-color-hover: var(--swui-button-icon-color);
   --swui-button-icon-color-active: var(--swui-button-icon-color);
@@ -113,7 +116,7 @@
    * Styling
    */
   --current-background-color: var(--swui-button-background-color);
-  --current-icon-height: 16px;
+  --current-icon-height: var(--swui-button-icon-height);
   --current-icon-color: var(--swui-button-icon-color);
   --current-text-color: var(--swui-button-text-color);
   --current-border-color: var(--swui-button-border-color);
@@ -167,20 +170,20 @@
    */
 
   &.small {
-    --current-line-height: 16px;
+    --current-line-height: 1.6rem;
     --swui-button-padding-vertical: calc(var(--swui-metrics-space) / 2 - 1px);
     --swui-button-padding-horizontal: calc(var(--swui-metrics-space) - 1px);
-    --current-text-size: 12px;
+    --current-text-size: 1.2rem;
   }
 
   &.large {
-    --current-line-height: 24px;
+    --current-line-height: 2.4rem;
     --swui-button-padding-vertical: calc(var(--swui-metrics-space) - 1px);
     --swui-button-padding-horizontal: calc(var(--swui-metrics-space) * 3 - 1px);
-    --current-text-size: 16px;
+    --current-text-size: 1.6rem;
 
     &.iconButton {
-      --current-icon-height: 24px;
+      --current-icon-height: var(--swui-button-icon-height-large);
     }
   }
 

--- a/packages/elements/src/components/ui/chip/Chip.module.css
+++ b/packages/elements/src/components/ui/chip/Chip.module.css
@@ -28,7 +28,7 @@
     font-weight: var(--swui-chip-font-weight);
     line-height: var(--swui-chip-line-height);
     color: var(--current-text-color);
-    height: var(--swui-chip-height);
+    min-height: var(--swui-chip-height);
     display: flex;
     align-items: center;
   }

--- a/packages/elements/src/components/ui/link/Link.module.css
+++ b/packages/elements/src/components/ui/link/Link.module.css
@@ -78,7 +78,7 @@
   &.overline {
     --current-font-size: var(--swui-font-size-smaller);
     --current-line-height: var(--swui-line-height-smaller);
-    --current-letter-spacing: 1px;
+    --current-letter-spacing: 0.1rem;
     text-transform: uppercase;
   }
 

--- a/packages/elements/src/components/ui/tag/Tag.module.css
+++ b/packages/elements/src/components/ui/tag/Tag.module.css
@@ -28,7 +28,7 @@
   font-weight: var(--swui-tag-font-weight);
   line-height: var(--swui-tag-line-height);
   color: var(--current-text-color);
-  height: var(--current-height);
+  min-height: var(--current-height);
   align-items: center;
   padding: 0 var(--swui-metrics-space);
 

--- a/packages/forms/src/components/ui/checkbox/Checkbox.module.css
+++ b/packages/forms/src/components/ui/checkbox/Checkbox.module.css
@@ -172,7 +172,7 @@
   }
 
   & + label {
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: var(--swui-checkbox-height);
     display: inline-block;
     vertical-align: top;

--- a/packages/forms/src/components/ui/radio/RadioButton.module.css
+++ b/packages/forms/src/components/ui/radio/RadioButton.module.css
@@ -139,7 +139,7 @@
   }
 
   & + label {
-    font-size: 14px;
+    font-size: 1.4rem;
     line-height: var(--swui-radiobutton-size-standard);
     display: inline-block;
     vertical-align: top;

--- a/packages/panels/src/components/collapsible/Collapsible.module.css
+++ b/packages/panels/src/components/collapsible/Collapsible.module.css
@@ -159,7 +159,7 @@
       color: var(--swui-collapsible-groupheading-text-color);
       text-transform: uppercase;
       font-weight: var(--swui-font-weight-text-bold);
-      letter-spacing: 1px;
+      letter-spacing: 0.1rem;
     }
 
     [data-hidden="true"] {

--- a/packages/panels/src/components/nav-bar/NavBarSearchField.module.css
+++ b/packages/panels/src/components/nav-bar/NavBarSearchField.module.css
@@ -1,5 +1,5 @@
 .navBarSearchFieldInput {
-  --swui-textinput-line-height: 27px;
+  --swui-textinput-line-height: 2.7rem;
   --swui-textinput-text-color: var(--lhds-color-ui-50);
 
   &:focus {

--- a/packages/panels/src/components/sidebar-menu/SidebarMenuContent.module.css
+++ b/packages/panels/src/components/sidebar-menu/SidebarMenuContent.module.css
@@ -8,7 +8,7 @@
 
 .icon {
   color: var(--current-text-color);
-  font-size: 16px;
+  font-size: 1.6rem;
 }
 
 .spinner {

--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -1,3 +1,4 @@
+import "./styles/base.css";
 import "./styles/default-colors.css";
 import "./styles/default-theme.css";
 

--- a/packages/theme/src/styles/base.css
+++ b/packages/theme/src/styles/base.css
@@ -1,0 +1,3 @@
+:root {
+  font-size: 62.5%;
+}

--- a/packages/theme/src/styles/default-theme.css
+++ b/packages/theme/src/styles/default-theme.css
@@ -34,15 +34,15 @@
   --swui-font-weight-link: 400;
   --swui-font-buttons: var(--swui-font-primary);
   --swui-font-input: var(--swui-font-primary);
-  --swui-font-size-inputs: 14px;
-  --swui-font-size-large: 16px;
-  --swui-line-height-large: 24px;
-  --swui-font-size-medium: 14px;
-  --swui-line-height-medium: 16px;
-  --swui-font-size-small: 12px;
-  --swui-line-height-small: 16px;
-  --swui-font-size-smaller: 10px;
-  --swui-line-height-smaller: 16px;
+  --swui-font-size-inputs: 1.4rem;
+  --swui-font-size-large: 1.6rem;
+  --swui-line-height-large: 2.4rem;
+  --swui-font-size-medium: 1.4rem;
+  --swui-line-height-medium: 1.6rem;
+  --swui-font-size-small: 1.2rem;
+  --swui-line-height-small: 1.6rem;
+  --swui-font-size-smaller: 1rem;
+  --swui-line-height-smaller: 1.6rem;
   --swui-font-weight-inputs: 400;
 
   /* Text */

--- a/packages/theme/src/styles/default-theme.css
+++ b/packages/theme/src/styles/default-theme.css
@@ -68,7 +68,7 @@
   --swui-field-text-color-disabled: var(--lhds-color-ui-700);
   --swui-field-text-spacing: 6px;
   --swui-field-letter-spacing: 0;
-  --swui-field-text-line-height: 20px;
+  --swui-field-text-line-height: 2rem;
   --swui-field-bg-enabled: var(--swui-white);
   --swui-field-bg-disabled: #e8e4ea;
   --swui-field-border-color: #bbc1e1;


### PR DESCRIPTION
- Add base.css which contains .... base CSS stuff. Only font-size for now.
- Set `font-size: 62.5%` on root, which makes it easy to move from `px` to `rem`. `24px` = `2.4rem`.
- Update font-sizes to use `rem` unit instead of `px`.
- Update `Chip` and `Tag` to use `min-height` instead of `height`, so that they expand if font gets larger.

Some components might have icons that need updating as well. This PR does not contain that, except for buttons. Button icons scale as well.

![image](https://user-images.githubusercontent.com/1266041/171179580-80a136b2-74cd-4101-ac1e-fa19c4e0ac28.png)
