### PR TITLE
Tooltip in StandardTable can be rendered to portal

### DIFF
--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -39,7 +39,7 @@ import { ColGroups } from "./ColGroups";
 import styles from "./StandardTable.module.css";
 import { StandardTableContent } from "./StandardTableContent";
 import { StandardTableHeadRow } from "./StandardTableHeadRow";
-import { TooltipProps } from "@stenajs-webui/tooltip";
+import { TableHeadProps } from "../../table-ui/components/table/TableHeadItem";
 
 export interface StandardTableProps<
   TItem,
@@ -80,7 +80,7 @@ export interface StandardTableProps<
    * Append tooltip to HTML element. This prop is passed to Tippy.
    * This is useful to solve z-index problems.
    */
-  appendTooltipTo?: TooltipProps["appendTo"];
+  appendTooltipTo?: TableHeadProps["appendTooltipTo"];
 
   /**
    * Items to list in the table.

--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -39,6 +39,7 @@ import { ColGroups } from "./ColGroups";
 import styles from "./StandardTable.module.css";
 import { StandardTableContent } from "./StandardTableContent";
 import { StandardTableHeadRow } from "./StandardTableHeadRow";
+import { TooltipProps } from "@stenajs-webui/tooltip";
 
 export interface StandardTableProps<
   TItem,
@@ -74,6 +75,12 @@ export interface StandardTableProps<
    * Config for the table. Required.
    */
   config: StandardTableConfig<TItem, TColumnKey, TColumnGroupKey>;
