### PR TITLE
Add initialDateInFocus prop to DateRangeCalendar

### DIFF
--- a/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/DateRangeCalendar.tsx
@@ -12,6 +12,7 @@ export interface DateRangeCalendarProps<T>
     ValueAndOnValueChangeProps<DateRange> {
   focusedInput?: DateRangeFocusedInput;
   setFocusedInput: (focusedInput: DateRangeFocusedInput) => void;
+  initialDateInFocus?: Date;
 }
 
 export function DateRangeCalendar<T>(props: DateRangeCalendarProps<T>) {

--- a/packages/calendar/src/components/calendar-types/date-range-calendar/hooks/UseDateRangeSelection.ts
+++ b/packages/calendar/src/components/calendar-types/date-range-calendar/hooks/UseDateRangeSelection.ts
@@ -12,10 +12,13 @@ export const useDateRangeSelection = <T>({
   setFocusedInput,
   statePerMonth,
   onChangePanel,
+  initialDateInFocus,
 }: DateRangeCalendarProps<T>): CalendarWithMonthSwitcherProps<T> => {
   const { currentPanel, setCurrentPanel } =
     useInternalPanelState(onChangePanel);
-  const [dateInFocus, setDateInFocus] = useState(() => new Date());
+  const [dateInFocus, setDateInFocus] = useState(
+    () => initialDateInFocus ?? new Date()
+  );
 
   const onClickDay = useDateRangeOnClickDayHandler(
     value,


### PR DESCRIPTION
Previously it was always `today`.