### PR TITLE
Modal is fullscreen on mobile

### DIFF
--- a/packages/modal/src/components/modal/Modal.module.css
+++ b/packages/modal/src/components/modal/Modal.module.css
@@ -28,12 +28,12 @@
   }
 
   .modal {
-    max-width: 100vw;
+    max-width: 100%;
     outline: none;
     pointer-events: none;
 
     @media (max-width: 768px) {
-      width: 100vw;
+      width: 100%;
     }
   }
 

--- a/packages/modal/src/components/modal/Modal.module.css
+++ b/packages/modal/src/components/modal/Modal.module.css
@@ -20,7 +20,6 @@
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  padding: var(--swui-modal-padding);
 
   animation: fadeIn var(--swui-modal-animation-time)
     cubic-bezier(0.645, 0.045, 0.355, 1) both;
@@ -30,9 +29,13 @@
   }
 
   .modal {
-    max-width: 100%;
+    max-width: 100vw;
     outline: none;
     pointer-events: none;
+
+    @media (max-width: 768px) {
+      width: 100vw;
+    }
   }
 
   .content {
@@ -41,12 +44,17 @@
     background: var(--swui-modal-content-bg-color);
     box-shadow: var(--swui-modal-shadow);
     pointer-events: all;
+    top: calc(var(--swui-metrics-space) * 2);
 
     width: var(--swui-modal-width);
     max-width: 100%;
 
     animation: appear var(--swui-animation-time-fast)
       cubic-bezier(0.645, 0.045, 0.355, 1) both;
+
+    @media (max-width: 768px) {
+      top: 0;
+    }
 
     @media print {
       box-shadow: none;
@@ -81,11 +89,9 @@
 
 @keyframes appear {
   0% {
-    top: calc(0 - var(--swui-metrics-space));
     opacity: 0;
   }
   100% {
-    top: var(--swui-metrics-space);
     opacity: 1;
   }
 }

--- a/packages/modal/src/components/modal/Modal.module.css
+++ b/packages/modal/src/components/modal/Modal.module.css
@@ -1,7 +1,6 @@
 .overlay {
   --swui-modal-animation-time: var(--swui-animation-time-fast);
   --swui-modal-overlay-bg-color: var(--swui-overlay-bg-color);
-  --swui-modal-padding: var(--swui-metrics-space);
   --swui-modal-content-bg-color: var(--swui-white);
   --swui-modal-width: 960px;
   --swui-modal-header-border-color: var(--lhds-color-ui-300);
@@ -102,7 +101,7 @@
 
 .stickyFooter {
   position: sticky;
-  bottom: calc(-1 * var(--swui-modal-padding));
+  bottom: 0;
   box-shadow: var(--swui-modal-footer-shadow);
 
   @media print {

--- a/packages/modal/src/components/modal/Modal.stories.tsx
+++ b/packages/modal/src/components/modal/Modal.stories.tsx
@@ -43,6 +43,28 @@ export const ModalWithHeader = () => {
   );
 };
 
+export const Mobile = () => {
+  const [isOpen, setOpen] = useState(false);
+  return (
+    <>
+      <PrimaryButton onClick={() => setOpen(true)} label={"Open modal"} />
+      <Modal
+        headerText={"Modal title here"}
+        isOpen={isOpen}
+        onRequestClose={() => setOpen(false)}
+      >
+        {loremIpsumSampleText}
+      </Modal>
+    </>
+  );
+};
+
+Mobile.parameters = {
+  viewport: {
+    defaultViewport: "mobile1",
+  },
+};
+
 export const ModalWithCustomHeaderComponent = () => {
   const [isOpen, setOpen] = useState(false);
   return (
@@ -136,6 +158,24 @@ export const _BaseModal = () => {
       </BaseModal>
     </>
   );
+};
+
+export const BaseModalMobile = () => {
+  const [isOpen, setOpen] = useState(false);
+  return (
+    <>
+      <PrimaryButton onClick={() => setOpen(true)} label={"Open modal"} />
+      <BaseModal isOpen={isOpen} onRequestClose={() => setOpen(false)}>
+        <Spacing indent>modal without header</Spacing>
+      </BaseModal>
+    </>
+  );
+};
+
+BaseModalMobile.parameters = {
+  viewport: {
+    defaultViewport: "mobile1",
+  },
 };
 
 export const DraggableModal = () => {


### PR DESCRIPTION
Fullscreen width only, height is dependent on content.

- Modal overlay no longer has padding, which was preventing the modal from moving all the way to the edge of the viewport.
- Modal is now fullscreen (width only) on mobile.
- Remove broken top animation for modal when appearing.

<img width="348" alt="image" src="https://user-images.githubusercontent.com/1266041/200844397-415682eb-1bc1-47fb-a9f6-5b40ca8295e5.png">

<img width="1107" alt="image" src="https://user-images.githubusercontent.com/1266041/200844452-a60ce69d-9600-464b-a0ad-4c6bada68836.png">
