### PR TITLE
Button icons now customisable using CSS properties

### DIFF
--- a/packages/elements/src/components/ui/button-links/PrimaryButtonLink.tsx
+++ b/packages/elements/src/components/ui/button-links/PrimaryButtonLink.tsx
@@ -4,10 +4,7 @@ import cx from "classnames";
 import styles from "../buttons/Button.module.css";
 import buttonLinkStyles from "./ButtonLink.module.css";
 import { AnchorElementProps } from "@stenajs-webui/core";
-import {
-  CommonButtonProps,
-  getIconSizeFromButtonSize,
-} from "../buttons/common/ButtonCommon";
+import { CommonButtonProps } from "../buttons/common/ButtonCommon";
 import { getButtonLabel } from "../buttons/common/ButtonLabelFactory";
 import { ButtonContent } from "../buttons/common/ButtonContent";
 
@@ -64,7 +61,6 @@ export const PrimaryButtonLink = forwardRef<
       {...anchorProps}
     >
       <ButtonContent
-        iconSize={getIconSizeFromButtonSize(size, hasLabel)}
         success={success}
         loading={loading}
         leftIcon={leftIcon}

--- a/packages/elements/src/components/ui/buttons/Button.module.css
+++ b/packages/elements/src/components/ui/buttons/Button.module.css
@@ -28,6 +28,13 @@
   );
 
   /* Icon */
+  --swui-button-icon-height-small: 1.2rem;
+  --swui-button-icon-height-small-icon-only: 1.2rem;
+  --swui-button-icon-height-medium: 1.6rem;
+  --swui-button-icon-height-medium-icon-only: 1.6rem;
+  --swui-button-icon-height-large: 1.6rem;
+  --swui-button-icon-height-large-icon-only: 2.4rem;
+
   --swui-button-icon-color: var(--swui-white);
   --swui-button-icon-color-focus: var(--swui-button-icon-color);
   --swui-button-icon-color-hover: var(--swui-button-icon-color);
@@ -119,6 +126,7 @@
    * Styling
    */
   --current-background-color: var(--swui-button-background-color);
+  --current-icon-height: var(--swui-button-icon-height-medium);
   --current-icon-color: var(--swui-button-icon-color);
   --current-text-color: var(--swui-button-text-color);
   --current-border-color: var(--swui-button-border-color);
