### PR TITLE
`SearchFilterDrawer` pass `header` prop down to `SearchFilterPanelHeader`

### DIFF
--- a/packages/filter/src/features/search-filter/components/SearchFilterDrawer.tsx
+++ b/packages/filter/src/features/search-filter/components/SearchFilterDrawer.tsx
@@ -37,7 +37,7 @@ export const SearchFilterDrawer: React.FC<SearchFilterDrawerProps> = ({
       {...drawerProps}
     >
       <Column>
-        <SearchFilterPanelHeader onRequestClose={closeDrawer} />
+        <SearchFilterPanelHeader onRequestClose={closeDrawer} header={header} />
         <SeparatorLine />
         {children}
       </Column>


### PR DESCRIPTION
Added header props that's an optional prop for SearchFilterPanelHeader, it was requested by Emil.