### PR TITLE
Color fix for snackskal and TextInputButton

### DIFF
--- a/packages/forms/src/components/ui/text-input/TextInput.stories.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInput.stories.tsx
@@ -82,8 +82,8 @@ export const Overview = () => (
       buttonLeft={
         <TextInputButton
           onClick={() => alert("click")}
-          icon={stenaAnimals}
-          variant={"danger"}
+          icon={stenaExclamationTriangle}
+          variant={"error"}
         />
       }
     />

--- a/packages/forms/src/components/ui/text-input/TextInputButton.module.css
+++ b/packages/forms/src/components/ui/text-input/TextInputButton.module.css
@@ -10,13 +10,13 @@
   background: transparent;
   cursor: pointer;
 
-  &:hover {
-    background: var(--lhds-color-ui-200);
-  }
-
   &.normal {
+    &:hover {
+      background: var(--himmel-lighter);
+    }
+
     &:active {
-      background: var(--lhds-color-blue-200);
+      background: var(--himmel);
     }
 
     .icon {
@@ -24,9 +24,13 @@
     }
   }
 
-  &.danger {
+  &.error {
+    &:hover {
+      background: var(--snackskal-light);
+    }
+
     &:active {
-      background: var(--lhds-color-red-200);
+      background: var(--snackskal);
     }
 
     .icon {

--- a/packages/forms/src/components/ui/text-input/TextInputButton.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInputButton.tsx
@@ -5,7 +5,7 @@ import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { Icon } from "@stenajs-webui/elements";
 import cx from "classnames";
 
-export type TextInputButtonVariant = "normal" | "danger";
+export type TextInputButtonVariant = "normal" | "error";
 
 export interface TextInputButtonProps extends ButtonElementProps {
   variant?: TextInputButtonVariant;

--- a/packages/panels/src/components/nav-bar/NavBarSearchField.tsx
+++ b/packages/panels/src/components/nav-bar/NavBarSearchField.tsx
@@ -36,7 +36,7 @@ export const NavBarSearchField: React.FC<NavBarSearchFieldProps> = ({
           <TextInputButton
             className={styles.clearButton}
             icon={stenaTimes}
-            variant={"danger"}
+            variant={"error"}
             onClick={onClickClearButton}
           />
         ) : undefined

--- a/packages/theme/src/styles/brand-colors.css
+++ b/packages/theme/src/styles/brand-colors.css
@@ -26,7 +26,7 @@
   --silver: #949494;
   --sjobod: rgb(176, 15, 46);
   --snackskal-light: #fce1db;
-  --snackskal: #fcb4cd;
+  --snackskal: #fbd4cd;
   --tang: #80091b;
   --tjara: rgb(51, 51, 51);
 }


### PR DESCRIPTION
- Rename TextInputButton variant `danger` to `error` for consistency with other component variants.
- Update colors in TextInputButton as per design.
- Fix typo in --snackskal color.