### PR TITLE
Bring back lost font family to Select group heading

### DIFF
--- a/packages/select/src/util/StylesBuilder.ts
+++ b/packages/select/src/util/StylesBuilder.ts
@@ -184,6 +184,7 @@ export const createStylesFromTheme = <
   }),
   groupHeading: (base) => ({
     ...base,
+    fontFamily: input.fontFamily,
     fontSize: groupHeading.fontSize,
     lineHeight: groupHeading.lineHeight,
     fontWeight: groupHeading.fontWeight as any,


### PR DESCRIPTION
Before:
<img width="363" alt="Screenshot 2022-08-22 at 11 37 37" src="https://user-images.githubusercontent.com/6987939/185891381-fb77a077-5b63-47a9-b808-187d8ae82f28.png">

After:
<img width="355" alt="Screenshot 2022-08-22 at 11 36 22" src="https://user-images.githubusercontent.com/6987939/185891403-5fce5177-19df-4766-bd2e-cc36f0547e13.png">

