### PR TITLE
Allow choice of headingLevel in CardHeader

### DIFF
--- a/packages/elements/src/components/ui/cards/Card.stories.tsx
+++ b/packages/elements/src/components/ui/cards/Card.stories.tsx
@@ -3,6 +3,7 @@ import { faCircle } from "@fortawesome/free-solid-svg-icons/faCircle";
 import { faCreditCard } from "@fortawesome/free-solid-svg-icons/faCreditCard";
 import { faJedi } from "@fortawesome/free-solid-svg-icons/faJedi";
 import {
+  Box,
   Heading,
   Indent,
   Row,
@@ -199,5 +200,36 @@ export const Approved = () => {
         <Text>Line has no padding.</Text>
       </CardBody>
     </Card>
+  );
+};
+
+export const HeadingLevel = () => {
+  return (
+    <Box gap={2}>
+      <Card>
+        <CardHeader text={"Heading level 2"} headingLevel={"h2"} />
+        <CardBody gap={2}>
+          <Text>
+            This card header has the same styling as the other, but it is
+            displayed as an h2 in the DOM.
+          </Text>
+          <Text>
+            A screen reader would acknowledge this as heading level 2.
+          </Text>
+        </CardBody>
+      </Card>
+      <Card>
+        <CardHeader text={"Heading level 3"} headingLevel={"h3"} />
+        <CardBody gap={2}>
+          <Text>
+            This card header has the same styling as the other, but it is
+            displayed as an h3 in the DOM.
+          </Text>
+          <Text>
+            A screen reader would acknowledge this as heading level 3.
+          </Text>
+        </CardBody>
+      </Card>
+    </Box>
   );
 };

--- a/packages/elements/src/components/ui/cards/CardHeader.tsx
+++ b/packages/elements/src/components/ui/cards/CardHeader.tsx
@@ -1,4 +1,4 @@
-import { BoxProps, Heading, Row } from "@stenajs-webui/core";
+import { BoxProps, Heading, HeadingVariant, Row } from "@stenajs-webui/core";
 import * as React from "react";
 import { ReactNode } from "react";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
@@ -15,6 +15,7 @@ export interface CardHeaderProps extends Pick<BoxProps, "className" | "flex"> {
   contentLeft?: ReactNode;
   contentCenter?: ReactNode;
   contentAfterHeading?: ReactNode;
+  headingLevel?: HeadingVariant;
 }
 
 export const CardHeader: React.FC<CardHeaderProps> = ({
@@ -25,6 +26,7 @@ export const CardHeader: React.FC<CardHeaderProps> = ({
   contentRight,
   contentLeft,
   contentCenter,
+  headingLevel = "h2",
   ...boxProps
 }) => {
   return (
@@ -41,7 +43,10 @@ export const CardHeader: React.FC<CardHeaderProps> = ({
           <Icon icon={leftIcon} size={variant === "compact" ? 16 : 24} />
         )}
         {text && (
-          <Heading variant={variant === "compact" ? "h5" : "h4"}>
+          <Heading
+            variant={variant === "compact" ? "h5" : "h4"}
+            as={headingLevel}
+          >
             {text}
           </Heading>
         )}


### PR DESCRIPTION
Defaulting to h2 might be considered a breaking change but I don't believe anyone truly cared about the semantic heading level before this.