### PR TITLE
Redesign ButtonGroup and ToggleButton

### DIFF
--- a/packages/core/src/types/ElementProps.tsx
+++ b/packages/core/src/types/ElementProps.tsx
@@ -21,6 +21,8 @@ export type H1Props = ComponentPropsWithoutRef<"h1">;
 
 export type ButtonElementProps = ComponentPropsWithoutRef<"button">;
 
+export type InputElementProps = ComponentPropsWithoutRef<"input">;
+
 export type AnchorElementProps = ComponentPropsWithoutRef<"a">;
 
 export interface WithInnerRef<TInputElement> {

--- a/packages/elements/src/components/ui/action-menu/ActionMenu.stories.tsx
+++ b/packages/elements/src/components/ui/action-menu/ActionMenu.stories.tsx
@@ -1,4 +1,3 @@
-import { faFire } from "@fortawesome/free-solid-svg-icons/faFire";
 import { faSave } from "@fortawesome/free-solid-svg-icons/faSave";
 import { useBoolean, useTimeoutState } from "@stenajs-webui/core";
 import { action } from "@storybook/addon-actions";
@@ -7,7 +6,6 @@ import { ActionMenu } from "./ActionMenu";
 import { ActionMenuSeparator } from "./ActionMenuSeparator";
 import markdown from "./ActionMenu.md?raw";
 import {
-  faExternalLinkAlt,
   faSadCry,
   faToggleOff,
   faToggleOn,
@@ -15,12 +13,16 @@ import {
 import { ActionMenuLink } from "./ActionMenuLink";
 import { ActionMenuItemContent } from "./ActionMenuItemContent";
 import { ButtonGroup } from "../button-group/ButtonGroup";
-import { faAirFreshener } from "@fortawesome/free-solid-svg-icons/faAirFreshener";
-import { SecondaryButton } from "../buttons/SecondaryButton";
-import { PrimaryButton } from "../buttons/PrimaryButton";
-import { stenaSearch } from "../../../icons/ui/IconsUi";
+import {
+  stenaExternalLink,
+  stenaSave,
+  stenaSearch,
+  stenaSlidersMini,
+  stenaTrash,
+} from "../../../icons/ui/IconsUi";
 import * as React from "react";
 import { useState } from "react";
+import { ToggleButton } from "../toggle-button/ToggleButton";
 
 export default {
   title: "elements/ActionMenu",
@@ -40,38 +42,38 @@ export const Standard = () => (
     />
     <ActionMenuItem
       label={"Save"}
-      leftIcon={faSave}
+      leftIcon={stenaSave}
       onClick={action("Saved")}
     />
     <ActionMenuLink
       label={"Open new window"}
-      leftIcon={faExternalLinkAlt}
+      leftIcon={stenaExternalLink}
       href={"https://www.google.com"}
       target={"_blank"}
     />
     <ActionMenuLink
       label={"Open disabled"}
       disabled
-      leftIcon={faExternalLinkAlt}
+      leftIcon={stenaExternalLink}
       href={"https://www.google.com"}
       target={"_blank"}
     />
     <ActionMenuItem
       label={"Burn it"}
-      leftIcon={faFire}
+      leftIcon={stenaTrash}
       onClick={action("It was burned!")}
       variant={"danger"}
     />
     <ActionMenuItem
       label={"Disabled danger"}
-      leftIcon={faFire}
+      leftIcon={stenaTrash}
       onClick={action("Oh noes how did you activate this!?")}
       variant={"danger"}
       disabled={true}
     />
     <ActionMenuItem
       label={"Save it"}
-      leftIcon={faSave}
+      leftIcon={stenaSave}
       onClick={action("It was saved!")}
     />
     <ActionMenuItem
@@ -88,9 +90,9 @@ export const Standard = () => (
       label={"Content right"}
       right={
         <ButtonGroup>
-          <PrimaryButton size={"small"} label={"S"} />
-          <SecondaryButton size={"small"} label={"M"} />
-          <SecondaryButton size={"small"} label={"L"} />
+          <ToggleButton value={true} size={"small"} label={"S"} />
+          <ToggleButton size={"small"} label={"M"} />
+          <ToggleButton size={"small"} label={"L"} />
         </ButtonGroup>
       }
     />
@@ -99,23 +101,23 @@ export const Standard = () => (
       leftIcon={stenaSearch}
       bottom={
         <ButtonGroup>
-          <SecondaryButton size={"small"} label={"25"} />
-          <PrimaryButton size={"small"} label={"50"} />
-          <SecondaryButton size={"small"} label={"100"} />
+          <ToggleButton size={"small"} label={"25"} />
+          <ToggleButton value={true} size={"small"} label={"50"} />
+          <ToggleButton size={"small"} label={"100"} />
         </ButtonGroup>
       }
     />
     <ActionMenuItemContent
       label={"Bottom full width"}
-      leftIcon={faAirFreshener}
+      leftIcon={stenaSlidersMini}
       bottom={
         <ButtonGroup>
-          <SecondaryButton size={"small"} label={"10"} />
-          <PrimaryButton size={"small"} label={"20"} />
-          <SecondaryButton size={"small"} label={"30"} />
-          <SecondaryButton size={"small"} label={"40"} />
-          <SecondaryButton size={"small"} label={"50"} />
-          <SecondaryButton size={"small"} label={"60"} />
+          <ToggleButton size={"small"} label={"10"} />
+          <ToggleButton size={"small"} label={"20"} value={true} />
+          <ToggleButton size={"small"} label={"30"} />
+          <ToggleButton size={"small"} label={"40"} />
+          <ToggleButton size={"small"} label={"50"} />
+          <ToggleButton size={"small"} label={"60"} />
         </ButtonGroup>
       }
       fullWidthBottomContent
@@ -123,15 +125,15 @@ export const Standard = () => (
     <ActionMenuItemContent
       disabled
       label={"Bottom full width disabled"}
-      leftIcon={faAirFreshener}
+      leftIcon={stenaSlidersMini}
       bottom={
         <ButtonGroup>
-          <SecondaryButton size={"small"} label={"10"} disabled />
-          <PrimaryButton size={"small"} label={"20"} disabled />
-          <SecondaryButton size={"small"} label={"30"} disabled />
-          <SecondaryButton size={"small"} label={"40"} disabled />
-          <SecondaryButton size={"small"} label={"50"} disabled />
-          <SecondaryButton size={"small"} label={"60"} disabled />
+          <ToggleButton size={"small"} label={"10"} disabled />
+          <ToggleButton value={true} size={"small"} label={"20"} disabled />
+          <ToggleButton size={"small"} label={"30"} disabled />
+          <ToggleButton size={"small"} label={"40"} disabled />
+          <ToggleButton size={"small"} label={"50"} disabled />
+          <ToggleButton size={"small"} label={"60"} disabled />
         </ButtonGroup>
       }
       fullWidthBottomContent

--- a/packages/elements/src/components/ui/button-group/ButtonGroup.module.css
+++ b/packages/elements/src/components/ui/button-group/ButtonGroup.module.css
@@ -1,26 +1,9 @@
 .buttonGroup {
-  display: flex;
+  display: inline-flex;
+  flex-direction: row;
+  padding: 2px;
+  gap: 2px;
+  border: 2px solid var(--lhds-color-ui-300);
 
-  & > button {
-    margin: 0;
-    position: relative;
-
-    &:not(:only-child):not(:last-child) {
-      margin-right: -1px;
-    }
-
-    &:hover:not(:disabled),
-    &:focus-visible {
-      z-index: 1;
-    }
-
-    &:not(:first-child) {
-      border-top-left-radius: 0;
-      border-bottom-left-radius: 0;
-    }
-    &:not(:last-child) {
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
-    }
-  }
+  border-radius: 12px;
 }

--- a/packages/elements/src/components/ui/button-group/ButtonGroup.stories.tsx
+++ b/packages/elements/src/components/ui/button-group/ButtonGroup.stories.tsx
@@ -1,11 +1,15 @@
-import { faAddressBook } from "@fortawesome/free-solid-svg-icons/faAddressBook";
-import { faAnchor } from "@fortawesome/free-solid-svg-icons/faAnchor";
-import { faEraser } from "@fortawesome/free-solid-svg-icons/faEraser";
-import { faRecycle } from "@fortawesome/free-solid-svg-icons/faRecycle";
 import { Row, Spacing } from "@stenajs-webui/core";
 import * as React from "react";
 import { SecondaryButton } from "../buttons/SecondaryButton";
 import { ButtonGroup } from "./ButtonGroup";
+import { FlatButton } from "../buttons/FlatButton";
+import {
+  stenaAccount,
+  stenaAnimals,
+  stenaSailingTicket,
+  stenaSailingTrain,
+  stenaSupport,
+} from "../../../icons/ui/IconsUi";
 
 export default {
   title: "elements/ButtonGroup",
@@ -17,26 +21,26 @@ export const Overview = () => (
   <>
     <Row>
       <ButtonGroup>
-        <SecondaryButton leftIcon={faRecycle} />
-        <SecondaryButton leftIcon={faAddressBook} />
-        <SecondaryButton leftIcon={faAddressBook} />
-        <SecondaryButton leftIcon={faAddressBook} />
-        <SecondaryButton leftIcon={faAnchor} />
+        <FlatButton leftIcon={stenaAccount} />
+        <FlatButton leftIcon={stenaAnimals} />
+        <FlatButton leftIcon={stenaSailingTicket} />
+        <FlatButton leftIcon={stenaSailingTrain} />
+        <FlatButton leftIcon={stenaSupport} />
       </ButtonGroup>
     </Row>
     <Spacing />
     <Row>
       <ButtonGroup>
-        <SecondaryButton leftIcon={faRecycle} />
-        <SecondaryButton leftIcon={faAddressBook} />
-        <SecondaryButton leftIcon={faAnchor} />
+        <FlatButton leftIcon={stenaSailingTicket} />
+        <FlatButton leftIcon={stenaSailingTrain} />
+        <FlatButton leftIcon={stenaSupport} />
       </ButtonGroup>
     </Row>
     <Spacing />
     <Row>
       <ButtonGroup>
-        <SecondaryButton leftIcon={faEraser} />
-        <SecondaryButton leftIcon={faEraser} />
+        <FlatButton leftIcon={stenaSailingTicket} />
+        <FlatButton leftIcon={stenaSailingTrain} />
       </ButtonGroup>
     </Row>
   </>

--- a/packages/elements/src/components/ui/button-group/ButtonGroup.tsx
+++ b/packages/elements/src/components/ui/button-group/ButtonGroup.tsx
@@ -1,11 +1,12 @@
 import cx from "classnames";
 import * as React from "react";
 import styles from "./ButtonGroup.module.css";
-import { ReactNode } from "react";
+import { ToggleButtonProps } from "../toggle-button/ToggleButton";
+import { FlatButtonProps } from "../buttons/FlatButton";
 
 export interface ButtonGroupProps {
   className?: string;
-  children?: ReactNode;
+  children: Iterable<React.ReactElement<ToggleButtonProps | FlatButtonProps>>;
 }
 
 export const ButtonGroup: React.FC<ButtonGroupProps> = ({

--- a/packages/elements/src/components/ui/toggle-button/ToggleButton.module.css
+++ b/packages/elements/src/components/ui/toggle-button/ToggleButton.module.css
@@ -2,36 +2,67 @@
   --swui-toggle-button-height: 32px;
 
   --swui-toggle-button-background: var(--swui-white);
-  --swui-toggle-button-background-pressed: var(--lhds-color-blue-100);
-  --swui-toggle-button-background-hover: var(--lhds-color-blue-50);
-  --swui-toggle-button-background-disabled: var(--lhds-color-ui-300);
+  --swui-toggle-button-background-selected: var(--lhds-color-blue-200);
+  --swui-toggle-button-background-hover: var(--lhds-color-ui-200);
+  --swui-toggle-button-background-focus: var(--lhds-color-blue-100);
+  --swui-toggle-button-background-focus-selected: var(--lhds-color-blue-300);
+  --swui-toggle-button-background-active: var(--lhds-color-blue-100);
+  --swui-toggle-button-background-disabled: var(--lhds-color-ui-500);
 
   --swui-toggle-button-text-color: var(--swui-button-text-color);
-  --swui-toggle-button-text-color-pressed: var(--swui-button-text-color);
+  --swui-toggle-button-text-color-disabled: var(--lhds-color-ui-50);
 
-  --swui-toggle-button-border-color: var(--lhds-color-ui-400);
-  --swui-toggle-button-border-color-hover: var(--lhds-color-blue-500);
-  --swui-toggle-button-border-color-pressed: var(--lhds-color-blue-500);
-  --swui-toggle-button-border-color-focus: var(--lhds-color-blue-500);
-  --swui-toggle-button-border-color-disabled: var(--lhds-color-ui-300);
+  /* State */
 
-  --swui-toggle-button-bow-shadow: none;
-  --swui-toggle-button-box-shadow-hover: 0 1px 1px 1px rgba(29, 100, 171, 0.16);
-  --swui-toggle-button-box-shadow-focus: inset 0 0 2px 1px
-    var(--lhds-color-blue-300);
+  --current-background: var(--swui-toggle-button-background);
 
-  background: var(--swui-toggle-button-background);
-  border: 1px solid var(--swui-toggle-button-border-color);
-  border-radius: var(--swui-border-radius);
-  box-shadow: var(--swui-toggle-button-bow-shadow);
-  box-sizing: border-box;
-  cursor: pointer;
-  height: var(--swui-toggle-button-height);
-  outline: 0;
-  padding: 0 var(--swui-metrics-space);
+  /* Styling */
+
+  label {
+    background: var(--current-background);
+    border-radius: var(--swui-border-radius);
+    cursor: pointer;
+    height: var(--swui-toggle-button-height);
+    min-width: var(--swui-toggle-button-height);
+    padding: 0 calc(var(--swui-metrics-space) * 1);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    font-family: var(--swui-font-primary);
+    font-weight: var(--swui-font-weight-text);
+    font-size: var(--swui-font-size-medium);
+    color: var(--swui-toggle-button-text-color);
+    user-select: none;
+  }
+
+  input {
+    position: absolute;
+    left: -100vw;
+  }
+
+  input:focus-visible ~ label {
+    --current-background: var(--swui-toggle-button-background-focus);
+  }
+
+  &.selected {
+    input:focus-visible ~ label {
+      --current-background: var(--swui-toggle-button-background-focus-selected);
+    }
+  }
+
+  &.disabled {
+    label {
+      color: var(--swui-toggle-button-text-color-disabled);
+    }
+  }
 
   &.small {
     --swui-toggle-button-height: 24px;
+    label {
+      font-size: var(--swui-font-size-small);
+    }
   }
 
   &.medium {
@@ -43,59 +74,23 @@
     padding: 0 calc(2 * var(--swui-metrics-space));
   }
 
-  .label {
-    color: var(--swui-toggle-button-text-color);
-  }
-
-  &:focus-visible {
-    --swui-toggle-button-border-color: var(
-      --swui-toggle-button-border-color-focus
-    );
-    --swui-toggle-button-bow-shadow: var(--swui-toggle-button-box-shadow-focus);
-  }
-
-  &:hover:not(:disabled) {
-    --swui-toggle-button-background: var(--swui-toggle-button-background-hover);
-    --swui-toggle-button-border-color: var(
-      --swui-toggle-button-border-color-hover
-    );
-    --swui-toggle-button-bow-shadow: var(--swui-toggle-button-box-shadow-hover);
-
-    &:focus-visible {
-      --swui-toggle-button-bow-shadow: var(
-          --swui-toggle-button-box-shadow-hover
-        ),
-        var(--swui-toggle-button-box-shadow-focus);
-    }
-  }
-
-  &.pressed {
-    --swui-toggle-button-background: var(
-      --swui-toggle-button-background-pressed
-    );
-    --swui-toggle-button-border-color: var(
-      --swui-toggle-button-border-color-pressed
-    );
-    z-index: 1;
-
+  &:not(.disabled) {
     &:hover {
-      --swui-toggle-button-background: var(
-        --swui-toggle-button-background-pressed
-      );
+      --current-background: var(--swui-toggle-button-background-hover);
+    }
+
+    &:active {
+      --current-background: var(--swui-toggle-button-background-active);
+    }
+
+    &.selected {
+      --current-background: var(--swui-toggle-button-background-selected);
+      z-index: 1;
     }
   }
 
-  &:disabled {
-    --swui-toggle-button-background: var(
-      --swui-toggle-button-background-disabled
-    );
-    --swui-toggle-button-border-color: var(
-      --swui-toggle-button-border-color-disabled
-    );
+  &.disabled {
+    --current-background: var(--swui-toggle-button-background-disabled);
     cursor: not-allowed;
-
-    .label {
-      color: var(--swui-text-disabled-color);
-    }
   }
 }

--- a/packages/elements/src/components/ui/toggle-button/ToggleButton.stories.tsx
+++ b/packages/elements/src/components/ui/toggle-button/ToggleButton.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { useState } from "react";
+import { ToggleButton, ToggleButtonSize } from "./ToggleButton";
+import { Column } from "@stenajs-webui/core";
 import { ButtonGroup } from "../button-group/ButtonGroup";
-import { ToggleButton } from "./ToggleButton";
 
 export default {
   title: "elements/ToggleButton",
@@ -20,6 +21,7 @@ interface State {
 
 export const Weekdays = () => {
   const [state, setState] = useState<State>({});
+
   return (
     <ButtonGroup>
       <ToggleButton
@@ -56,6 +58,7 @@ export const Weekdays = () => {
         label={"Sunday"}
         onValueChange={(sun) => setState({ ...state, sun })}
         value={state.sun}
+        disabled
       />
     </ButtonGroup>
   );
@@ -100,7 +103,64 @@ export const ShortWeekdays = () => {
         label={"S"}
         onValueChange={(sun) => setState({ ...state, sun })}
         value={state.sun}
+        disabled
       />
     </ButtonGroup>
+  );
+};
+
+export const Sizes = () => {
+  const [state, setState] = useState<State>({});
+  const sizes: Array<ToggleButtonSize> = ["small", "medium", "large"];
+  return (
+    <Column gap={4}>
+      {sizes.map((size) => (
+        <ButtonGroup>
+          <ToggleButton
+            label={"Monday"}
+            onValueChange={(mon) => setState({ ...state, mon })}
+            value={state.mon}
+            size={size}
+          />
+          <ToggleButton
+            label={"Tuesday"}
+            onValueChange={(tue) => setState({ ...state, tue })}
+            value={state.tue}
+            size={size}
+          />
+          <ToggleButton
+            label={"Wednesday"}
+            onValueChange={(wed) => setState({ ...state, wed })}
+            value={state.wed}
+            size={size}
+          />
+          <ToggleButton
+            label={"Thursday"}
+            onValueChange={(thu) => setState({ ...state, thu })}
+            value={state.thu}
+            size={size}
+          />
+          <ToggleButton
+            label={"Friday"}
+            onValueChange={(fri) => setState({ ...state, fri })}
+            value={state.fri}
+            size={size}
+          />
+          <ToggleButton
+            label={"Saturday"}
+            onValueChange={(sat) => setState({ ...state, sat })}
+            value={state.sat}
+            size={size}
+          />
+          <ToggleButton
+            label={"Sunday"}
+            onValueChange={(sun) => setState({ ...state, sun })}
+            value={state.sun}
+            size={size}
+            disabled
+          />
+        </ButtonGroup>
+      ))}
+    </Column>
   );
 };

--- a/packages/elements/src/components/ui/toggle-button/ToggleButton.tsx
+++ b/packages/elements/src/components/ui/toggle-button/ToggleButton.tsx
@@ -60,7 +60,6 @@ export const ToggleButton: React.FC<ToggleButtonProps> = forwardRef<
     >
       <input
         type={"checkbox"}
-        aria-pressed={value}
         onChange={onChangeHandler}
         disabled={disabled}
         checked={value}

--- a/packages/elements/src/components/ui/toggle-button/ToggleButton.tsx
+++ b/packages/elements/src/components/ui/toggle-button/ToggleButton.tsx
@@ -1,46 +1,29 @@
-import styled from "@emotion/styled";
-import { ButtonElementProps, Text } from "@stenajs-webui/core";
-import { forwardRef, useCallback } from "react";
+import { InputElementProps } from "@stenajs-webui/core";
 import * as React from "react";
+import { forwardRef, useCallback, useId } from "react";
 import cx from "classnames";
-import { width, WidthProps } from "styled-system";
 import styles from "./ToggleButton.module.css";
 
 export type ToggleButtonSize = "small" | "medium" | "large";
 
 export interface ToggleButtonProps
-  extends WidthProps,
-    Omit<ButtonElementProps, "value"> {
+  extends Omit<InputElementProps, "value" | "size" | "checked"> {
+  value?: boolean;
+  onValueChange?: (value: boolean) => void;
+
   /**
    * The label of the button.
    */
   label?: string | number;
 
   /**
-   * The pressed state change handler.
-   */
-  onValueChange?: (value: boolean) => void;
-
-  /**
-   * If true, the button will display as pressed.
-   */
-  value?: boolean;
-
-  /**
    * The size of the button.
    */
   size?: ToggleButtonSize;
-
-  /**
-   * If true, the button will be disabled.
-   */
-  disabled?: boolean;
 }
 
-const Button = styled.button(width);
-
 export const ToggleButton: React.FC<ToggleButtonProps> = forwardRef<
-  HTMLButtonElement,
+  HTMLInputElement,
   ToggleButtonProps
 >(function ToggleButton(
   {
@@ -48,32 +31,45 @@ export const ToggleButton: React.FC<ToggleButtonProps> = forwardRef<
     value,
     size = "medium",
     onValueChange,
+    onChange,
     disabled,
-    onClick,
-    ...buttonProps
+    ...inputProps
   },
   ref
 ) {
-  const handleClick = useCallback(
-    (ev: React.MouseEvent<HTMLButtonElement>) => {
-      onClick?.(ev);
+  const id = useId();
+
+  const onChangeHandler = useCallback<
+    React.ChangeEventHandler<HTMLInputElement>
+  >(
+    (ev) => {
+      onChange?.(ev);
       onValueChange?.(!value);
     },
-    [onClick, onValueChange, value]
+    [onChange, onValueChange, value]
   );
 
   return (
-    <Button
-      aria-pressed={value}
-      className={cx(styles.toggleButton, styles[size], value && styles.pressed)}
-      onClick={handleClick}
-      disabled={disabled}
-      ref={ref}
-      {...buttonProps}
+    <div
+      className={cx(
+        styles.toggleButton,
+        styles[size],
+        value && styles.selected,
+        disabled && styles.disabled
+      )}
     >
-      <Text size={"small"} className={styles.label}>
-        {label}
-      </Text>
-    </Button>
+      <input
+        type={"checkbox"}
+        aria-pressed={value}
+        onChange={onChangeHandler}
+        disabled={disabled}
+        checked={value}
+        ref={ref}
+        id={id}
+        value={label}
+        {...inputProps}
+      />
+      <label htmlFor={id}>{label}</label>
+    </div>
   );
 });

--- a/packages/panels/src/components/action-menu-button/ActionMenuButton.stories.tsx
+++ b/packages/panels/src/components/action-menu-button/ActionMenuButton.stories.tsx
@@ -4,14 +4,15 @@ import {
   ActionMenuLink,
   ActionMenuSeparator,
   ButtonGroup,
-  PrimaryButton,
-  SecondaryButton,
+  stenaBusinessClaim,
+  stenaSave,
+  stenaTrash,
+  ToggleButton,
 } from "@stenajs-webui/elements";
 import { faCoffee } from "@fortawesome/free-solid-svg-icons/faCoffee";
 import { faEllipsisV } from "@fortawesome/free-solid-svg-icons/faEllipsisV";
 import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons/faExternalLinkAlt";
 import { faFire } from "@fortawesome/free-solid-svg-icons/faFire";
-import { faSave } from "@fortawesome/free-solid-svg-icons/faSave";
 import {
   Box,
   Column,
@@ -53,15 +54,15 @@ export const Overview = () => (
           renderItems={(close) => (
             <>
               <ActionMenuItem label={"Open"} />
-              <ActionMenuItem label={"Save"} leftIcon={faSave} />
+              <ActionMenuItem label={"Save"} leftIcon={stenaSave} />
               <ActionMenuItem
                 label={"Don't close on click"}
                 disableCloseOnClick
-                leftIcon={faCoffee}
+                leftIcon={stenaBusinessClaim}
               />
               <ActionMenuItem
                 label={"Burn it"}
-                leftIcon={faFire}
+                leftIcon={stenaTrash}
                 variant={"danger"}
               />
               <ActionMenuItem label={"Disabled"} disabled />
@@ -69,9 +70,9 @@ export const Overview = () => (
                 label={"Content right"}
                 right={
                   <ButtonGroup>
-                    <PrimaryButton size={"small"} label={"S"} />
-                    <SecondaryButton size={"small"} label={"M"} />
-                    <SecondaryButton size={"small"} label={"L"} />
+                    <ToggleButton value={true} size={"small"} label={"S"} />
+                    <ToggleButton size={"small"} label={"M"} />
+                    <ToggleButton size={"small"} label={"L"} />
                   </ButtonGroup>
                 }
               />
@@ -79,17 +80,14 @@ export const Overview = () => (
                 label={"Content very much text"}
                 bottom={
                   <ButtonGroup>
-                    <SecondaryButton
-                      size={"small"}
-                      label={"25"}
-                      onClick={close}
-                    />
-                    <PrimaryButton
+                    <ToggleButton size={"small"} label={"25"} onClick={close} />
+                    <ToggleButton
+                      value={true}
                       size={"small"}
                       label={"50"}
                       onClick={close}
                     />
-                    <SecondaryButton
+                    <ToggleButton
                       size={"small"}
                       label={"100"}
                       onClick={close}

--- a/packages/theme/src/styles/default-colors.css
+++ b/packages/theme/src/styles/default-colors.css
@@ -58,7 +58,7 @@
   --lhds-color-ui-50: #ffffff;
   --lhds-color-ui-100: #fafafb;
   --lhds-color-ui-200: var(--silver-lighter);
-  --lhds-color-ui-300: #e4e5e9;
+  --lhds-color-ui-300: #e4e4e4;
   --lhds-color-ui-400: var(--silver-light);
   --lhds-color-ui-500: var(--silver);
   --lhds-color-ui-600: #5c6171;


### PR DESCRIPTION
- Redesign ToggleButton.
- Redesign ButtonGroup.
- Breaking: ButtonGroup should contain ToggleButton or FlatButton, no other kind of button.
- Update icons and button groups in ActionMenu and ActionMenuButton stories.
- Remove aria-pressed from ToggleButton.

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/473e4f55-baaa-4c3a-9198-6f12213a7adf)

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/caf83d2a-e2df-4ac2-a969-27419074f4d6)

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/098f388e-6627-4c16-9cd9-4f8dc9df5916)
