### PR TITLE
Update button icon sizes and visual center

### DIFF
--- a/packages/elements/src/components/ui/buttons/common/BaseButton.module.css
+++ b/packages/elements/src/components/ui/buttons/common/BaseButton.module.css
@@ -19,10 +19,7 @@
    * Styling
    */
   --swui-button-padding-vertical: 6px;
-  --swui-button-padding-horizontal: calc(var(--swui-metrics-spacing) * 2 - 1px);
-  --swui-button-padding-horizontal-label-only: calc(
-    var(--swui-metrics-spacing) * 3 - 1px
-  );
+  --swui-button-padding-horizontal: 16px;
 
   box-sizing: border-box;
   min-height: var(--swui-button-height-medium);
@@ -44,12 +41,7 @@
   justify-content: center;
   --current-icon-height: var(--swui-button-icon-height-medium);
 
-  &.labelOnly {
-    padding: var(--swui-button-padding-vertical)
-      var(--swui-button-padding-horizontal-label-only);
-  }
-
-  &.iconOnly {
+  &.roundButton {
     padding: var(--swui-button-padding-vertical);
     flex: none;
 
@@ -90,22 +82,15 @@
 
   &.small {
     --swui-button-padding-vertical: 3px;
-    --swui-button-padding-horizontal: calc(var(--swui-metrics-space) - 1px);
-    --swui-button-padding-horizontal-label-only: calc(
-      var(--swui-metrics-space) * 2 - 1px
-    );
     font-size: 1.2rem;
     min-height: var(--swui-button-height-small);
     height: var(--swui-button-height-small);
     --current-icon-height: var(--swui-button-icon-height-small);
+    --swui-button-padding-horizontal: 8px;
   }
 
   &.large {
     --swui-button-padding-vertical: 8px;
-    --swui-button-padding-horizontal: calc(var(--swui-metrics-space) * 3 - 1px);
-    --swui-button-padding-horizontal-label-only: calc(
-      var(--swui-metrics-space) * 3 - 1px
-    );
     font-size: 1.8rem;
     min-height: var(--swui-button-height-large);
     height: var(--swui-button-height-large);
@@ -114,14 +99,11 @@
 
   &.larger {
     --swui-button-padding-vertical: 8px;
-    --swui-button-padding-horizontal: calc(var(--swui-metrics-space) * 6 - 1px);
-    --swui-button-padding-horizontal-label-only: calc(
-      var(--swui-metrics-space) * 6 - 1px
-    );
     min-height: var(--swui-button-height-larger);
     height: var(--swui-button-height-larger);
     font-size: 2rem;
     --current-icon-height: var(--swui-button-icon-height-larger);
+    --swui-button-padding-horizontal: 40px;
   }
 
   &:focus:not(:focus-visible) {

--- a/packages/elements/src/components/ui/buttons/common/BaseButton.module.css
+++ b/packages/elements/src/components/ui/buttons/common/BaseButton.module.css
@@ -6,14 +6,14 @@
   --swui-button-height-larger: 72px;
 
   /* Icon */
-  --swui-button-icon-height-small: 1.2rem;
-  --swui-button-icon-height-small-icon-only: 1.2rem;
+  --swui-button-icon-height-small: 1.6rem;
+  --swui-button-icon-height-small-icon-only: 1.6rem;
   --swui-button-icon-height-medium: 2rem;
   --swui-button-icon-height-medium-icon-only: 2rem;
-  --swui-button-icon-height-large: 2rem;
-  --swui-button-icon-height-large-icon-only: 2rem;
-  --swui-button-icon-height-larger: 2rem;
-  --swui-button-icon-height-larger-icon-only: 2.4rem;
+  --swui-button-icon-height-large: 2.4rem;
+  --swui-button-icon-height-large-icon-only: 2.4rem;
+  --swui-button-icon-height-larger: 3.2rem;
+  --swui-button-icon-height-larger-icon-only: 3.2rem;
 
   /*
    * Styling
@@ -42,6 +42,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  --current-icon-height: var(--swui-button-icon-height-medium);
 
   &.labelOnly {
     padding: var(--swui-button-padding-vertical)
@@ -61,21 +62,25 @@
     &.small {
       width: var(--swui-button-height-small);
       height: var(--swui-button-height-small);
+      --current-icon-height: var(--swui-button-icon-height-small-icon-only);
     }
 
     &.medium {
       width: var(--swui-button-height-medium);
       height: var(--swui-button-height-medium);
+      --current-icon-height: var(--swui-button-icon-height-medium-icon-only);
     }
 
     &.large {
       width: var(--swui-button-height-large);
       height: var(--swui-button-height-large);
+      --current-icon-height: var(--swui-button-icon-height-large-icon-only);
     }
 
     &.larger {
       width: var(--swui-button-height-larger);
       height: var(--swui-button-height-larger);
+      --current-icon-height: var(--swui-button-icon-height-larger-icon-only);
     }
   }
 
@@ -92,6 +97,7 @@
     font-size: 1.2rem;
     min-height: var(--swui-button-height-small);
     height: var(--swui-button-height-small);
+    --current-icon-height: var(--swui-button-icon-height-small);
   }
 
   &.large {
@@ -103,6 +109,7 @@
     font-size: 1.8rem;
     min-height: var(--swui-button-height-large);
     height: var(--swui-button-height-large);
+    --current-icon-height: var(--swui-button-icon-height-large);
   }
 
   &.larger {
@@ -114,6 +121,7 @@
     min-height: var(--swui-button-height-larger);
     height: var(--swui-button-height-larger);
     font-size: 2rem;
+    --current-icon-height: var(--swui-button-icon-height-larger);
   }
 
   &:focus:not(:focus-visible) {

--- a/packages/elements/src/components/ui/buttons/common/BaseButton.tsx
+++ b/packages/elements/src/components/ui/buttons/common/BaseButton.tsx
@@ -52,8 +52,14 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
         (loading && loadingLabel)
     );
 
-    const labelOnly = hasLabel && !left && !leftIcon && !right && !rightIcon;
-    const iconOnly = leftIcon && !hasLabel && !left && !right && !rightIcon;
+    const leftIconOnly = leftIcon && !hasLabel && !left && !right && !rightIcon;
+    const rightIconOnly =
+      rightIcon && !hasLabel && !left && !right && !leftIcon;
+    const loadingOnly = loading && !loadingLabel;
+    const successIconOnly = success && !successLabel;
+
+    const isRound =
+      leftIconOnly || rightIconOnly || loadingOnly || successIconOnly;
 
     return (
       <button
@@ -62,8 +68,7 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
         className={cx(
           buttonBaseStyles.button,
           buttonBaseStyles[size],
-          iconOnly && buttonBaseStyles.iconOnly,
-          labelOnly && buttonBaseStyles.labelOnly,
+          isRound && buttonBaseStyles.roundButton,
           className
         )}
         disabled={disabled}

--- a/packages/elements/src/components/ui/buttons/common/ButtonContent.module.css
+++ b/packages/elements/src/components/ui/buttons/common/ButtonContent.module.css
@@ -1,3 +1,8 @@
+.buttonContent {
+  display: flex;
+  flex-direction: row;
+}
+
 .iconLeft,
 .iconRight {
   color: var(--current-icon-color);
@@ -9,22 +14,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.leftWrapper:not(:last-child) {
-  margin-right: var(--swui-metrics-indent);
-
-  &.larger {
-    margin-right: calc(var(--swui-metrics-indent) * 2);
-  }
-}
-
-.rightWrapper:not(:first-child) {
-  margin-left: var(--swui-metrics-indent);
-
-  &.larger {
-    margin-left: calc(var(--swui-metrics-indent) * 2);
-  }
 }
 
 .responsiveIconOnly {

--- a/packages/elements/src/components/ui/buttons/common/ButtonContent.tsx
+++ b/packages/elements/src/components/ui/buttons/common/ButtonContent.tsx
@@ -7,6 +7,7 @@ import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import styles from "./ButtonContent.module.css";
 import { stenaCheck } from "../../../../icons/generated/CommonIcons";
 import { ButtonSize } from "./ButtonCommon";
+import { Space } from "@stenajs-webui/core";
 
 export interface ButtonContentProps {
   label?: string;
@@ -41,43 +42,61 @@ export const ButtonContent: React.FC<ButtonContentProps> = ({
   size = "medium",
   responsiveIconOnly = false,
 }) => {
-  return (
-    <>
-      {(success || loading || leftIcon || left) && (
-        <div
-          className={cx(
-            styles.leftWrapper,
-            styles[size],
-            leftWrapperClassName,
-            responsiveIconOnly && styles.responsiveIconOnly
-          )}
-        >
-          {success ? (
-            <FontAwesomeIcon
-              icon={stenaCheck}
-              className={cx(styles.iconLeft, iconClassName)}
-            />
-          ) : loading ? (
-            <div
-              className={cx(
-                styles.iconLeft,
-                styles.spinnerLeft,
-                spinnerClassName
-              )}
-            >
-              <InputSpinner />
-            </div>
-          ) : left ? (
-            left
-          ) : leftIcon ? (
-            <FontAwesomeIcon
-              icon={leftIcon}
-              className={cx(styles.iconLeft, iconClassName)}
-            />
-          ) : null}
-        </div>
+  const leftContent = (success || loading || leftIcon || left) && (
+    <div
+      className={cx(
+        styles.leftWrapper,
+        styles[size],
+        leftWrapperClassName,
+        responsiveIconOnly && styles.responsiveIconOnly
       )}
+    >
+      {success ? (
+        <FontAwesomeIcon
+          icon={stenaCheck}
+          className={cx(styles.iconLeft, iconClassName)}
+        />
+      ) : loading ? (
+        <div
+          className={cx(styles.iconLeft, styles.spinnerLeft, spinnerClassName)}
+        >
+          <InputSpinner />
+        </div>
+      ) : left ? (
+        left
+      ) : leftIcon ? (
+        <FontAwesomeIcon
+          icon={leftIcon}
+          className={cx(styles.iconLeft, iconClassName)}
+        />
+      ) : null}
+    </div>
+  );
 
+  const rightContent = (right || rightIcon) && (
+    <div
+      className={cx(
+        styles.rightWrapper,
+        styles[size],
+        rightWrapperClassName,
+        responsiveIconOnly && styles.responsiveIconOnly
+      )}
+    >
+      {right ? (
+        right
+      ) : rightIcon ? (
+        <FontAwesomeIcon
+          icon={rightIcon}
+          className={cx(styles.iconRight, iconClassName)}
+        />
+      ) : null}
+    </div>
+  );
+
+  return (
+    <div className={styles.buttonContent}>
+      {leftContent}
+      {label ? <Space /> : null}
       {label && (
         <span
           className={cx(
@@ -89,26 +108,8 @@ export const ButtonContent: React.FC<ButtonContentProps> = ({
           {label}
         </span>
       )}
-
-      {(right || rightIcon) && (
-        <div
-          className={cx(
-            styles.rightWrapper,
-            styles[size],
-            rightWrapperClassName,
-            responsiveIconOnly && styles.responsiveIconOnly
-          )}
-        >
-          {right ? (
-            right
-          ) : rightIcon ? (
-            <FontAwesomeIcon
-              icon={rightIcon}
-              className={cx(styles.iconRight, iconClassName)}
-            />
-          ) : null}
-        </div>
-      )}
-    </>
+      {label ? <Space /> : null}
+      {rightContent}
+    </div>
   );
 };

--- a/packages/elements/src/components/ui/buttons/stories/Buttons.stories.tsx
+++ b/packages/elements/src/components/ui/buttons/stories/Buttons.stories.tsx
@@ -1,4 +1,3 @@
-import { faJedi } from "@fortawesome/free-solid-svg-icons/faJedi";
 import { Column, Indent, Row, Space, Text } from "@stenajs-webui/core";
 import * as React from "react";
 import { ButtonSize, ButtonVariant } from "../common/ButtonCommon";
@@ -8,6 +7,10 @@ import { FlatButton } from "../FlatButton";
 import { Icon } from "../../icon/Icon";
 import { Story } from "@storybook/react";
 import { stenaCheck } from "../../../../icons/generated/CommonIcons";
+import {
+  stenaArrowRight,
+  stenaArrowShortRight,
+} from "../../../../icons/generated/ArrowIcons";
 
 const buttonSizes: Array<ButtonSize> = ["small", "medium", "large", "larger"];
 
@@ -82,23 +85,27 @@ export const Overview = () => (
                   <ButtonVariant size={size} label={"Submit"} disabled />
                 </td>
                 <td>
-                  <ButtonVariant size={size} leftIcon={faJedi} />
-                </td>
-                <td>
-                  <ButtonVariant size={size} leftIcon={faJedi} disabled />
+                  <ButtonVariant size={size} leftIcon={stenaArrowRight} />
                 </td>
                 <td>
                   <ButtonVariant
                     size={size}
-                    label={"Submit"}
-                    leftIcon={faJedi}
+                    leftIcon={stenaArrowRight}
+                    disabled
                   />
                 </td>
                 <td>
                   <ButtonVariant
                     size={size}
                     label={"Submit"}
-                    rightIcon={faJedi}
+                    leftIcon={stenaArrowRight}
+                  />
+                </td>
+                <td>
+                  <ButtonVariant
+                    size={size}
+                    label={"Submit"}
+                    rightIcon={stenaArrowShortRight}
                   />
                 </td>
                 <td>
@@ -106,7 +113,7 @@ export const Overview = () => (
                     size={size}
                     label={"Submit"}
                     leftIcon={stenaCheck}
-                    rightIcon={faJedi}
+                    rightIcon={stenaArrowShortRight}
                   />
                 </td>
                 <td>


### PR DESCRIPTION
- Fix missing icons in button stories.
- Fix icon only button, was not round.
- Loading and success with no label is now round.
- Fix missing icon size on buttons.
- Update sizes of icons in buttons.
- Update the alignment of label and icons in ButtonContent (for buttons, tabs, etc), to make it visually centered.

# Before

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/de45dc15-0496-4d86-9f18-489bf85fbd75)

# After

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/40183a68-2d9e-4e03-b7ca-c5267593b98d)
