### PR TITLE
Fix tooltip icon height with border-box

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -16,6 +16,16 @@
     font-size: 14px;
   }
 
+  html {
+    box-sizing: border-box;
+  }
+
+  *,
+  *:before,
+  *:after {
+    box-sizing: inherit;
+  }
+
   .margin-wrapper > * {
     margin: 8px;
   }

--- a/packages/tooltip/src/components/tooltip/Tooltip.module.css
+++ b/packages/tooltip/src/components/tooltip/Tooltip.module.css
@@ -25,7 +25,6 @@
   border: 1px solid var(--current-border-color);
   border-radius: var(--swui-border-radius);
   padding: calc(var(--swui-metrics-spacing) * 0.5);
-  height: 16px;
   align-items: flex-start;
 
   svg {

--- a/packages/tooltip/src/components/tooltip/Tooltip.stories.tsx
+++ b/packages/tooltip/src/components/tooltip/Tooltip.stories.tsx
@@ -99,6 +99,20 @@ export const Variants = () => (
     >
       <Text>Tooltip with lots of text</Text>
     </Tooltip>
+
+    <Tooltip
+      label={`This is my tooltip, there's many like them, but this one is mine!
+    There are many colours in the world, but the coolest color is surely the tooltip color.
+    If I had a coin for everytime I saw a tooltip, I'd have many coins.
+    Tooltips will soon take over the world.
+    AI bots has nothing on tooltips.`}
+      placement="bottom"
+      variant={"error"}
+    >
+      <Text color={cssColor("--lhds-color-red-700")}>
+        Tooltip with lots of text
+      </Text>
+    </Tooltip>
   </Column>
 );
 


### PR DESCRIPTION
- Remove fixed height, this was not needed
- Add story with long text and variant
- Set box-sizing: border-box for all stories
