### PR TITLE
New component: TextInputButton

### DIFF
--- a/packages/calendar/src/components/input-types/date-input/DateInput.tsx
+++ b/packages/calendar/src/components/input-types/date-input/DateInput.tsx
@@ -1,5 +1,9 @@
-import { Box, Row } from "@stenajs-webui/core";
-import { TextInput, TextInputProps } from "@stenajs-webui/forms";
+import { Box } from "@stenajs-webui/core";
+import {
+  TextInput,
+  TextInputButton,
+  TextInputProps,
+} from "@stenajs-webui/forms";
 import { Popover } from "@stenajs-webui/tooltip";
 import { format } from "date-fns";
 import * as React from "react";
@@ -15,7 +19,7 @@ import { DateTextInputCalendarProps } from "../date-text-input/DateTextInput";
 import { useDateInput } from "./UseDateInput";
 import { OptionalMinMaxDatesAsString } from "../../../types/CalendarTypes";
 import { defaultMaxDate } from "../../../config/DefaultMaxDate";
-import { FlatButton, stenaCalendar } from "@stenajs-webui/elements";
+import { stenaCalendar } from "@stenajs-webui/elements";
 
 export interface DateInputProps<T = {}> extends OptionalMinMaxDatesAsString {
   /** The current value */
@@ -112,18 +116,10 @@ export const DateInput: React.FC<DateInputProps> = ({
       >
         <TextInput
           type={"date"}
-          contentRight={
-            <Row alignItems={"center"}>
-              <FlatButton
-                size={"small"}
-                disabled={disabled}
-                leftIcon={stenaCalendar}
-                onClick={showCalendar}
-              />
-            </Row>
-          }
           onFocus={showCalendar}
-          onClickRight={showCalendar}
+          buttonRight={
+            <TextInputButton onClick={showCalendar} icon={stenaCalendar} />
+          }
           value={value ? format(value, displayFormat) : ""}
           placeholder={placeholder}
           size={9}

--- a/packages/forms/src/components/ui/password-input/PasswordInput.tsx
+++ b/packages/forms/src/components/ui/password-input/PasswordInput.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { TextInput, TextInputProps } from "../text-input/TextInput";
 import { stenaEyeHide, stenaEyeShow } from "@stenajs-webui/elements";
+import { TextInputButton } from "../text-input/TextInputButton";
 
 export interface PasswordInputProps extends TextInputProps {
   visibleIcon?: IconDefinition;
@@ -18,8 +19,12 @@ export const PasswordInput: React.FC<PasswordInputProps> = ({
 
   return (
     <TextInput
-      iconRight={isPassword ? hiddenIcon : visibleIcon}
-      onClickRight={() => setIsPassword((x) => !x)}
+      buttonRight={
+        <TextInputButton
+          icon={isPassword ? hiddenIcon : visibleIcon}
+          onClick={() => setIsPassword((x) => !x)}
+        />
+      }
       type={isPassword ? "password" : "text"}
       {...props}
     />

--- a/packages/forms/src/components/ui/text-input/TextInput.stories.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInput.stories.tsx
@@ -4,7 +4,11 @@ import { Box, Space, Text } from "@stenajs-webui/core";
 import { TextInput, TextInputProps, TextInputVariant } from "./TextInput";
 import { Story } from "@storybook/react";
 import { disabledControl } from "../../../storybook-helpers/storybook-controls";
-import { Badge, stenaAnimals } from "@stenajs-webui/elements";
+import {
+  stenaAnimals,
+  stenaExclamationTriangle,
+} from "@stenajs-webui/elements";
+import { TextInputButton } from "./TextInputButton";
 
 export default {
   title: "forms/TextInput/TextInput",
@@ -45,16 +49,43 @@ export const Overview = () => (
       </React.Fragment>
     ))}
     <Text>Icon left</Text>
-    <TextInput value={"Some text"} iconLeft={stenaAnimals} />
+    <TextInput value={"Some text"} iconLeft={stenaExclamationTriangle} />
     <Space />
     <Text>Icon right</Text>
-    <TextInput value={"Some text"} iconRight={stenaAnimals} />
+    <TextInput value={"Some text"} iconRight={stenaExclamationTriangle} />
     <Space />
-    <Text>Icon clickable</Text>
+    <Text>Button left side</Text>
     <TextInput
       value={"Some text"}
-      iconLeft={stenaAnimals}
-      onClickLeft={() => alert("click")}
+      buttonLeft={
+        <TextInputButton
+          icon={stenaExclamationTriangle}
+          onClick={() => alert("click")}
+        />
+      }
+    />
+    <Space />
+    <Text>Button right side</Text>
+    <TextInput
+      value={"Some text"}
+      buttonRight={
+        <TextInputButton
+          icon={stenaExclamationTriangle}
+          onClick={() => alert("click")}
+        />
+      }
+    />
+    <Space />
+    <Text>Button left side danger</Text>
+    <TextInput
+      value={"Some text"}
+      buttonLeft={
+        <TextInputButton
+          onClick={() => alert("click")}
+          icon={stenaAnimals}
+          variant={"danger"}
+        />
+      }
     />
     <Space />
     <Text>Content left</Text>
@@ -185,14 +216,5 @@ export const DisabledWithContent = () => (
 export const TypeDate = () => (
   <Box width={"400px"}>
     <TextInput type={"date"} />
-  </Box>
-);
-
-export const WithClickableContent = () => (
-  <Box width={"400px"}>
-    <TextInput
-      contentRight={<Badge label={"2"} />}
-      onClickRight={() => alert("Clicked")}
-    />
   </Box>
 );

--- a/packages/forms/src/components/ui/text-input/TextInput.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInput.tsx
@@ -24,6 +24,10 @@ interface ExtraContent {
   contentLeft?: React.ReactNode;
   /** React node to put to the right. Right icon is ignored if this is set. */
   contentRight?: React.ReactNode;
+  /** TextInputButton to the left. Left icon and content is ignored if this is set. */
+  buttonLeft?: React.ReactNode;
+  /** React node to put to the right. Right icon and content is ignored if this is set. */
+  buttonRight?: React.ReactNode;
   /** If true, there will be no padding between contentLeft/contentRight and the border. */
   disableContentPadding?: boolean;
   /** If true, there will be no padding between contentLeft and the border. */
@@ -34,10 +38,6 @@ interface ExtraContent {
   iconLeft?: IconDefinition;
   /** Icon on the right side. */
   iconRight?: IconDefinition;
-  /** On click left. */
-  onClickLeft?: () => void;
-  /** On click right. */
-  onClickRight?: () => void;
 }
 
 export interface TextInputProps
@@ -64,6 +64,8 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     inputRef,
     disabled,
     className,
+    buttonLeft,
+    buttonRight,
     contentLeft,
     contentRight,
     disableContentPadding,
@@ -71,8 +73,6 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     disableContentPaddingRight,
     iconLeft,
     iconRight,
-    onClickLeft,
-    onClickRight,
     moveCursorToEndOnMount,
     selectAllOnMount,
     autoFocus,
@@ -139,7 +139,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
         disableContentPaddingRight={disableContentPaddingRight}
         icon={iconLeft}
         spaceOnLeft
-        onClick={onClickLeft}
+        button={buttonLeft}
       />
       <input
         className={cx(styles.input, className)}
@@ -157,7 +157,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
         disableContentPaddingRight={disableContentPaddingRight}
         icon={currentIconRight}
         spaceOnRight
-        onClick={onClickRight}
+        button={buttonRight}
       />
     </div>
   );

--- a/packages/forms/src/components/ui/text-input/TextInputBox.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInputBox.tsx
@@ -9,7 +9,9 @@ import {
   stenaCheck,
   stenaExclamationTriangle,
 } from "@stenajs-webui/elements";
-import { Row } from "@stenajs-webui/core";
+import { ButtonElementProps, Row } from "@stenajs-webui/core";
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { TextInputButton } from "./TextInputButton";
 
 export interface TextInputBoxProps
   extends Pick<
@@ -23,12 +25,12 @@ export interface TextInputBoxProps
     | "disableContentPadding"
     | "disableContentPaddingLeft"
     | "disableContentPaddingRight"
-    | "iconRight"
-    | "iconLeft"
-    | "onClickLeft"
-    | "onClickRight"
   > {
   children?: ReactNode;
+  iconRight?: IconDefinition;
+  iconLeft?: IconDefinition;
+  onClickLeft?: ButtonElementProps["onClick"];
+  onClickRight?: ButtonElementProps["onClick"];
 }
 
 export const TextInputBox: React.FC<TextInputBoxProps> = ({
@@ -75,9 +77,12 @@ export const TextInputBox: React.FC<TextInputBoxProps> = ({
         disableContentPadding={disableContentPadding}
         disableContentPaddingLeft={disableContentPaddingLeft}
         disableContentPaddingRight={disableContentPaddingRight}
-        icon={iconLeft}
         spaceOnLeft
-        onClick={onClickLeft}
+        button={
+          iconLeft ? (
+            <TextInputButton onClick={onClickLeft} icon={iconLeft} />
+          ) : undefined
+        }
       />
       <Row alignItems={"center"}>{children}</Row>
       <TextInputIcon
@@ -85,9 +90,12 @@ export const TextInputBox: React.FC<TextInputBoxProps> = ({
         disableContentPadding={disableContentPadding}
         disableContentPaddingLeft={disableContentPaddingLeft}
         disableContentPaddingRight={disableContentPaddingRight}
-        icon={currentIconRight}
         spaceOnRight
-        onClick={onClickRight}
+        button={
+          currentIconRight ? (
+            <TextInputButton onClick={onClickRight} icon={currentIconRight} />
+          ) : undefined
+        }
       />
     </div>
   );

--- a/packages/forms/src/components/ui/text-input/TextInputButton.module.css
+++ b/packages/forms/src/components/ui/text-input/TextInputButton.module.css
@@ -1,0 +1,40 @@
+.textInputButton {
+  border: none;
+  outline: none;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  border-radius: var(--swui-border-radius-small);
+  justify-content: center;
+  align-items: center;
+  background: transparent;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--lhds-color-ui-200);
+  }
+
+  &.normal {
+    &:active {
+      background: var(--lhds-color-blue-200);
+    }
+
+    .icon {
+      color: var(--core-blue);
+    }
+  }
+
+  &.danger {
+    &:active {
+      background: var(--lhds-color-red-200);
+    }
+
+    .icon {
+      color: var(--modern-red);
+    }
+  }
+
+  &:focus-visible {
+    outline: var(--swui-focus-outline);
+  }
+}

--- a/packages/forms/src/components/ui/text-input/TextInputButton.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInputButton.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import styles from "./TextInputButton.module.css";
+import { ButtonElementProps } from "@stenajs-webui/core";
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import { Icon } from "@stenajs-webui/elements";
+import cx from "classnames";
+
+export type TextInputButtonVariant = "normal" | "danger";
+
+export interface TextInputButtonProps extends ButtonElementProps {
+  variant?: TextInputButtonVariant;
+  icon: IconDefinition;
+}
+
+export const TextInputButton: React.FC<TextInputButtonProps> = ({
+  variant = "normal",
+  icon,
+  className,
+  ...buttonProps
+}) => {
+  return (
+    <button
+      {...buttonProps}
+      className={cx(styles.textInputButton, styles[variant], className)}
+    >
+      <Icon icon={icon} size={20} className={styles.icon} />
+    </button>
+  );
+};

--- a/packages/forms/src/components/ui/text-input/TextInputIcon.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInputIcon.tsx
@@ -4,21 +4,21 @@ import cx from "classnames";
 import * as React from "react";
 import styles from "./TextInput.module.css";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { FlatButton } from "@stenajs-webui/elements";
 
 export interface TextInputIconProps {
   iconClassName?: string;
   content?: React.ReactNode;
+  button?: React.ReactNode;
   icon?: IconDefinition;
   spaceOnRight?: boolean;
   spaceOnLeft?: boolean;
   disableContentPadding?: boolean;
   disableContentPaddingLeft?: boolean;
   disableContentPaddingRight?: boolean;
-  onClick?: () => void;
 }
 
 export const TextInputIcon: React.FC<TextInputIconProps> = ({
+  button,
   icon,
   iconClassName,
   content,
@@ -27,10 +27,19 @@ export const TextInputIcon: React.FC<TextInputIconProps> = ({
   disableContentPadding,
   disableContentPaddingLeft,
   disableContentPaddingRight,
-  onClick,
 }) => {
-  if (!content && !icon) {
+  if (!content && !icon && !button) {
     return null;
+  }
+
+  if (button) {
+    return (
+      <>
+        {spaceOnLeft ? <Space num={0.25} /> : null}
+        {button}
+        {spaceOnRight ? <Space num={0.25} /> : null}
+      </>
+    );
   }
 
   if (content) {
@@ -40,14 +49,7 @@ export const TextInputIcon: React.FC<TextInputIconProps> = ({
         !(disableContentPadding || disableContentPaddingLeft) ? (
           <Space />
         ) : null}
-        {onClick ? (
-          <span onClick={onClick} className={styles.clickable}>
-            {content || null}
-          </span>
-        ) : (
-          <>{content || null}</>
-        )}
-
+        {content || null}
         {spaceOnRight &&
         !(disableContentPadding || disableContentPaddingRight) ? (
           <Space />
@@ -60,21 +62,10 @@ export const TextInputIcon: React.FC<TextInputIconProps> = ({
     <>
       {spaceOnLeft ? <Space /> : null}
       {icon && (
-        <>
-          {onClick ? (
-            <FlatButton
-              type={"button"}
-              onClick={onClick}
-              leftIcon={icon}
-              size={"small"}
-            />
-          ) : (
-            <FontAwesomeIcon
-              icon={icon}
-              className={cx(styles.icon, iconClassName)}
-            />
-          )}
-        </>
+        <FontAwesomeIcon
+          icon={icon}
+          className={cx(styles.icon, iconClassName)}
+        />
       )}
       {spaceOnRight ? <Space /> : null}
     </>

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -13,6 +13,7 @@ export * from "./components/ui/input-label/InputLabelText";
 export * from "./components/ui/labelled-text-input/LabelledTextInput";
 export * from "./components/ui/text-input/TextInput";
 export * from "./components/ui/text-input/TextInputBox";
+export * from "./components/ui/text-input/TextInputButton";
 export * from "./components/ui/text-area/TextArea";
 export * from "./components/ui/types";
 export * from "./hooks/UseKeyboardNavigation";

--- a/packages/panels/src/components/nav-bar/NavBarSearchField.module.css
+++ b/packages/panels/src/components/nav-bar/NavBarSearchField.module.css
@@ -3,7 +3,7 @@
   --swui-textinput-text-color: var(--lhds-color-ui-50);
   --swui-textinput-placeholder-color: var(--lhds-color-blue-800);
 
-  padding: 1px var(--swui-metrics-indent);
+  padding: 0 var(--swui-metrics-indent);
 
   &:focus {
     --swui-textinput-text-color: var(--lhds-color-ui-800);
@@ -18,13 +18,21 @@
   --swui-textinput-border-color: transparent;
   --swui-textinput-border-color-hover: transparent;
 
-  padding: 1px var(--swui-metrics-indent) 0;
+  padding: 0 var(--swui-metrics-indent);
 
   border-radius: var(--swui-max-border-radius);
+
+  &.withButton {
+    padding-right: 1px;
+  }
 
   &:focus-within {
     --swui-textinput-text-color: var(--lhds-color-ui-800);
     --swui-field-text-color: var(--swui-field-text-color);
     --swui-textinput-bg-color: var(--lhds-color-ui-50);
   }
+}
+
+.clearButton {
+  border-radius: var(--swui-max-border-radius);
 }

--- a/packages/panels/src/components/nav-bar/NavBarSearchField.stories.tsx
+++ b/packages/panels/src/components/nav-bar/NavBarSearchField.stories.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useState } from "react";
 import { NavBar } from "./NavBar";
 import { NavBarButton } from "./NavBarButton";
 import { NavBarSearchField } from "./NavBarSearchField";
@@ -11,9 +12,21 @@ export default {
   },
 };
 
-export const CenterContent = () => (
-  <NavBar center={<NavBarSearchField />}>
-    <NavBarButton label={"Customers"} selected />
-    <NavBarButton label={"Bookings"} />
-  </NavBar>
-);
+export const CenterContent = () => {
+  const [text, setText] = useState("");
+  return (
+    <NavBar
+      center={
+        <NavBarSearchField
+          showClearButton
+          onClickClearButton={() => setText("")}
+          value={text}
+          onValueChange={setText}
+        />
+      }
+    >
+      <NavBarButton label={"Customers"} selected />
+      <NavBarButton label={"Bookings"} />
+    </NavBar>
+  );
+};

--- a/packages/panels/src/components/nav-bar/NavBarSearchField.tsx
+++ b/packages/panels/src/components/nav-bar/NavBarSearchField.tsx
@@ -1,21 +1,46 @@
 import * as React from "react";
-import { TextInput, TextInputProps } from "@stenajs-webui/forms";
+import {
+  TextInput,
+  TextInputButton,
+  TextInputProps,
+} from "@stenajs-webui/forms";
 import cx from "classnames";
 import styles from "./NavBarSearchField.module.css";
+import { ButtonElementProps } from "@stenajs-webui/core";
+import { stenaTimes } from "@stenajs-webui/elements";
 
-interface NavBarSearchFieldProps extends TextInputProps {}
+interface NavBarSearchFieldProps extends TextInputProps {
+  showClearButton?: boolean;
+  onClickClearButton?: ButtonElementProps["onClick"];
+}
 
 export const NavBarSearchField: React.FC<NavBarSearchFieldProps> = ({
   placeholder = "Search",
   className,
   wrapperClassName,
+  showClearButton,
+  onClickClearButton,
   ...textInputProps
 }) => {
   return (
     <TextInput
-      wrapperClassName={cx(styles.navBarSearchField, wrapperClassName)}
+      wrapperClassName={cx(
+        styles.navBarSearchField,
+        showClearButton ? styles.withButton : undefined,
+        wrapperClassName
+      )}
       className={cx(styles.navBarSearchFieldInput, className)}
       placeholder={placeholder}
+      buttonRight={
+        showClearButton ? (
+          <TextInputButton
+            className={styles.clearButton}
+            icon={stenaTimes}
+            variant={"danger"}
+            onClick={onClickClearButton}
+          />
+        ) : undefined
+      }
       {...textInputProps}
     />
   );

--- a/packages/theme/src/styles/default-theme.css
+++ b/packages/theme/src/styles/default-theme.css
@@ -88,6 +88,7 @@
   --swui-field-placeholder-font-weight: var(--swui-font-weight-text-bold);
 
   /* Borders */
+  --swui-border-radius-small: 4px;
   --swui-border-radius: 8px;
   --swui-border-radius-large: 16px;
   --swui-max-border-radius: 10000px;


### PR DESCRIPTION
- Add `buttonLeft` and `buttonRight` props to `TextInput`.
- Update stories.
- Add clear button to NavBarSearchField. It adds a `TextInputButton` with max border radius, correct icon and colors.
- Remove `onClickLeft` and `onClickRight` props on `TextInput`.

# Breaking

Props `onClickLeft` and `onClickRight` has been removed on `TextInput`. 
These props created `span` elements with `onClick`, instead of a `<button>`. 
There was no way to set aria props, etc, on these elements. 
Instead, use `buttonLeft={<TextInputButton ../>}`.

`contentLeft` and `contentRight` can still be used for custom content. 
If you want them to be clickable, make the content into proper buttons manually.

# Design

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/f3f2ca90-4c40-400d-85ac-5ea969a86664)

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/04409c2d-daec-4606-b07c-b53d14117da3)

# Result

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/5d6441d7-524a-4590-8b24-a601738a9afa)

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/1c803f8f-0c20-4b7a-992a-bb7f339ce9e1)

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/c4a07a58-963f-483c-bfd2-b12c35c7acd9)
