### PR TITLE
Column group header in standard table is transparent instead of filled

### DIFF
--- a/packages/grid/src/features/standard-table/features/column-groups/ColumnGroupRow.tsx
+++ b/packages/grid/src/features/standard-table/features/column-groups/ColumnGroupRow.tsx
@@ -91,6 +91,7 @@ export const ColumnGroupRow = React.memo(function ColumnGroupRow({
         />
       ))}
       {rowIndent && <th style={stickyHeaderProps} />}
+      <th style={stickyHeaderProps} />
     </tr>
   );
 });


### PR DESCRIPTION
<img width="2478" alt="Screenshot 2023-08-22 at 16 25 01" src="https://github.com/StenaIT/stenajs-webui/assets/4313943/7eac5dfd-24b0-4ffc-90de-fa75c420b960">

Bug/Issue:
When having a column group that does not fill the entire table (for example when having fixed widths on the columns) and a sticky header, the "remaining" part of the column group header is transparent causing the columns to show through the header.

The fix consists of adding another th element with matching style to fill out the remaining space. Compare to how StandardTableHeadRow.tsx looks