### PR TITLE
Update StandardTable to allow easy ways to reduce text size

### DIFF
--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -58,6 +58,8 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
     return selectedIds.indexOf(itemKey) >= 0;
   }, [itemKey, selectedIds]);
 
+  const { defaultCellRenderer, defaultTextSize } = useStandardTableConfig();
+
   const {
     itemValueResolver,
     itemLabelFormatter,
@@ -132,20 +134,25 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
 
   const content = useMemo(
     () =>
-      renderCell ? (
-        renderCell({
-          label,
-          value: itemValue,
-          item,
-          gridCell,
-          isEditable: editable,
-          isSelected,
-          zIndex: currentZIndex,
-          itemKey,
-        })
-      ) : (
-        <TextCell label={label} />
-      ),
+      renderCell?.({
+        label,
+        value: itemValue,
+        item,
+        gridCell,
+        isEditable: editable,
+        isSelected,
+        zIndex: currentZIndex,
+        itemKey,
+      }) ??
+      defaultCellRenderer?.({
+        label,
+        item,
+        gridCell,
+        isEditable: editable,
+        isSelected,
+        zIndex: currentZIndex,
+        itemKey,
+      }) ?? <TextCell label={label} size={defaultTextSize} />,
     [
       renderCell,
       label,
@@ -156,6 +163,8 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
       isSelected,
       currentZIndex,
       itemKey,
+      defaultCellRenderer,
+      defaultTextSize,
     ]
   );
 

--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -20,6 +20,7 @@ import { getCellBorder } from "../util/CellBorderCalculator";
 import { formatValueLabel } from "../util/LabelFormatter";
 import { StandardTableCellUi } from "./StandardTableCellUi";
 import { TextCell } from "./TextCell";
+import { DefaultStandardTableCellRenderer } from "../config/StandardTableColumnConfig";
 
 export interface StandardTableCellProps<TItem> {
   columnId: string;
@@ -30,6 +31,11 @@ export interface StandardTableCellProps<TItem> {
   borderFromGroup?: boolean | string;
   disableBorderLeft?: boolean;
 }
+
+const fallbackCellRenderer: DefaultStandardTableCellRenderer<unknown> = ({
+  label,
+  textSize,
+}) => <TextCell label={label} size={textSize} />;
 
 export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
   columnId,
@@ -58,7 +64,8 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
     return selectedIds.indexOf(itemKey) >= 0;
   }, [itemKey, selectedIds]);
 
