### PR TITLE
Do not render space below heading if PageHeader has no breadcrumbs

### DIFF
--- a/packages/panels/src/components/page-header/PageHeader.stories.tsx
+++ b/packages/panels/src/components/page-header/PageHeader.stories.tsx
@@ -187,6 +187,29 @@ export const VariantsWithNoHeadingContent = () => {
   ));
 };
 
+export const VariantsWithNoBreadCrumbs = () => {
+  const variants: PageHeadingVariant[] = ["compact", "standard", "relaxed"];
+
+  return (
+    <Box background={cssColor("--lhds-color-ui-300")}>
+      {variants.map((variant) => (
+        <Fragment key={variant}>
+          <PageHeader
+            renderPageHeading={() => (
+              <PageHeading heading={variant} variant={variant} />
+            )}
+          >
+            <PageHeaderRow>
+              <TextInput />
+            </PageHeaderRow>
+          </PageHeader>
+          <Space num={4} />
+        </Fragment>
+      ))}
+    </Box>
+  );
+};
+
 export const BreadCrumbsAndHeading = () => {
   return (
     <>

--- a/packages/panels/src/components/page-header/PageHeader.tsx
+++ b/packages/panels/src/components/page-header/PageHeader.tsx
@@ -25,7 +25,7 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
       </Box>
       {children && (
         <>
-          {!renderTabs && <Space />}
+          {!renderTabs && renderBreadCrumbs && <Space />}
           <SeparatorLine />
           {children}
         </>


### PR DESCRIPTION
Before:
![Screenshot 2022-08-17 at 10 31 12](https://user-images.githubusercontent.com/6987939/185072825-8e7fc7f1-c2b0-4ded-b916-d75ccc32bec6.png)

After:
![Screenshot 2022-08-17 at 10 31 36](https://user-images.githubusercontent.com/6987939/185072808-7dd2939f-d9c9-41da-9026-99090097c975.png)

