### PR TITLE
Change focus to focus-visible for form elements

### DIFF
--- a/packages/elements/src/components/ui/buttons/Button.module.css
+++ b/packages/elements/src/components/ui/buttons/Button.module.css
@@ -189,6 +189,9 @@
 
   &:focus {
     outline: 0;
+  }
+
+  &:focus-visible {
     --current-background-color: var(--swui-button-background-color-focus);
     --current-border-color: var(--swui-button-border-color-focus);
     --current-icon-color: var(--swui-button-icon-color-focus);
@@ -233,6 +236,9 @@
 
     &:focus {
       outline: 0;
+    }
+
+    &:focus-visible {
       --current-background-color: var(
         --swui-button-danger-background-color-focus
       );
@@ -268,6 +274,9 @@
 
     &:focus {
       outline: 0;
+    }
+
+    &:focus-visible {
       --current-background-color: var(
         --swui-button-success-background-color-focus
       );

--- a/packages/elements/src/components/ui/up-down-buttons/UpDownButtons.module.css
+++ b/packages/elements/src/components/ui/up-down-buttons/UpDownButtons.module.css
@@ -11,6 +11,9 @@
 
     &:focus {
       outline: none;
+    }
+
+    &:focus-visible {
       box-shadow: var(--swui-stepper-button-focus-shadow);
     }
 

--- a/packages/forms/src/components/ui/checkbox/Checkbox.module.css
+++ b/packages/forms/src/components/ui/checkbox/Checkbox.module.css
@@ -162,7 +162,7 @@
     }
   }
 
-  &:focus {
+  &:focus-visible {
     &:checked {
       box-shadow: var(--swui-checkbox-checked-focus-shadow);
     }

--- a/packages/forms/src/components/ui/radio/RadioButton.module.css
+++ b/packages/forms/src/components/ui/radio/RadioButton.module.css
@@ -129,7 +129,7 @@
     }
   }
 
-  &:focus {
+  &:focus-visible {
     &:checked {
       box-shadow: var(--swui-radiobutton-checked-focus-shadow);
     }

--- a/packages/forms/src/components/ui/switch/Switch.module.css
+++ b/packages/forms/src/components/ui/switch/Switch.module.css
@@ -36,6 +36,9 @@
 
   &:focus {
     outline: 0;
+  }
+
+  &:focus-visible {
     border: 1px solid var(--swui-switch-selected-highlight-color);
     box-shadow: inset var(--swui-switch-selected-highlight-color) 0 0 4px 0;
   }


### PR DESCRIPTION
With this change, the focus border will be shown for these elements only when navigating with the keyboard:
Checkbox, RadioButton, Switch and all kinds of Button & UpDownButtons