-  const { defaultCellRenderer, defaultTextSize } = useStandardTableConfig();
+  const { defaultCellRenderer = fallbackCellRenderer, defaultTextSize } =
+    useStandardTableConfig();
 
   const {
     itemValueResolver,
@@ -67,7 +74,7 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
     minWidth,
     justifyContentCell = "flex-start",
     borderLeft,
-    renderCell,
+    renderCell = defaultCellRenderer,
     gridCellOptions: gridCellOptionsForColumn,
     isEditable,
     onChange,
@@ -134,7 +141,7 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
 
   const content = useMemo(
     () =>
-      renderCell?.({
+      renderCell({
         label,
         value: itemValue,
         item,
@@ -142,17 +149,9 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
         isEditable: editable,
         isSelected,
         zIndex: currentZIndex,
+        textSize: defaultTextSize,
         itemKey,
-      }) ??
-      defaultCellRenderer?.({
-        label,
-        item,
-        gridCell,
-        isEditable: editable,
-        isSelected,
-        zIndex: currentZIndex,
-        itemKey,
-      }) ?? <TextCell label={label} size={defaultTextSize} />,
+      }),
     [
       renderCell,
       label,
@@ -163,7 +162,6 @@ export const StandardTableCell = React.memo(function StandardTableCell<TItem>({
       isSelected,
       currentZIndex,
       itemKey,
-      defaultCellRenderer,
       defaultTextSize,
     ]
   );

--- a/packages/grid/src/features/standard-table/components/TextCell.tsx
+++ b/packages/grid/src/features/standard-table/components/TextCell.tsx
@@ -1,17 +1,21 @@
-import { Indent, Text } from "@stenajs-webui/core";
+import { Indent, Text, TextSize } from "@stenajs-webui/core";
 import * as React from "react";
 import styles from "./TextCell.module.css";
 
 interface Props {
   label?: string;
+  size?: TextSize;
+  color?: string;
 }
 
 export const TextCell: React.FC<Props> = React.memo(function TextCell({
   label,
+  size,
+  color,
 }) {
   return (
     <Indent overflow={"hidden"}>
-      <Text className={styles.textCell} title={label}>
+      <Text className={styles.textCell} title={label} size={size} color={color}>
         {label}
       </Text>
     </Indent>

--- a/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
@@ -6,6 +6,7 @@ import {
 } from "../../grid-cell/hooks/UseGridCell";
 import { SortOrderIconVariant } from "../../table-ui/components/table/SortOrderIcon";
 import { StandardTableOnKeyDownArgs } from "./StandardTableConfig";
+import { TextSize } from "@stenajs-webui/core";
 
 export type StandardTableColumnConfig<
   TItem,
@@ -211,6 +212,7 @@ export interface StandardTableCellRendererArgObject<TItemValue, TItem> {
   gridCell: UseGridCellResult<string>;
   isEditable?: boolean;
   isSelected: boolean;
+  textSize?: TextSize;
   /**
    * The z-index used for that cell. Usable if the cell has a popover which should get same z-index for example.
    */
@@ -222,21 +224,8 @@ export interface StandardTableCellRendererArgObject<TItemValue, TItem> {
  * Therefor, it can not know "value: TItemValue", since it has not been defined yet.
  */
 export type DefaultStandardTableCellRenderer<TItem> = (
-  arg: DefaultStandardTableCellRendererArgObject<TItem>
+  arg: StandardTableCellRendererArgObject<unknown, TItem>
 ) => ReactNode;
-
-export interface DefaultStandardTableCellRendererArgObject<TItem> {
-  label: string;
-  item: TItem;
-  itemKey: string;
-  gridCell: UseGridCellResult<string>;
-  isEditable?: boolean;
-  isSelected: boolean;
-  /**
-   * The z-index used for that cell. Usable if the cell has a popover which should get same z-index for example.
-   */
-  zIndex?: number | string;
-}
 
 export type BackgroundResolver<TItem> = (item: TItem) => string | undefined;
 

--- a/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableColumnConfig.ts
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { ReactNode } from "react";
 import {
   UseGridCellOptions,
@@ -5,7 +6,6 @@ import {
 } from "../../grid-cell/hooks/UseGridCell";
 import { SortOrderIconVariant } from "../../table-ui/components/table/SortOrderIcon";
 import { StandardTableOnKeyDownArgs } from "./StandardTableConfig";
-import * as React from "react";
 
 export type StandardTableColumnConfig<
   TItem,
@@ -206,6 +206,27 @@ export type StandardTableCellRenderer<TItemValue, TItem> = (
 export interface StandardTableCellRendererArgObject<TItemValue, TItem> {
   label: string;
   value: TItemValue;
+  item: TItem;
+  itemKey: string;
+  gridCell: UseGridCellResult<string>;
+  isEditable?: boolean;
+  isSelected: boolean;
+  /**
+   * The z-index used for that cell. Usable if the cell has a popover which should get same z-index for example.
+   */
+  zIndex?: number | string;
+}
+
+/**
+ * Default renderer. This is defined in config, not for a specific column.
+ * Therefor, it can not know "value: TItemValue", since it has not been defined yet.
+ */
+export type DefaultStandardTableCellRenderer<TItem> = (
+  arg: DefaultStandardTableCellRendererArgObject<TItem>
+) => ReactNode;
+
+export interface DefaultStandardTableCellRendererArgObject<TItem> {
+  label: string;
   item: TItem;
   itemKey: string;
   gridCell: UseGridCellResult<string>;

--- a/packages/grid/src/features/standard-table/config/StandardTableConfig.ts
+++ b/packages/grid/src/features/standard-table/config/StandardTableConfig.ts
@@ -2,10 +2,12 @@ import { ReactNode } from "react";
 import { UseGridCellOptions } from "../../grid-cell/hooks/UseGridCell";
 import { SortOrderIconVariant } from "../../table-ui/components/table/SortOrderIcon";
 import {
+  DefaultStandardTableCellRenderer,
   StandardTableColumnConfig,
   StandardTableColumnConfigWithGroups,
 } from "./StandardTableColumnConfig";
 import { StandardTableColumnGroupConfig } from "./StandardTableColumnGroupConfig";
+import { TextSize } from "@stenajs-webui/core";
 
 export interface RowExpansionArgs {
   onRequestCollapse?: () => void;
@@ -220,6 +222,20 @@ export interface StandardTableConfigBase<TItem, TColumnKey extends string> {
    * @default amount
    */
   sortOrderIconVariant?: SortOrderIconVariant;
+
+  /**
+   * This can be used to override default text renderer for the whole table.
+   * Column cellRenderer will still override this. Since this is global for the table, and not local to a column,
+   * the type of itemValue can not be known. It should use `label` as source of text instead.
+   * If omitted, TextCell is used as usual.
+   */
+  defaultCellRenderer?: DefaultStandardTableCellRenderer<TItem>;
+
+  /**
+   * This config specifies the text size to be used by the default TextCell component.
+   * If omitted, "normal" is used.
+   */
+  defaultTextSize?: TextSize;
 }
 
 export interface RowBackgroundResolverColorCombination {

--- a/packages/grid/src/features/standard-table/helpers/cell-renderers/editable-text-cell/EditableTextCell.tsx
+++ b/packages/grid/src/features/standard-table/helpers/cell-renderers/editable-text-cell/EditableTextCell.tsx
@@ -1,10 +1,12 @@
-import { Indent, Text } from "@stenajs-webui/core";
+import { Indent, Text, TextSize } from "@stenajs-webui/core";
 import { TextInput } from "@stenajs-webui/forms";
 import * as React from "react";
 import { StandardTableCellRenderer } from "../../../config/StandardTableColumnConfig";
 
 export const createStandardEditableTextCell =
-  <TItemValue, TItem>(): StandardTableCellRenderer<TItemValue, TItem> =>
+  <TItemValue, TItem>(
+    textSize?: TextSize
+  ): StandardTableCellRenderer<TItemValue, TItem> =>
   ({
     label,
     gridCell: {
@@ -29,6 +31,8 @@ export const createStandardEditableTextCell =
       />
     ) : (
       <Indent>
-        <Text color={"var(--swui-primary-action-color)"}>{label}</Text>
+        <Text color={"var(--swui-primary-action-color)"} size={textSize}>
+          {label}
+        </Text>
       </Indent>
     );

--- a/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
@@ -50,6 +50,48 @@ export const Overview = () => {
   return <StandardTable items={items} config={config} />;
 };
 
+export const DefaultTextSize = () => {
+  const { items, onChangeNumPassengers } = useListState(mockedItems);
+
+  const config: StandardTableConfig<ListItem, keyof ListItem> = {
+    ...standardTableConfigForStories,
+    defaultTextSize: "smaller",
+    checkboxDisabledResolver: (item) => item.id === "125",
+    columns: {
+      ...standardTableConfigForStories.columns,
+      numPassengers: {
+        ...standardTableConfigForStories.columns.numPassengers,
+        onChange: onChangeNumPassengers,
+      },
+    },
+  };
+
+  return <StandardTable items={items} config={config} />;
+};
+
+export const DefaultCellRenderer = () => {
+  const { items, onChangeNumPassengers } = useListState(mockedItems);
+
+  const config: StandardTableConfig<ListItem, keyof ListItem> = {
+    ...standardTableConfigForStories,
+    defaultCellRenderer: ({ label }) => (
+      <Indent>
+        <Tag label={label} variant={"success"} />
+      </Indent>
+    ),
+    checkboxDisabledResolver: (item) => item.id === "125",
+    columns: {
+      ...standardTableConfigForStories.columns,
+      numPassengers: {
+        ...standardTableConfigForStories.columns.numPassengers,
+        onChange: onChangeNumPassengers,
+      },
+    },
+  };
+
+  return <StandardTable items={items} config={config} />;
+};
+
 export const Variants = () => {
   const { items } = useListState(mockedItems);
 


### PR DESCRIPTION
- Add two new config options to StandardTable.

### defaultCellRenderer

This can be used to override default text renderer for the whole table.
Column cellRenderer will still override this. Since this is global for the table, and not local to a column,
the type of itemValue can not be known. It should use `label` as source of text instead.
If omitted, TextCell is used as usual.

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/3e1ac0d1-cee3-4306-86d0-fa0f5ee82c42)


### defaultTextSize

This config specifies the text size to be used by the default TextCell component.
If omitted, "normal" is used.

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/4fc25827-6d94-497a-87fd-0965f45bfc59)
