### PR TITLE
Only use cssInjectedByJsPlugin in production

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -27,8 +27,12 @@ module.exports = {
     },
   ],
   viteFinal(config, { configType }) {
-    return mergeConfig(config, {
-      plugins: [svgr(), cssInjectedByJsPlugin({ topExecutionPriority: false })],
-    });
+    let plugins = [svgr()];
+
+    if (configType === "PRODUCTION") {
+      plugins.push(cssInjectedByJsPlugin({ topExecutionPriority: false }));
+    }
+
+    return mergeConfig(config, { plugins });
   },
 };


### PR DESCRIPTION
- This fixes the error which causes the Docs tab to crash when trying to import the iframe css file
