### PR TITLE
Spread all props into RailMenuLink

### DIFF
--- a/packages/panels/src/components/sidebar-menu/items/SidebarMenuLink.tsx
+++ b/packages/panels/src/components/sidebar-menu/items/SidebarMenuLink.tsx
@@ -19,13 +19,7 @@ export const SidebarMenuLink: React.FC<SidebarMenuLinkProps> = (props) => {
   const isRail = useRailContext();
 
   if (isRail) {
-    return (
-      <RailMenuLink
-        leftIcon={props.leftIcon}
-        onClick={props.onClick}
-        label={props.label}
-      />
-    );
+    return <RailMenuLink {...props} />;
   }
 
   return <MenuButtonLink {...props} />;


### PR DESCRIPTION
Needed to allow custom `renderLink` function in rail mode.