### PR TITLE
Tag icon size is different depending on variant

### DIFF
--- a/packages/elements/src/components/ui/tag/Tag.module.css
+++ b/packages/elements/src/components/ui/tag/Tag.module.css
@@ -11,11 +11,14 @@
   --swui-tag-bg-color: var(--lhds-color-blue-100);
   --swui-tag-text-color: var(--lhds-color-blue-800);
   --swui-tag-indent: var(--swui-metrics-indent);
+  --swui-tag-icon-size-normal: 16px;
+  --swui-tag-icon-size-small: 12px;
 
   /* State vars */
   --current-text-color: var(--swui-tag-text-color);
   --current-bg-color: var(--swui-tag-bg-color);
   --current-height: var(--swui-tag-height-normal);
+  --current-icon-size: var(--swui-tag-icon-size-normal);
 
   /* Styling */
   background-color: var(--current-bg-color);
@@ -37,8 +40,13 @@
     padding: 0 var(--swui-tag-indent);
   }
 
+  .icon {
+    font-size: var(--current-icon-size);
+  }
+
   &.small {
     --current-height: var(--swui-tag-height-small);
+    --current-icon-size: var(--swui-tag-icon-size-small);
   }
 
   &.error {

--- a/packages/elements/src/components/ui/tag/Tag.module.css
+++ b/packages/elements/src/components/ui/tag/Tag.module.css
@@ -10,15 +10,18 @@
   --swui-tag-border-radius: 10rem;
   --swui-tag-bg-color: var(--lhds-color-blue-100);
   --swui-tag-text-color: var(--lhds-color-blue-800);
-  --swui-tag-indent: var(--swui-metrics-indent);
-  --swui-tag-icon-size-normal: 1.6rem;
-  --swui-tag-icon-size-small: 1.2rem;
+  --swui-tag-icon-label-indent: var(--swui-metrics-indent);
+  --swui-tag-indent-normal: calc(var(--swui-metrics-indent) * 2);
+  --swui-tag-indent-small: var(--swui-metrics-indent);
+  --swui-tag-icon-size-normal: 1.4rem;
+  --swui-tag-icon-size-small: 1rem;
 
   /* State vars */
   --current-text-color: var(--swui-tag-text-color);
   --current-bg-color: var(--swui-tag-bg-color);
   --current-height: var(--swui-tag-height-normal);
   --current-icon-size: var(--swui-tag-icon-size-normal);
+  --current-indent: var(--swui-tag-indent-normal);
 
   /* Styling */
   background-color: var(--current-bg-color);
@@ -34,19 +37,17 @@
   border-radius: var(--swui-tag-border-radius);
   min-height: var(--current-height);
   align-items: center;
-  padding: 0 var(--swui-tag-indent);
-
-  .label {
-    padding: 0 var(--swui-tag-indent);
-  }
+  padding: 0 var(--current-indent);
 
   .icon {
     font-size: var(--current-icon-size);
+    padding-right: var(--swui-tag-icon-label-indent);
   }
 
   &.small {
     --current-height: var(--swui-tag-height-small);
     --current-icon-size: var(--swui-tag-icon-size-small);
+    --current-indent: var(--swui-tag-indent-small);
   }
 
   &.error {

--- a/packages/elements/src/components/ui/tag/Tag.module.css
+++ b/packages/elements/src/components/ui/tag/Tag.module.css
@@ -11,8 +11,8 @@
   --swui-tag-bg-color: var(--lhds-color-blue-100);
   --swui-tag-text-color: var(--lhds-color-blue-800);
   --swui-tag-indent: var(--swui-metrics-indent);
-  --swui-tag-icon-size-normal: 16px;
-  --swui-tag-icon-size-small: 12px;
+  --swui-tag-icon-size-normal: 1.6rem;
+  --swui-tag-icon-size-small: 1.2rem;
 
   /* State vars */
   --current-text-color: var(--swui-tag-text-color);

--- a/packages/elements/src/components/ui/tag/Tag.stories.tsx
+++ b/packages/elements/src/components/ui/tag/Tag.stories.tsx
@@ -2,7 +2,7 @@ import { Column, Indent, Row, Space, Text } from "@stenajs-webui/core";
 import { Story } from "@storybook/react";
 import * as React from "react";
 import { CSSProperties } from "react";
-import { stenaCheck } from "../../../icons/ui/IconsUi";
+import { stenaSailingOnQuay } from "../../../icons/ui/IconsUi";
 import { disabledControl } from "../../../storybook-helpers/storybook-controls";
 import { Tag, TagProps, TagVariant } from "./Tag";
 
@@ -40,7 +40,7 @@ export const Overview = () => (
               size={size}
               variant={variant}
               label={"Default"}
-              icon={stenaCheck}
+              icon={stenaSailingOnQuay}
             />
           </Row>
         ))}

--- a/packages/elements/src/components/ui/tag/Tag.tsx
+++ b/packages/elements/src/components/ui/tag/Tag.tsx
@@ -35,7 +35,7 @@ export const Tag: React.FC<TagProps> = ({
       {...getDataProps(rest)}
     >
       {icon && <FontAwesomeIcon icon={icon} className={styles.icon} />}
-      <span className={styles.label}>{label}</span>
+      <span>{label}</span>
     </div>
   );
 };

--- a/packages/elements/src/components/ui/tag/Tag.tsx
+++ b/packages/elements/src/components/ui/tag/Tag.tsx
@@ -34,7 +34,7 @@ export const Tag: React.FC<TagProps> = ({
       style={style}
       {...getDataProps(rest)}
     >
-      {icon && <FontAwesomeIcon icon={icon} />}
+      {icon && <FontAwesomeIcon icon={icon} className={styles.icon} />}
       <span className={styles.label}>{label}</span>
     </div>
   );


### PR DESCRIPTION
- Tag icon size can be customised
- Update design of Tag, now validated by UX/UI.
- 
<img width="279" alt="image" src="https://user-images.githubusercontent.com/1266041/222695927-43020175-3ab5-46ba-8060-717f3912c83e.png">

