### PR TITLE
Add rail menu focus outline

### DIFF
--- a/packages/elements/src/components/ui/buttons/menu-button/MenuButton.module.css
+++ b/packages/elements/src/components/ui/buttons/menu-button/MenuButton.module.css
@@ -92,7 +92,7 @@
     &:focus-visible {
       background: var(--current-background-color-focus);
       outline: var(--swui-focus-outline);
-      outline-offset: 0;
+      outline-offset: var(--swui-focus-outline-width);
     }
 
     &:active {

--- a/packages/panels/src/components/sidebar-menu/SidebarMenu.stories.tsx
+++ b/packages/panels/src/components/sidebar-menu/SidebarMenu.stories.tsx
@@ -5,7 +5,10 @@ import {
   stenaBusinessClaim,
   stenaBusinessInvoice,
   stenaCalendar,
+  stenaClock,
+  stenaHelp,
   stenaSailingTicket,
+  stenaSlidersMini,
   stenaStatisticsBar,
   stenaStatisticsLine,
   stenaStatusNoShow,
@@ -15,6 +18,7 @@ import { SidebarMenu } from "./SidebarMenu";
 import { SidebarMenuLink } from "./items/SidebarMenuLink";
 import { SidebarMenuCollapsible } from "./items/SidebarMenuCollapsible";
 import { SidebarMenuSeparator } from "./items/SidebarMenuSeparator";
+import { SidebarRailMenu } from "./rail/SidebarRailMenu";
 
 export default {
   title: "panels/SidebarMenu",
@@ -26,6 +30,74 @@ export default {
     SidebarMenuSeparator,
   },
 };
+
+const createSidebarMenuItems = (onClick: () => void) => (
+  <>
+    <SidebarMenuHeading label={"Freight portal"} />
+    <SidebarMenuLink href={"#"} leftIcon={stenaCalendar} label={"Manage"} />
+    <SidebarMenuLink
+      href={"#"}
+      label={"Book (selected)"}
+      leftIcon={stenaSailingTicket}
+      selected
+    />
+    <SidebarMenuLink
+      href={"#"}
+      label={"Statistics"}
+      leftIcon={stenaStatisticsLine}
+    />
+    <SidebarMenuHeading label={"Administration"} />
+    <SidebarMenuCollapsible label={"Invoices"} leftIcon={stenaBusinessInvoice}>
+      <SidebarMenuLink label={"No show & late handling"} onClick={onClick} />
+      <SidebarMenuLink label={"Late payment"} onClick={onClick} />
+      <SidebarMenuLink
+        label={"Archive (selected)"}
+        onClick={onClick}
+        selected
+      />
+      <SidebarMenuLink label={"Level 2.4"} onClick={onClick} />
+      <SidebarMenuCollapsible label={"Level 2.5"} leftIcon={stenaStatisticsBar}>
+        <SidebarMenuLink label={"Level 3.1"} onClick={onClick} />
+        <SidebarMenuLink label={"Level 3.2"} onClick={onClick} />
+        <SidebarMenuCollapsible
+          label={"Level 3.3"}
+          leftIcon={stenaStatisticsBar}
+        >
+          <SidebarMenuLink label={"Level 4.1"} onClick={onClick} />
+          <SidebarMenuLink label={"Level 4.2"} onClick={onClick} />
+        </SidebarMenuCollapsible>
+      </SidebarMenuCollapsible>
+    </SidebarMenuCollapsible>
+
+    <SidebarMenuCollapsible label={"No icon"}>
+      <SidebarMenuLink label={"Level 2"} onClick={onClick} />
+    </SidebarMenuCollapsible>
+
+    <SidebarMenuHeading label={"Support"} />
+    <SidebarMenuLink
+      leftIcon={stenaBusinessClaim}
+      label={"Make a claim"}
+      href={"#"}
+    />
+    <SidebarMenuLink
+      leftIcon={stenaStatusNoShow}
+      label={"No show, late handling"}
+      href={"#"}
+    />
+  </>
+);
+
+const bottomItems = (
+  <>
+    <SidebarMenuLink leftIcon={stenaClock} label={"Timetable"} href={"#"} />
+    <SidebarMenuLink leftIcon={stenaHelp} label={"Help"} href={"#"} />
+    <SidebarMenuLink
+      leftIcon={stenaSlidersMini}
+      label={"Settings"}
+      href={"#"}
+    />
+  </>
+);
 
 export const Overview = () => {
   const onClick = () => alert("Click");
@@ -102,6 +174,18 @@ export const Overview = () => {
   );
 };
 
+export const RailMenu = () => {
+  return (
+    <SidebarRailMenu
+      onClickMenuButton={() => alert("Open sidebar menu")}
+      closeButtonVisible
+      onClickCloseButton={() => alert("Unpin it")}
+      bottomItems={bottomItems}
+    >
+      {createSidebarMenuItems(() => alert("Clicked a link"))}
+    </SidebarRailMenu>
+  );
+};
 export const WithoutIcons = () => {
   const onClick = () => alert("Click");
   return (

--- a/packages/panels/src/components/sidebar-menu/items/RailMenuButton.tsx
+++ b/packages/panels/src/components/sidebar-menu/items/RailMenuButton.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { IconMenuButton, IconMenuButtonProps } from "@stenajs-webui/elements";
+import { Tooltip } from "@stenajs-webui/tooltip";
+
+export type RailMenuButtonProps = IconMenuButtonProps & { label: string };
+
+export const RailMenuButton: React.FC<RailMenuButtonProps> = ({
+  label,
+  ...menuButtonLinkProps
+}) => {
+  return (
+    <Tooltip label={label} placement={"right"} appendTo={document.body}>
+      <IconMenuButton {...menuButtonLinkProps} />
+    </Tooltip>
+  );
+};

--- a/packages/panels/src/components/sidebar-menu/rail/SidebarRailMenu.tsx
+++ b/packages/panels/src/components/sidebar-menu/rail/SidebarRailMenu.tsx
@@ -8,7 +8,7 @@ import {
   stenaAngleLeftDouble,
   stenaHamburger,
 } from "@stenajs-webui/elements";
-import { SidebarMenuLink } from "../items/SidebarMenuLink";
+import { RailMenuButton } from "../items/RailMenuButton";
 
 interface SidebarRailMenuProps {
   closeButtonVisible?: boolean;
@@ -49,8 +49,8 @@ export const SidebarRailMenu: React.FC<SidebarRailMenuProps> = ({
             <RailContext.Provider value={true}>
               {bottomItems}
               {closeButtonVisible && (
-                <SidebarMenuLink
-                  leftIcon={stenaAngleLeftDouble}
+                <RailMenuButton
+                  icon={stenaAngleLeftDouble}
                   label={closeButtonTitle}
                   onClick={onClickCloseButton}
                 />


### PR DESCRIPTION
- Update focus to have -2px offset, which makes it visible regardless of parent element.
- Add separate rail menu story.

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/1511f090-a8a8-4424-a8be-ae61d9af2114)
