### PR TITLE
Convert local date to utc before setting due to the component using u…

### DIFF
--- a/packages/calendar/src/components/input-types/date-time-input/hooks/UseDateRangeHandlers.ts
+++ b/packages/calendar/src/components/input-types/date-time-input/hooks/UseDateRangeHandlers.ts
@@ -49,7 +49,9 @@ export const useDateRangeHandlers = (
       }
       setDateInFocus(newDate);
       if (dateInputRef.current) {
-        dateInputRef.current.valueAsDate = newDate;
+        dateInputRef.current.valueAsDate = new Date(
+          Date.UTC(newDate.getFullYear(), newDate.getMonth(), newDate.getDate())
+        );
       }
     },
     [date, dateInputRef, localTime, onValueChange, setDateInFocus, setLocalDate]


### PR DESCRIPTION
…tc date

Previously we can have this situation (when you select a time, it becomes correct again):
<img width="414" alt="Screenshot 2022-12-21 at 11 32 02" src="https://user-images.githubusercontent.com/4313943/208884189-c1f412c5-07ce-4470-9c95-a8f4bf88e715.png">

With the fix however, the dates now match:
<img width="414" alt="Screenshot 2022-12-21 at 11 33 16" src="https://user-images.githubusercontent.com/4313943/208884482-c47895b3-76ec-450b-a306-fa81084ea4fa.png">
