### PR TITLE
Bottom items in SidebarMenu

### DIFF
--- a/packages/core/src/components/decorators/separatorline/SeparatorLine.tsx
+++ b/packages/core/src/components/decorators/separatorline/SeparatorLine.tsx
@@ -2,6 +2,7 @@ import styled from "@emotion/styled";
 import { Property } from "csstype";
 import * as React from "react";
 import { forwardRef } from "react";
+import { cssColor } from "@stenajs-webui/theme";
 
 export interface SeparatorLineProps {
   color?: Property.Color;
@@ -32,7 +33,7 @@ const SeparatorLineComponent = styled.hr<SeparatorLineComponentProps>`
 export const SeparatorLine = forwardRef<HTMLHRElement, SeparatorLineProps>(
   (
     {
-      color = "var(--lhds-color-ui-300)",
+      color = cssColor("--lhds-color-ui-300"),
       size = "100%",
       width = "1px",
       vertical = false,

--- a/packages/panels/src/components/nav-bar/NavBar.stories.tsx
+++ b/packages/panels/src/components/nav-bar/NavBar.stories.tsx
@@ -19,9 +19,12 @@ import {
   stenaBusinessClaim,
   stenaBusinessInvoice,
   stenaCalendar,
+  stenaClock,
   stenaCog,
+  stenaHelp,
   stenaSailingTicket,
   stenaSignOut,
+  stenaSlidersMini,
   stenaStatisticsBar,
   stenaStatisticsLine,
   stenaStatusNoShow,
@@ -125,6 +128,26 @@ export const Demo: Story<Pick<NavBarProps, "variant">> = ({ variant }) => {
     </>
   );
 
+  const bottomItems = (
+    <>
+      <SidebarMenuLink
+        leftIcon={stenaClock}
+        label={"Timetable"}
+        onClick={() => alert("Click on quick guide")}
+      />
+      <SidebarMenuLink
+        leftIcon={stenaHelp}
+        label={"Help"}
+        onClick={() => alert("Click on contact")}
+      />
+      <SidebarMenuLink
+        leftIcon={stenaSlidersMini}
+        label={"Settings"}
+        onClick={() => alert("Click on contact")}
+      />
+    </>
+  );
+
   return (
     <div>
       <Drawer isOpen={isOpen} onRequestClose={close} width={"250px"}>
@@ -134,6 +157,7 @@ export const Demo: Story<Pick<NavBarProps, "variant">> = ({ variant }) => {
             pinButtonVisible
             onClickPinButton={togglePin}
             isPinned={pinned}
+            bottomItems={bottomItems}
           >
             {sidebarMenuItems}
           </SidebarMenu>
@@ -144,6 +168,7 @@ export const Demo: Story<Pick<NavBarProps, "variant">> = ({ variant }) => {
           onClickMenuButton={open}
           closeButtonVisible
           onClickCloseButton={unpin}
+          bottomItems={bottomItems}
         >
           {sidebarMenuItems}
         </SidebarRailMenu>

--- a/packages/panels/src/components/sidebar-menu/SidebarMenu.tsx
+++ b/packages/panels/src/components/sidebar-menu/SidebarMenu.tsx
@@ -51,13 +51,15 @@ export const SidebarMenu: React.FC<SidebarMenuProps> = ({
       >
         <Column justifyContent={"space-between"} flex={1} gap={1}>
           <Column gap={1}>{children}</Column>
-          {pinButtonVisible && (
+          {(bottomItems || pinButtonVisible) && (
             <Column gap={1}>
               {bottomItems}
-              <SidebarMenuPinButton
-                isPinned={isPinned}
-                onClick={onClickPinButton}
-              />
+              {pinButtonVisible && (
+                <SidebarMenuPinButton
+                  isPinned={isPinned}
+                  onClick={onClickPinButton}
+                />
+              )}
               <Space />
             </Column>
           )}

--- a/packages/panels/src/components/sidebar-menu/SidebarMenu.tsx
+++ b/packages/panels/src/components/sidebar-menu/SidebarMenu.tsx
@@ -1,6 +1,7 @@
 import { Box, BoxProps, Column, Space } from "@stenajs-webui/core";
 import cx from "classnames";
 import * as React from "react";
+import { ReactNode } from "react";
 import styles from "./SidebarMenu.module.css";
 import {
   SidebarMenuCloseButtonRow,
@@ -16,6 +17,7 @@ export interface SidebarMenuProps extends BoxProps {
   variant?: SidebarMenuVariant;
   pinButtonVisible?: boolean;
   isPinned?: boolean;
+  bottomItems?: ReactNode;
   onClickPinButton?: () => void;
 }
 
@@ -26,6 +28,7 @@ export const SidebarMenu: React.FC<SidebarMenuProps> = ({
   variant = "standard",
   pinButtonVisible,
   onClickPinButton,
+  bottomItems,
   isPinned,
   ...boxProps
 }) => {
@@ -49,7 +52,8 @@ export const SidebarMenu: React.FC<SidebarMenuProps> = ({
         <Column justifyContent={"space-between"} flex={1} gap={1}>
           <Column gap={1}>{children}</Column>
           {pinButtonVisible && (
-            <Column>
+            <Column gap={1}>
+              {bottomItems}
               <SidebarMenuPinButton
                 isPinned={isPinned}
                 onClick={onClickPinButton}

--- a/packages/panels/src/components/sidebar-menu/rail/SidebarRailMenu.tsx
+++ b/packages/panels/src/components/sidebar-menu/rail/SidebarRailMenu.tsx
@@ -8,12 +8,15 @@ import {
   stenaAngleLeftDouble,
   stenaHamburger,
 } from "@stenajs-webui/elements";
+import { SidebarMenuLink } from "../items/SidebarMenuLink";
 
 interface SidebarRailMenuProps {
   closeButtonVisible?: boolean;
   onClickCloseButton?: () => void;
   onClickMenuButton?: () => void;
   children?: ReactNode;
+  bottomItems?: ReactNode;
+  unpinButtonTitle?: string;
 }
 
 export const SidebarRailMenu: React.FC<SidebarRailMenuProps> = ({
@@ -21,6 +24,8 @@ export const SidebarRailMenu: React.FC<SidebarRailMenuProps> = ({
   onClickCloseButton,
   onClickMenuButton,
   children,
+  bottomItems,
+  unpinButtonTitle = "Unpin menu",
 }) => {
   return (
     <Box
@@ -39,12 +44,20 @@ export const SidebarRailMenu: React.FC<SidebarRailMenuProps> = ({
         <Column gap={1}>
           <RailContext.Provider value={true}>{children}</RailContext.Provider>
         </Column>
-        {closeButtonVisible && (
-          <IconMenuButton
-            icon={stenaAngleLeftDouble}
-            onClick={onClickCloseButton}
-          />
-        )}
+        <Column gap={1}>
+          {(bottomItems || closeButtonVisible) && (
+            <RailContext.Provider value={true}>
+              {bottomItems}
+              {closeButtonVisible && (
+                <SidebarMenuLink
+                  leftIcon={stenaAngleLeftDouble}
+                  label={unpinButtonTitle}
+                  onClick={onClickCloseButton}
+                />
+              )}
+            </RailContext.Provider>
+          )}
+        </Column>
       </Column>
     </Box>
   );

--- a/packages/panels/src/components/sidebar-menu/rail/SidebarRailMenu.tsx
+++ b/packages/panels/src/components/sidebar-menu/rail/SidebarRailMenu.tsx
@@ -16,7 +16,7 @@ interface SidebarRailMenuProps {
   onClickMenuButton?: () => void;
   children?: ReactNode;
   bottomItems?: ReactNode;
-  unpinButtonTitle?: string;
+  closeButtonTitle?: string;
 }
 
 export const SidebarRailMenu: React.FC<SidebarRailMenuProps> = ({
@@ -25,7 +25,7 @@ export const SidebarRailMenu: React.FC<SidebarRailMenuProps> = ({
   onClickMenuButton,
   children,
   bottomItems,
-  unpinButtonTitle = "Unpin menu",
+  closeButtonTitle = "Unpin menu",
 }) => {
   return (
     <Box
@@ -51,7 +51,7 @@ export const SidebarRailMenu: React.FC<SidebarRailMenuProps> = ({
               {closeButtonVisible && (
                 <SidebarMenuLink
                   leftIcon={stenaAngleLeftDouble}
-                  label={unpinButtonTitle}
+                  label={closeButtonTitle}
                   onClick={onClickCloseButton}
                 />
               )}


### PR DESCRIPTION
- Add `bottomItems` prop to SidebarMenu and SidebarRailMenu. This items will be placed at the bottom.

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/2c5f7bb0-a8a5-4e92-99f3-cb13a9011bd6)

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/f0444c62-f5d6-42df-a45e-aec6e220ff98)
