### PR TITLE
Show month names in correct locale

### DIFF
--- a/packages/calendar/src/features/calendar-with-month-year-pickers/CalendarWithMonthYearPickers.tsx
+++ b/packages/calendar/src/features/calendar-with-month-year-pickers/CalendarWithMonthYearPickers.tsx
@@ -22,6 +22,7 @@ interface CalendarWithMonthYearPickersProps<T>
 
 export const CalendarWithMonthYearPickers =
   function CalendarWithMonthYearPickers<T>({
+    locale,
     dateInFocus,
     setDateInFocus,
     currentPanel,
@@ -69,6 +70,7 @@ export const CalendarWithMonthYearPickers =
               date={dateInFocus}
               onClickYear={onClickYear}
               onClickMonth={onClickMonth}
+              locale={locale}
             />
           </>
         );
@@ -77,6 +79,7 @@ export const CalendarWithMonthYearPickers =
           <MonthPicker
             value={dateInFocus.getMonth()}
             onValueChange={onChangeSelectedMonth}
+            locale={locale}
           />
         );
       case "year":

--- a/packages/calendar/src/features/month-picker/MonthPicker.tsx
+++ b/packages/calendar/src/features/month-picker/MonthPicker.tsx
@@ -1,10 +1,13 @@
+import { enGB } from "date-fns/locale";
 import * as React from "react";
 import { Month } from "../../util/calendar/CalendarDataFactory";
 import { ValueAndOnValueChangeProps } from "@stenajs-webui/forms";
 import { Column, Row } from "@stenajs-webui/core";
 import { MonthPickerCell } from "./MonthPickerCell";
 
-export interface MonthPickerProps extends ValueAndOnValueChangeProps<Month> {}
+export interface MonthPickerProps extends ValueAndOnValueChangeProps<Month> {
+  locale?: Locale;
+}
 
 const monthMatrix = [
   [Month.JANUARY, Month.FEBRUARY, Month.MARCH],
@@ -16,6 +19,7 @@ const monthMatrix = [
 export const MonthPicker: React.FC<MonthPickerProps> = ({
   value,
   onValueChange,
+  locale = enGB,
 }) => {
   return (
     <Column>
@@ -27,6 +31,7 @@ export const MonthPicker: React.FC<MonthPickerProps> = ({
               month={month}
               onValueChange={onValueChange}
               value={value}
+              locale={locale}
             />
           ))}
         </Row>

--- a/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
+++ b/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
@@ -1,3 +1,4 @@
+import { startCase } from "lodash";
 import * as React from "react";
 import { useMemo } from "react";
 import { Row } from "@stenajs-webui/core";
@@ -8,17 +9,19 @@ import { format } from "date-fns";
 
 interface Props extends ValueAndOnValueChangeProps<Month> {
   month: Month;
+  locale: Locale;
 }
 
 export const MonthPickerCell: React.FC<Props> = ({
   value,
   onValueChange,
   month,
+  locale,
 }) => {
   const label = useMemo(() => {
     const now = new Date(2000, month, 1);
-    return format(now, "MMM");
-  }, [month]);
+    return startCase(format(now, "MMM", { locale }));
+  }, [locale, month]);
 
   return (
     <Row width={"64px"} justifyContent={"center"} spacing={0.5} indent={0.5}>

--- a/packages/calendar/src/util/calendar/CalendarDataFactory.ts
+++ b/packages/calendar/src/util/calendar/CalendarDataFactory.ts
@@ -14,6 +14,7 @@ import {
   startOfMonth,
   startOfWeek,
 } from "date-fns";
+import { startCase } from "lodash";
 import { DateFormats } from "../date/DateFormats";
 
 export enum Month {
@@ -97,7 +98,9 @@ export const getMonthInYear = (
   const firstDayOfMonth = new Date(yearToUse, monthToUse, 1);
   return {
     monthString: format(firstDayOfMonth, DateFormats.yearAndMonth),
-    name: format(firstDayOfMonth, DateFormats.fullMonthName),
+    name: startCase(
+      format(firstDayOfMonth, DateFormats.fullMonthName, { locale })
+    ),
     year: yearToUse,
     monthInYear: monthToUse,
     weeks: getWeeksForMonth(yearToUse, monthToUse, locale),


### PR DESCRIPTION
In both calendar and month picker.

<img width="311" alt="image" src="https://user-images.githubusercontent.com/1266041/214271343-2e9904cc-8972-43b5-be56-e9310c69376c.png">

<img width="195" alt="image" src="https://user-images.githubusercontent.com/1266041/214271370-889c6380-5732-4a27-93c0-0367449622e0.png">
