### PR TITLE
Fix misaligned StandardTable header when rowCheckbox is true and headerCheckbox is false

### DIFF
--- a/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
@@ -55,6 +55,7 @@ export const StandardTableHeadRow = React.memo(function StandardTableHeadRow<
     zIndex,
     stickyHeader,
     stickyCheckboxColumn,
+    showRowCheckbox,
   } = useStandardTableConfig();
 
   const columnGroupOrder = useColumnGroupOrderContext();
@@ -123,7 +124,7 @@ export const StandardTableHeadRow = React.memo(function StandardTableHeadRow<
           </Row>
         </th>
       )}
-      {showHeaderCheckbox && (
+      {(showRowCheckbox || showHeaderCheckbox) && (
         <th
           style={{
             ...stickyHeaderStyle,
@@ -142,13 +143,15 @@ export const StandardTableHeadRow = React.memo(function StandardTableHeadRow<
             alignItems={"center"}
             justifyContent={"center"}
           >
-            <Checkbox
-              size={"small"}
-              disabled={checkboxDisabled}
-              value={allItemsAreSelected}
-              indeterminate={!selectionIsEmpty && !allItemsAreSelected}
-              onValueChange={onClickCheckbox}
-            />
+            {showHeaderCheckbox && (
+              <Checkbox
+                size={"small"}
+                disabled={checkboxDisabled}
+                value={allItemsAreSelected}
+                indeterminate={!selectionIsEmpty && !allItemsAreSelected}
+                onValueChange={onClickCheckbox}
+              />
+            )}
           </Row>
         </th>
       )}

--- a/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
@@ -83,6 +83,25 @@ export const Variants = () => {
   );
 };
 
+export const WithoutCheckboxInHeader = () => {
+  const { items, onChangeNumPassengers } = useListState(mockedItems);
+
+  const config: StandardTableConfig<ListItem, keyof ListItem> = {
+    ...standardTableConfigForStories,
+    showHeaderCheckbox: false,
+    checkboxDisabledResolver: (item) => item.id === "125",
+    columns: {
+      ...standardTableConfigForStories.columns,
+      numPassengers: {
+        ...standardTableConfigForStories.columns.numPassengers,
+        onChange: onChangeNumPassengers,
+      },
+    },
+  };
+
+  return <StandardTable items={items} config={config} />;
+};
+
 export const BackgroundResolver = () => {
   const { items, onChangeNumPassengers } = useListState(mockedItems);
 


### PR DESCRIPTION
Fix misaligned StandardTable header when `showRowCheckbox=true` and `showHeaderCheckbox=false`