+
+  /**
+   * Append tooltip to HTML element. This prop is passed to Tippy.
+   * This is useful to solve z-index problems.
+   */
+  appendTooltipTo?: TooltipProps["appendTo"];
 
   /**
    * Items to list in the table.
@@ -160,6 +167,7 @@ export const StandardTable = function StandardTable<
   variant = "standard",
   onKeyDown,
   onSortOrderChange,
+  appendTooltipTo,
   ...props
 }: StandardTableProps<TItem, TColumnKey, TColumnGroupKey>) {
   const generatedTableId = useId();
@@ -297,6 +305,7 @@ export const StandardTable = function StandardTable<
                                   <StandardTableHeadRow
                                     items={props.items}
                                     height={"var(--current-row-height)"}
+                                    appendTooltipTo={appendTooltipTo}
                                   />
                                 </thead>
                                 <StandardTableContent

--- a/packages/grid/src/features/standard-table/components/StandardTableHeadItem.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableHeadItem.tsx
@@ -1,13 +1,15 @@
 import * as React from "react";
 import { CSSProperties } from "react";
-import { TableHeadItem } from "../../table-ui/components/table/TableHeadItem";
+import {
+  TableHeadItem,
+  TableHeadProps,
+} from "../../table-ui/components/table/TableHeadItem";
 import { useStickyPropsPerColumnContext } from "../context/StickyPropsPerColumnContext";
 import { useTableSortHeader } from "../features/sorting/UseTableSortHeader";
 import { useColumnConfigById } from "../hooks/UseColumnConfigById";
 import { useStandardTableConfig } from "../hooks/UseStandardTableConfig";
 import { getCellBorder } from "../util/CellBorderCalculator";
 import { formatColumnIdToHeaderCellLabel } from "../util/LabelFormatter";
-import { TooltipProps } from "@stenajs-webui/tooltip";
 
 export interface StandardTableHeaderItemProps {
   columnId: string;
@@ -15,7 +17,7 @@ export interface StandardTableHeaderItemProps {
   borderFromGroup?: boolean | string;
   stickyHeader?: boolean;
   top?: string | number;
-  appendTooltipTo?: TooltipProps["appendTo"];
+  appendTooltipTo?: TableHeadProps["appendTooltipTo"];
 }
 
 export const StandardTableHeadItem = React.memo(

--- a/packages/grid/src/features/standard-table/components/StandardTableHeadItem.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableHeadItem.tsx
@@ -7,6 +7,7 @@ import { useColumnConfigById } from "../hooks/UseColumnConfigById";
 import { useStandardTableConfig } from "../hooks/UseStandardTableConfig";
 import { getCellBorder } from "../util/CellBorderCalculator";
 import { formatColumnIdToHeaderCellLabel } from "../util/LabelFormatter";
+import { TooltipProps } from "@stenajs-webui/tooltip";
 
 export interface StandardTableHeaderItemProps {
   columnId: string;
@@ -14,6 +15,7 @@ export interface StandardTableHeaderItemProps {
   borderFromGroup?: boolean | string;
   stickyHeader?: boolean;
   top?: string | number;
+  appendTooltipTo?: TooltipProps["appendTo"];
 }
 
 export const StandardTableHeadItem = React.memo(
@@ -23,6 +25,7 @@ export const StandardTableHeadItem = React.memo(
     disableBorderLeft,
     stickyHeader,
     top,
+    appendTooltipTo,
   }: StandardTableHeaderItemProps) {
     const {
       justifyContentHeader,
@@ -102,6 +105,7 @@ export const StandardTableHeadItem = React.memo(
           sortOrderIconVariant={
             sortOrderIconVariant ?? defaultSortOrderIconVariant
           }
+          appendTooltipTo={appendTooltipTo}
           selected={selected}
           height={"100%"}
         />

--- a/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
@@ -17,10 +17,12 @@ import { useStandardTableConfig } from "../hooks/UseStandardTableConfig";
 import { getCellBorderFromGroup } from "../util/CellBorderCalculator";
 import { StandardTableHeadItem } from "./StandardTableHeadItem";
 import { TrWithHoverBackground } from "./TrWithHoverBackground";
+import { TooltipProps } from "@stenajs-webui/tooltip";
 
 interface StandardTableHeaderProps<TItem> {
   items?: Array<TItem>;
   height?: string;
+  appendTooltipTo?: TooltipProps["appendTo"];
 }
 
 const getTopPosition = (
@@ -43,7 +45,11 @@ const getTopPosition = (
 
 export const StandardTableHeadRow = React.memo(function StandardTableHeadRow<
   TItem
->({ items, height = defaultTableRowHeight }: StandardTableHeaderProps<TItem>) {
+>({
+  items,
+  appendTooltipTo,
+  height = defaultTableRowHeight,
+}: StandardTableHeaderProps<TItem>) {
   const groupConfigsAndIds = useGroupConfigsAndIdsForRows();
 
   const {
@@ -171,6 +177,7 @@ export const StandardTableHeadRow = React.memo(function StandardTableHeadRow<
                   disableBorderLeft={groupIndex === 0 && index === 0}
                   stickyHeader={stickyHeader}
                   top={stickyHeaderStyle.top}
+                  appendTooltipTo={appendTooltipTo}
                 />
               );
             })}

--- a/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableHeadRow.tsx
@@ -17,12 +17,12 @@ import { useStandardTableConfig } from "../hooks/UseStandardTableConfig";
 import { getCellBorderFromGroup } from "../util/CellBorderCalculator";
 import { StandardTableHeadItem } from "./StandardTableHeadItem";
 import { TrWithHoverBackground } from "./TrWithHoverBackground";
-import { TooltipProps } from "@stenajs-webui/tooltip";
+import { TableHeadProps } from "../../table-ui/components/table/TableHeadItem";
 
 interface StandardTableHeaderProps<TItem> {
   items?: Array<TItem>;
   height?: string;
-  appendTooltipTo?: TooltipProps["appendTo"];
+  appendTooltipTo?: TableHeadProps["appendTooltipTo"];
 }
 
 const getTopPosition = (

--- a/packages/grid/src/features/table-ui/components/table/TableHeadItem.tsx
+++ b/packages/grid/src/features/table-ui/components/table/TableHeadItem.tsx
@@ -11,6 +11,7 @@ import {
   ButtonWithPopoverProps,
   Popover,
   Tooltip,
+  TooltipProps,
 } from "@stenajs-webui/tooltip";
 import * as React from "react";
 import { CSSProperties, useRef } from "react";
@@ -30,6 +31,7 @@ export interface TableHeadProps extends BoxProps {
   selected?: boolean;
   alignRight?: boolean;
   sortOrderIconVariant?: SortOrderIconVariant;
+  appendTooltipTo?: TooltipProps["appendTo"];
 }
 
 export const TableHeadItem: React.FC<TableHeadProps> = React.memo(
@@ -45,6 +47,7 @@ export const TableHeadItem: React.FC<TableHeadProps> = React.memo(
     overflow = "hidden",
     alignRight,
     sortOrderIconVariant,
+    appendTooltipTo,
     ...boxProps
   }) => {
     const containerRef = useRef(null);
@@ -120,6 +123,7 @@ export const TableHeadItem: React.FC<TableHeadProps> = React.memo(
                 <Tooltip
                   label={infoIconTooltipText}
                   zIndex={"var(--swui-sticky-popover-z-index)" as any}
+                  appendTo={appendTooltipTo}
                 >
                   <Icon
                     icon={stenaInfoCircle}


### PR DESCRIPTION
- Add `appendTooltipTo` prop to StandardTable, which is passed to the Tooltip `appendTo` prop.