### PR TITLE
Add support for locale in calendar

### DIFF
--- a/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.stories.tsx
@@ -1,8 +1,9 @@
 import { addDays, format } from "date-fns";
+import { sv, enUS } from "date-fns/locale";
 import * as React from "react";
-import markdown from "./DateRangeCalendar.md?raw";
 import { setDayStateValue } from "../../../util/calendar/StateModifier";
 import { DateRangeCalendar, DateRangeCalendarProps } from "./DateRangeCalendar";
+import markdown from "./DateRangeCalendar.md?raw";
 import { useDateRangeCalendarState } from "./hooks/UseDateRangeCalendarState";
 
 export default {
@@ -43,6 +44,16 @@ function DateRangeCalendarWithState<T>({
 export const Standard = () => {
   const props = useDateRangeCalendarState();
   return <DateRangeCalendar {...props} />;
+};
+
+export const SwedishLocale = () => {
+  const props = useDateRangeCalendarState();
+  return <DateRangeCalendar {...props} locale={sv} />;
+};
+
+export const WeekStartAtSunday = () => {
+  const props = useDateRangeCalendarState();
+  return <DateRangeCalendar {...props} locale={enUS} />;
 };
 
 export const WithStateHook = () => <DateRangeCalendarWithState />;

--- a/packages/calendar/src/components/calendar-types/single-week-calendar/UseSingleWeekSelection.ts
+++ b/packages/calendar/src/components/calendar-types/single-week-calendar/UseSingleWeekSelection.ts
@@ -1,23 +1,25 @@
+import { setWeek } from "date-fns";
+import { enGB } from "date-fns/locale";
 import { useCallback, useMemo, useState } from "react";
+import { useInternalPanelState } from "../../../features/internal-panel-state/UseInternalPanelState";
 import { CalendarWithMonthSwitcherProps } from "../../../features/month-switcher/CalendarWithMonthSwitcher";
+import { OnClickDay, OnClickWeek } from "../../../types/CalendarTypes";
 import {
-  getStartDateOfISOWeek,
   getWeekForDate,
   WeekData,
 } from "../../../util/calendar/CalendarDataFactory";
 import { addWeekRangeHighlights } from "../../../util/calendar/StateModifier";
 import { SingleWeekCalendarProps } from "./SingleWeekCalendar";
-import { useInternalPanelState } from "../../../features/internal-panel-state/UseInternalPanelState";
-import { OnClickDay, OnClickWeek } from "../../../types/CalendarTypes";
 
 export const useSingleWeekSelection = <T>({
   onChange,
   value,
   statePerMonth,
   onChangePanel,
+  locale = enGB,
 }: SingleWeekCalendarProps<T>): CalendarWithMonthSwitcherProps<T> => {
   const [dateInFocus, setDateInFocus] = useState(() => {
-    const week = getWeekDataFromWeekString(value);
+    const week = getWeekDataFromWeekString(value, locale);
     if (!week) {
       return new Date();
     }
@@ -29,10 +31,10 @@ export const useSingleWeekSelection = <T>({
   const onClickDay = useCallback<OnClickDay<T>>(
     (day) => {
       if (onChange) {
-        onChange(getWeekStringFromWeekData(getWeekForDate(day.date)));
+        onChange(getWeekStringFromWeekData(getWeekForDate(day.date, locale)));
       }
     },
-    [onChange]
+    [locale, onChange]
   );
   const onClickWeek = useCallback<OnClickWeek>(
     (week) => {
@@ -44,19 +46,19 @@ export const useSingleWeekSelection = <T>({
   );
 
   const statePerMonthWithSelection = useMemo(() => {
-    const weekData = getWeekDataFromWeekString(value);
+    const weekData = getWeekDataFromWeekString(value, locale);
     return weekData
       ? addWeekRangeHighlights(statePerMonth, weekData)
       : statePerMonth;
-  }, [value, statePerMonth]);
+  }, [value, locale, statePerMonth]);
 
   const date = useMemo(() => {
-    const week = getWeekDataFromWeekString(value);
+    const week = getWeekDataFromWeekString(value, locale);
     if (!week) {
       return new Date();
     }
     return week.days[0].date;
-  }, [value]);
+  }, [locale, value]);
 
   return {
     statePerMonth: statePerMonthWithSelection,
@@ -80,7 +82,8 @@ const getWeekStringFromWeekData = (
 };
 
 const getWeekDataFromWeekString = (
-  week: string | undefined
+  week: string | undefined,
+  locale: Locale
 ): WeekData | undefined => {
   if (!week) {
     return undefined;
@@ -88,5 +91,7 @@ const getWeekDataFromWeekString = (
   const parts = week.split("-");
   const weekNumber = parseInt(parts[1], 10);
   const year = parseInt(parts[0], 10);
-  return getWeekForDate(getStartDateOfISOWeek(weekNumber, year));
+  const date = new Date();
+  date.setFullYear(year);
+  return getWeekForDate(setWeek(date, weekNumber), locale);
 };

--- a/packages/calendar/src/components/calendar/Calendar.tsx
+++ b/packages/calendar/src/components/calendar/Calendar.tsx
@@ -1,7 +1,9 @@
 import { Row, Space, Spacing } from "@stenajs-webui/core";
 import { getMonth, getYear, parse } from "date-fns";
+import { enGB } from "date-fns/locale";
 import { chunk } from "lodash";
 import * as React from "react";
+import { useMemo } from "react";
 import { useHighlightToday } from "../../features/today-state/UseHighlightToday";
 import {
   CalendarOnClicks,
@@ -16,12 +18,11 @@ import {
   getMonthsInYear,
   MonthData,
 } from "../../util/calendar/CalendarDataFactory";
+import styles from "./Calendar.module.css";
 
 import { CalendarMonth } from "./CalendarMonth";
 import { CalendarTheme, defaultCalendarTheme } from "./CalendarTheme";
 import { CalendarDay } from "./renderers/CalendarDay";
-import styles from "./Calendar.module.css";
-import { useMemo } from "react";
 
 interface CalendarPanelProps<T>
   extends CalendarProps<T>,
@@ -117,6 +118,7 @@ export function Calendar<T>(props: CalendarProps<T>) {
   const monthRows = getMonthRows(
     year,
     month,
+    props.locale ?? enGB,
     props.numMonths,
     props.monthsPerRow
   );
@@ -160,14 +162,15 @@ const getInitialDate = (year?: number, month?: number, date?: Date) => {
 const getMonthRows = (
   year: number,
   month: number,
+  locale: Locale,
   numMonths?: number,
   monthsPerRow?: number
 ): Array<Array<MonthData>> => {
   if (numMonths == null) {
-    return [[getMonthInYear(year, month)]];
+    return [[getMonthInYear(year, month, locale)]];
   }
   if (monthsPerRow == null) {
-    return [getMonthsInYear(year, month, numMonths)];
+    return [getMonthsInYear(year, month, numMonths, locale)];
   }
-  return chunk(getMonthsInYear(year, month, numMonths), monthsPerRow);
+  return chunk(getMonthsInYear(year, month, numMonths, locale), monthsPerRow);
 };

--- a/packages/calendar/src/components/calendar/CalendarMonth.tsx
+++ b/packages/calendar/src/components/calendar/CalendarMonth.tsx
@@ -100,19 +100,7 @@ export function CalendarMonth<T>({
             <tr>
               {showWeekNumber && (
                 <td>
-                  <Box
-                    width={theme.width}
-                    height={theme.height}
-                    justifyContent={"center"}
-                    alignItems={"center"}
-                  >
-                    <Text
-                      size={"small"}
-                      color={theme.CalendarMonth.headerTextColor}
-                    >
-                      W
-                    </Text>
-                  </Box>
+                  <Box width={theme.width} height={theme.height} />
                 </td>
               )}
               {month.weeks[0].days.map((day: DayData) => (

--- a/packages/calendar/src/types/CalendarTypes.tsx
+++ b/packages/calendar/src/types/CalendarTypes.tsx
@@ -92,6 +92,9 @@ export interface CalendarProps<T>
   /** If true, today's date will be highlighted. */
   highlightToday?: boolean;
 
+  /** The locale to use for formatting */
+  locale?: Locale;
+
   /** The theme to use. */
   theme?: CalendarTheme;
 }

--- a/packages/calendar/src/util/calendar/CalendarDataFactory.ts
+++ b/packages/calendar/src/util/calendar/CalendarDataFactory.ts
@@ -7,12 +7,12 @@ import {
   format,
   getDate,
   getISODay,
-  getISOWeek,
   getMonth,
+  getWeek,
   getYear,
   isSameDay,
-  startOfISOWeek,
   startOfMonth,
+  startOfWeek,
 } from "date-fns";
 import { DateFormats } from "../date/DateFormats";
 
@@ -77,16 +77,21 @@ export interface MonthData {
 export const getMonthsInYear = (
   year: number,
   startMonth: number,
-  numMonths: number
+  numMonths: number,
+  locale: Locale
 ): Array<MonthData> => {
   const months = [];
   for (let i = 0; i < numMonths; i++) {
-    months.push(getMonthInYear(year, startMonth + i));
+    months.push(getMonthInYear(year, startMonth + i, locale));
   }
   return months;
 };
 
-export const getMonthInYear = (year: number, month: number): MonthData => {
+export const getMonthInYear = (
+  year: number,
+  month: number,
+  locale: Locale
+): MonthData => {
   const yearToUse = year + Math.floor(month / 12);
   const monthToUse = month % 12;
   const firstDayOfMonth = new Date(yearToUse, monthToUse, 1);
@@ -95,20 +100,23 @@ export const getMonthInYear = (year: number, month: number): MonthData => {
     name: format(firstDayOfMonth, DateFormats.fullMonthName),
     year: yearToUse,
     monthInYear: monthToUse,
-    weeks: getWeeksForMonth(yearToUse, monthToUse),
+    weeks: getWeeksForMonth(yearToUse, monthToUse, locale),
   };
 };
 
 export const getWeeksForMonth = (
   year: number,
   month: number,
+  locale: Locale,
   forceSixWeeks: boolean = true
 ): Array<WeekData> => {
   const firstDayOfMonth = new Date(year, month, 1);
-  const firstDayOfFirstWeek = startOfISOWeek(firstDayOfMonth);
+  const firstDayOfFirstWeek = startOfWeek(firstDayOfMonth, { locale });
+
   const weeks = [];
+
   for (let i = 0; i < 6; i++) {
-    const week = getWeekForDate(addWeeks(firstDayOfFirstWeek, i));
+    const week = getWeekForDate(addWeeks(firstDayOfFirstWeek, i), locale);
     if (i > 0 && week.startMonth !== month && !forceSixWeeks) {
       return weeks;
     }
@@ -117,27 +125,30 @@ export const getWeeksForMonth = (
   return weeks;
 };
 
-export const getWeekForDate = (firstDayOfWeek: Date): WeekData => {
+export const getWeekForDate = (
+  firstDayOfWeek: Date,
+  locale: Locale
+): WeekData => {
   const isLastWeekOfMonth =
     getMonth(addDays(firstDayOfWeek, 7)) !== getMonth(firstDayOfWeek);
   return {
-    weekNumber: getISOWeek(firstDayOfWeek),
+    weekNumber: getWeek(firstDayOfWeek, { locale }),
     startMonth: getMonth(firstDayOfWeek),
     startYear: getYear(firstDayOfWeek),
     endMonth: getMonth(addDays(firstDayOfWeek, 6)),
     endYear: getYear(addDays(firstDayOfWeek, 6)),
-    days: getDaysForWeekForDate(firstDayOfWeek),
+    days: getDaysForWeekForDate(firstDayOfWeek, locale),
     isLastWeekOfMonth,
   };
 };
 
-export const createDay = (date: Date): DayData => {
+export const createDay = (date: Date, locale: Locale): DayData => {
   const dayOfWeek = getISODay(date);
   return {
     date,
-    name: format(date, "EEE"),
+    name: format(date, "EEE", locale ? { locale } : undefined),
     dateString: format(addHours(date, 12), DateFormats.fullDate),
-    weekNumber: getISOWeek(date),
+    weekNumber: getWeek(date, { locale }),
     year: getYear(date),
     month: getMonth(date),
     dayOfMonth: getDate(date),
@@ -149,26 +160,14 @@ export const createDay = (date: Date): DayData => {
   };
 };
 
-export const getDaysForWeekForDate = (firstDayOfWeek: Date): Array<DayData> => {
+export const getDaysForWeekForDate = (
+  firstDayOfWeek: Date,
+  locale: Locale
+): Array<DayData> => {
   return eachDayOfInterval({
     start: firstDayOfWeek,
     end: addDays(firstDayOfWeek, 6),
-  }).map(createDay);
-};
-
-export const getStartDateOfISOWeek = (
-  weekNumber: number,
-  year: number
-): Date => {
-  const simple = new Date(year, 0, 1 + (weekNumber - 1) * 7);
-  const dayOfWeek = simple.getDay();
-  const isoWeekStart = simple;
-  if (dayOfWeek <= 4) {
-    isoWeekStart.setDate(simple.getDate() - simple.getDay() + 1);
-  } else {
-    isoWeekStart.setDate(simple.getDate() + 8 - simple.getDay());
-  }
-  return isoWeekStart;
+  }).map((d) => createDay(d, locale));
 };
 
 export const calculateOverflowingMonth = (

--- a/packages/calendar/src/util/calendar/__tests__/CalendarDataFactory.test.ts
+++ b/packages/calendar/src/util/calendar/__tests__/CalendarDataFactory.test.ts
@@ -7,30 +7,37 @@ import {
   Month,
   WeekDay,
 } from "../CalendarDataFactory";
+import { enGB } from "date-fns/locale";
 
 describe("CalendarDataFactory", () => {
   describe("getMonthInYear", () => {
     it("should wrap to next year when month is too high", () => {
-      const month = getMonthInYear(2017, 12);
+      const month = getMonthInYear(2017, 12, enGB);
       expect(month.weeks[0].startYear).toBe(2018);
     });
     it("should return correct monthFormat", () => {
-      expect(getMonthInYear(2018, Month.JANUARY).monthString).toBe("2018-01");
-      expect(getMonthInYear(2018, Month.FEBRUARY).monthString).toBe("2018-02");
-      expect(getMonthInYear(2018, Month.DECEMBER).monthString).toBe("2018-12");
+      expect(getMonthInYear(2018, Month.JANUARY, enGB).monthString).toBe(
+        "2018-01"
+      );
+      expect(getMonthInYear(2018, Month.FEBRUARY, enGB).monthString).toBe(
+        "2018-02"
+      );
+      expect(getMonthInYear(2018, Month.DECEMBER, enGB).monthString).toBe(
+        "2018-12"
+      );
     });
   });
   describe("createDay", () => {
     it("should handle 2018-02-01", () => {
       const date = new Date(2018, 1, 1);
-      const day = createDay(date);
+      const day = createDay(date, enGB);
       expect(day.name).toBe("Thu");
       expect(day.dateString).toBe("2018-02-01");
     });
   });
   describe("getWeeksForMonth", () => {
     it("should return correct weeks", () => {
-      const weeks = getWeeksForMonth(2018, Month.FEBRUARY);
+      const weeks = getWeeksForMonth(2018, Month.FEBRUARY, enGB);
       expect(weeks.length).toBe(6);
       expect(weeks[0].startMonth).toBe(0);
       expect(weeks[0].endMonth).toBe(1);
@@ -55,7 +62,7 @@ describe("CalendarDataFactory", () => {
     });
 
     it("should return correct days", () => {
-      const weeks = getWeeksForMonth(2018, Month.FEBRUARY);
+      const weeks = getWeeksForMonth(2018, Month.FEBRUARY, enGB);
       expect(weeks[0].days[0].dateString).toBe("2018-01-29");
       expect(weeks[0].days[0].dayOfWeek).toBe(WeekDay.MONDAY);
       expect(weeks[0].days[0].year).toBe(2018);
@@ -68,11 +75,11 @@ describe("CalendarDataFactory", () => {
     });
 
     it("should handle weeks where first days are part of previous month", () => {
-      expect(getWeeksForMonth(2019, Month.JANUARY).length > 0).toBe(true);
+      expect(getWeeksForMonth(2019, Month.JANUARY, enGB).length > 0).toBe(true);
     });
 
     it("should handle december 2018", () => {
-      expect(getWeeksForMonth(2018, Month.DECEMBER).length).toBe(6);
+      expect(getWeeksForMonth(2018, Month.DECEMBER, enGB).length).toBe(6);
     });
   });
 
@@ -97,7 +104,7 @@ describe("CalendarDataFactory", () => {
 
   describe("getMonthsInYear", () => {
     it("should handle when interval passes a new year", () => {
-      const monthsInYear = getMonthsInYear(2018, Month.DECEMBER, 3);
+      const monthsInYear = getMonthsInYear(2018, Month.DECEMBER, 3, enGB);
       expect(monthsInYear[0].year).toBe(2018);
       expect(monthsInYear[0].monthInYear).toBe(Month.DECEMBER);
       expect(monthsInYear[0].weeks.length > 0).toBe(true);


### PR DESCRIPTION
- Add support for date-fns locale objects in calendar.
- Calendar now supports translated day names and weeks starting on other days than monday.
- Week numbers are now also based on locale, where for example US week nr 1 is defined differently than week nr 1 in Sweden.
- The `W` label on top of week numbers has been removed, since there was no built-in support for this in date-fns.
- `locale` prop is optional, and defaults to `enGB`, which is same behaviour as before.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/1266041/207044329-b00be552-db2f-46c4-b505-5ce4f0766d2d.png">

<img width="312" alt="image" src="https://user-images.githubusercontent.com/1266041/207044368-861b03d4-edc5-4962-bed8-ba9d452802b7.png">
