### PR TITLE
Remove link styling for last-of-type (fixes AB#97856)

### DIFF
--- a/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
+++ b/packages/elements/src/components/ui/bread-crumbs/Crumb.module.css
@@ -1,23 +1,26 @@
 .crumb {
-  color: var(--swui-text-action-color);
   font-size: 1rem;
   font-family: var(--swui-font-primary);
   font-weight: var(--swui-font-weight-text-bold);
   letter-spacing: 0.1rem;
   text-decoration: none;
-  cursor: pointer;
-}
 
-.crumb:hover {
-  text-decoration: underline;
-  color: var(--swui-text-action-color-hover);
-}
+  &:not(:last-of-type) {
+    cursor: pointer;
+    color: var(--swui-text-action-color);
 
-.crumb:focus {
-  color: var(--swui-text-action-color-focus);
-}
+    &:hover {
+      text-decoration: underline;
+      color: var(--swui-text-action-color-hover);
+    }
 
-.crumb:active {
-  text-decoration: underline;
-  color: var(--swui-text-action-color-active);
+    &:focus {
+      color: var(--swui-text-action-color-focus);
+    }
+
+    &:active {
+      text-decoration: underline;
+      color: var(--swui-text-action-color-active);
+    }
+  }
 }


### PR DESCRIPTION
<img width="304" alt="image" src="https://user-images.githubusercontent.com/817046/187225754-60542f7b-f57b-4a80-bbce-8dc06fdb5b12.png">
