### PR TITLE
Add top content render option to let navbar render messages easier

### DIFF
--- a/packages/panels/src/components/page-header/PageHeader.stories.tsx
+++ b/packages/panels/src/components/page-header/PageHeader.stories.tsx
@@ -11,6 +11,7 @@ import {
   TabMenu,
   Tag,
   stenaSliders,
+  Banner,
 } from "@stenajs-webui/elements";
 import { PageHeading, PageHeadingVariant } from "./PageHeading";
 import { Box, Heading, Row, Space } from "@stenajs-webui/core";
@@ -19,6 +20,7 @@ import { TextInput } from "@stenajs-webui/forms";
 import { NavBar } from "../nav-bar/NavBar";
 import { cssColor } from "@stenajs-webui/theme";
 import { PageHeaderRow } from "./PageHeaderRow";
+import { ErrorScreen } from "../error-panel/ErrorScreen";
 
 export default {
   title: "panels/PageHeader",
@@ -100,6 +102,38 @@ export const NoTabsOrHeadingContent = () => {
         </Box>
         <PrimaryButton label={"Action"} />
       </PageHeaderRow>
+    </PageHeader>
+  );
+};
+
+export const TopAndBotContent = () => {
+  return (
+    <PageHeader
+      TopContent={
+        <Banner
+          variant={"error"}
+          headerText={"Oh noes! There's an error here!"}
+        />
+      }
+      renderBreadCrumbs={() => (
+        <BreadCrumbs>
+          <Crumb label={"Home"} />
+          <Crumb label={"Customer"} />
+          <Crumb label={"Booking"} />
+        </BreadCrumbs>
+      )}
+      renderPageHeading={() => <PageHeading heading={"Page Header"} />}
+    >
+      <PageHeaderRow gap={2}>
+        <Box>
+          <TextInput />
+        </Box>
+        <PrimaryButton label={"Action"} />
+      </PageHeaderRow>
+      <Banner
+        variant={"info"}
+        headerText={"Having errors in the code is not good."}
+      />
     </PageHeader>
   );
 };

--- a/packages/panels/src/components/page-header/PageHeader.tsx
+++ b/packages/panels/src/components/page-header/PageHeader.tsx
@@ -7,6 +7,7 @@ export interface PageHeaderProps {
   renderBreadCrumbs?: () => ReactNode;
   renderPageHeading?: () => ReactNode;
   renderTabs?: () => ReactNode;
+  TopContent?: ReactNode;
   children?: ReactNode;
 }
 
@@ -14,10 +15,12 @@ export const PageHeader: React.FC<PageHeaderProps> = ({
   renderBreadCrumbs,
   renderPageHeading,
   renderTabs,
+  TopContent,
   children,
 }) => {
   return (
     <Box shadow={"box"} background={cssColor("--lhds-color-ui-50")}>
+      {TopContent}
       <Box indent={3}>
         {renderBreadCrumbs && <Row spacing={1.25}>{renderBreadCrumbs()}</Row>}
         {renderPageHeading?.()}


### PR DESCRIPTION
We have a PBI that needs an easy way to show error messages at the top of the screen, so adding an option to render top content for the PageHeader would help a lot.
https://stenait.visualstudio.com/Freightlink/_workitems/edit/97581/