@@ -144,6 +152,8 @@
   justify-content: center;
 
   &.iconButton {
+    --current-icon-height: var(--swui-button-icon-height-medium-icon-only);
+
     padding: var(--swui-button-padding-vertical);
     color: var(--current-icon-color);
     flex: none;
@@ -176,6 +186,11 @@
     --swui-button-padding-vertical: calc(var(--swui-metrics-space) / 2 - 1px);
     --swui-button-padding-horizontal: calc(var(--swui-metrics-space) - 1px);
     --current-text-size: 1.2rem;
+    --current-icon-height: var(--swui-button-icon-height-small);
+
+    &.iconButton {
+      --current-icon-height: var(--swui-button-icon-height-small-icon-only);
+    }
   }
 
   &.large {
@@ -183,6 +198,11 @@
     --swui-button-padding-vertical: calc(var(--swui-metrics-space) - 1px);
     --swui-button-padding-horizontal: calc(var(--swui-metrics-space) * 3 - 1px);
     --current-text-size: 1.6rem;
+    --current-icon-height: var(--swui-button-icon-height-large);
+
+    &.iconButton {
+      --current-icon-height: var(--swui-button-icon-height-large-icon-only);
+    }
   }
 
   &:hover {

--- a/packages/elements/src/components/ui/buttons/PrimaryButton.tsx
+++ b/packages/elements/src/components/ui/buttons/PrimaryButton.tsx
@@ -3,10 +3,7 @@ import cx from "classnames";
 import * as React from "react";
 import { forwardRef } from "react";
 import styles from "./Button.module.css";
-import {
-  CommonButtonProps,
-  getIconSizeFromButtonSize,
-} from "./common/ButtonCommon";
+import { CommonButtonProps } from "./common/ButtonCommon";
 import { getButtonLabel } from "./common/ButtonLabelFactory";
 import { ButtonContent } from "./common/ButtonContent";
 import styled from "@emotion/styled";
@@ -79,7 +76,6 @@ export const PrimaryButton = forwardRef<HTMLButtonElement, PrimaryButtonProps>(
           leftIcon={leftIcon}
           left={left}
           right={right}
-          iconSize={getIconSizeFromButtonSize(size, hasLabel)}
           rightIcon={rightIcon}
           label={buttonLabel}
           iconClassName={iconClassName}

--- a/packages/elements/src/components/ui/buttons/common/ButtonCommon.ts
+++ b/packages/elements/src/components/ui/buttons/common/ButtonCommon.ts
@@ -4,13 +4,6 @@ import { ReactNode } from "react";
 export type ButtonSize = "medium" | "small" | "large";
 export type ButtonVariant = "normal" | "danger" | "success";
 
-export const getIconSizeFromButtonSize = (
-  size: ButtonSize,
-  hasLabel: boolean
-): ButtonSize => {
-  return size === "large" ? (hasLabel ? "medium" : "large") : size;
-};
-
 export interface CommonButtonProps {
   /** The text on the button. */
   label?: string;

--- a/packages/elements/src/components/ui/buttons/common/ButtonContent.module.css
+++ b/packages/elements/src/components/ui/buttons/common/ButtonContent.module.css
@@ -1,6 +1,7 @@
 .iconLeft,
 .iconRight {
   color: var(--current-icon-color);
+  font-size: var(--current-icon-height);
 }
 
 .leftWrapper,

--- a/packages/elements/src/components/ui/buttons/common/ButtonContent.tsx
+++ b/packages/elements/src/components/ui/buttons/common/ButtonContent.tsx
@@ -1,3 +1,4 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import * as React from "react";
 import { ReactNode } from "react";
 import cx from "classnames";
@@ -5,7 +6,6 @@ import { InputSpinner } from "../../spinner/InputSpinner";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import styles from "./ButtonContent.module.css";
 import { stenaCheck } from "../../../../icons/ui/IconsUi";
-import { Icon } from "../../icon/Icon";
 
 export interface ButtonContentProps {
   label?: string;
@@ -20,7 +20,6 @@ export interface ButtonContentProps {
   spinnerClassName?: string;
   leftWrapperClassName?: string;
   rightWrapperClassName?: string;
-  iconSize?: "large" | "medium" | "small";
 }
 
 export const ButtonContent: React.FC<ButtonContentProps> = ({
@@ -36,17 +35,13 @@ export const ButtonContent: React.FC<ButtonContentProps> = ({
   spinnerClassName,
   leftWrapperClassName,
   rightWrapperClassName,
-  iconSize = "medium",
 }) => {
-  const iconPixelSize =
-    iconSize === "small" ? 12 : iconSize === "large" ? 24 : undefined;
   return (
     <>
       {(success || loading || leftIcon || left) && (
         <div className={cx(styles.leftWrapper, leftWrapperClassName)}>
           {success ? (
-            <Icon
-              size={iconPixelSize}
+            <FontAwesomeIcon
               icon={stenaCheck}
               className={cx(styles.iconLeft, iconClassName)}
             />
@@ -63,8 +58,7 @@ export const ButtonContent: React.FC<ButtonContentProps> = ({
           ) : left ? (
             left
           ) : leftIcon ? (
-            <Icon
-              size={iconPixelSize}
+            <FontAwesomeIcon
               icon={leftIcon}
               className={cx(styles.iconLeft, iconClassName)}
             />
@@ -81,8 +75,7 @@ export const ButtonContent: React.FC<ButtonContentProps> = ({
           {right ? (
             right
           ) : rightIcon ? (
-            <Icon
-              size={iconPixelSize}
+            <FontAwesomeIcon
               icon={rightIcon}
               className={cx(styles.iconRight, iconClassName)}
             />

--- a/packages/elements/src/components/ui/icon/Icon.tsx
+++ b/packages/elements/src/components/ui/icon/Icon.tsx
@@ -3,7 +3,7 @@ import {
   FontAwesomeIcon,
   FontAwesomeIconProps,
 } from "@fortawesome/react-fontawesome";
-import { Box, Omit, BoxProps } from "@stenajs-webui/core";
+import { Box, BoxProps, Omit } from "@stenajs-webui/core";
 import * as React from "react";
 import { forwardRef } from "react";
 
@@ -23,20 +23,20 @@ export const Icon = forwardRef<HTMLDivElement, IconProps>(function Icon(
     icon,
     pulse,
     rotation,
-    size,
+    size = 16,
     spin,
     style,
     transform,
     display,
     ...props
-  },
+  }: IconProps,
   ref
 ) {
   if (!icon) {
     return null;
   }
 
-  const fontSize = typeof size === "string" ? size : (size ?? 16) / 10 + "rem";
+  const fontSize = typeof size === "string" ? size : size / 10 + "rem";
 
   return (
     <Box

--- a/packages/elements/src/components/ui/icon/Icon.tsx
+++ b/packages/elements/src/components/ui/icon/Icon.tsx
@@ -12,18 +12,18 @@ export interface IconProps
     Pick<BoxProps, "display"> {
   icon?: IconDefinition;
   color?: string;
-  size?: number;
+  size?: number | string;
 }
 
 export const Icon = forwardRef<HTMLDivElement, IconProps>(function Icon(
   {
     className,
-    color = "var(--lhds-color-ui-900)",
+    color = "var(--swui-text-primary-color)",
     flip,
     icon,
     pulse,
     rotation,
-    size = 16,
+    size,
     spin,
     style,
     transform,
@@ -35,6 +35,8 @@ export const Icon = forwardRef<HTMLDivElement, IconProps>(function Icon(
   if (!icon) {
     return null;
   }
+
+  const fontSize = typeof size === "string" ? size : (size ?? 16) / 10 + "rem";
 
   return (
     <Box
@@ -51,7 +53,7 @@ export const Icon = forwardRef<HTMLDivElement, IconProps>(function Icon(
         pulse={pulse}
         rotation={rotation}
         spin={spin}
-        style={{ fontSize: size / 10 + "rem", ...style }}
+        style={{ fontSize, ...style }}
         transform={transform}
         {...props}
       />


### PR DESCRIPTION
Previously, it was impossible to have custom icon sizes in buttons, since the styling was hard coded in JS. These values have now been moved to CSS properties.

Storybook looks identical to before this PR.

- Update styling of buttons so that it uses CSS for icons.
- All button variants and icon-only have different CSS properties for icon sizes.
- The button icons are now possible to theme.
- `Icon` prop `size` can now be a string, so that we can pass CSS properties or rem values.
- Remove hard coded styling.

