### PR TITLE
Card bottom padding and NavBarSearchField fixes

### DIFF
--- a/packages/elements/src/components/ui/card/Card.tsx
+++ b/packages/elements/src/components/ui/card/Card.tsx
@@ -8,9 +8,9 @@ export const Card: React.FC<CardProps> = ({
   ...boxProps
 }) => (
   <Column
-    {...boxProps}
     shadow={"box"}
     background={background}
-    borderRadius={"var(--swui-border-radius)"}
+    borderRadius={"var(--swui-border-radius-card)"}
+    {...boxProps}
   />
 );

--- a/packages/elements/src/components/ui/card/Card.tsx
+++ b/packages/elements/src/components/ui/card/Card.tsx
@@ -10,7 +10,7 @@ export const Card: React.FC<CardProps> = ({
   <Column
     shadow={"box"}
     background={background}
-    borderRadius={"var(--swui-border-radius-card)"}
+    borderRadius={"var(--swui-border-radius)"}
     {...boxProps}
   />
 );

--- a/packages/elements/src/components/ui/cardy/Cardy.module.css
+++ b/packages/elements/src/components/ui/cardy/Cardy.module.css
@@ -1,11 +1,11 @@
 .cardy.cardy {
-  border-radius: 24px;
+  border-radius: var(--swui-border-radius-card);
 
   padding-top: 32px;
-  padding-bottom: 56px;
+  padding-bottom: 32px;
   @media (max-width: 768px) {
     padding-top: 24px;
-    padding-bottom: 48px;
+    padding-bottom: 24px;
   }
 }
 

--- a/packages/elements/src/components/ui/cardy/Cardy.module.css
+++ b/packages/elements/src/components/ui/cardy/Cardy.module.css
@@ -1,5 +1,5 @@
 .cardy.cardy {
-  border-radius: var(--swui-border-radius-card);
+  border-radius: 24px;
 
   padding-top: 32px;
   padding-bottom: 32px;

--- a/packages/panels/src/components/nav-bar/NavBarSearchField.module.css
+++ b/packages/panels/src/components/nav-bar/NavBarSearchField.module.css
@@ -1,22 +1,22 @@
 .navBarSearchFieldInput.navBarSearchFieldInput {
-  --swui-textinput-line-height: 2.7rem;
-  --swui-textinput-text-color: var(--lhds-color-ui-50);
-  --swui-textinput-placeholder-color: var(--lhds-color-blue-800);
+  line-height: 2.7rem;
+  color: var(--lhds-color-ui-800);
+
+  &::placeholder {
+    color: var(--lhds-color-blue-800);
+  }
 
   padding: 0 var(--swui-metrics-indent);
 
-  &:focus {
-    --swui-textinput-text-color: var(--lhds-color-ui-800);
-  }
 }
 
-.navBarSearchField {
-  --swui-textinput-animation-time: var(--swui-animation-time-fast);
+.navBarSearchFieldWrapper.navBarSearchFieldWrapper {
+  background: var(--lhds-color-ui-200);
+  border-color: transparent;
 
-  --swui-textinput-placeholder-color: var(--lhds-color-ui-500);
-  --swui-textinput-bg-color: var(--lhds-color-ui-200);
-  --swui-textinput-border-color: transparent;
-  --swui-textinput-border-color-hover: transparent;
+  &:hover {
+    border-color: transparent;
+  }
 
   padding: 0 var(--swui-metrics-indent);
 
@@ -27,9 +27,8 @@
   }
 
   &:focus-within {
-    --swui-textinput-text-color: var(--lhds-color-ui-800);
-    --swui-field-text-color: var(--swui-field-text-color);
-    --swui-textinput-bg-color: var(--lhds-color-ui-50);
+    color: var(--lhds-color-ui-800);
+    background: var(--lhds-color-ui-50);
   }
 }
 

--- a/packages/panels/src/components/nav-bar/NavBarSearchField.module.css
+++ b/packages/panels/src/components/nav-bar/NavBarSearchField.module.css
@@ -7,7 +7,6 @@
   }
 
   padding: 0 var(--swui-metrics-indent);
-
 }
 
 .navBarSearchFieldWrapper.navBarSearchFieldWrapper {

--- a/packages/panels/src/components/nav-bar/NavBarSearchField.stories.tsx
+++ b/packages/panels/src/components/nav-bar/NavBarSearchField.stories.tsx
@@ -13,7 +13,7 @@ export default {
 };
 
 export const CenterContent = () => {
-  const [text, setText] = useState("");
+  const [text, setText] = useState<string>("");
   return (
     <NavBar
       center={

--- a/packages/panels/src/components/nav-bar/NavBarSearchField.tsx
+++ b/packages/panels/src/components/nav-bar/NavBarSearchField.tsx
@@ -20,19 +20,21 @@ export const NavBarSearchField: React.FC<NavBarSearchFieldProps> = ({
   wrapperClassName,
   showClearButton,
   onClickClearButton,
+  value,
   ...textInputProps
 }) => {
   return (
     <TextInput
       wrapperClassName={cx(
-        styles.navBarSearchField,
+        styles.navBarSearchFieldWrapper,
         showClearButton ? styles.withButton : undefined,
         wrapperClassName
       )}
       className={cx(styles.navBarSearchFieldInput, className)}
       placeholder={placeholder}
+      value={value}
       buttonRight={
-        showClearButton ? (
+        value && showClearButton ? (
           <TextInputButton
             className={styles.clearButton}
             icon={stenaTimes}

--- a/packages/theme/src/styles/default-theme.css
+++ b/packages/theme/src/styles/default-theme.css
@@ -91,6 +91,7 @@
   --swui-border-radius-small: 4px;
   --swui-border-radius: 8px;
   --swui-border-radius-large: 16px;
+  --swui-border-radius-card: 20px;
   --swui-max-border-radius: 10000px;
 
   /* Shadows */

--- a/packages/theme/src/styles/default-theme.css
+++ b/packages/theme/src/styles/default-theme.css
@@ -91,7 +91,6 @@
   --swui-border-radius-small: 4px;
   --swui-border-radius: 8px;
   --swui-border-radius-large: 16px;
-  --swui-border-radius-card: 20px;
   --swui-max-border-radius: 10000px;
 
   /* Shadows */


### PR DESCRIPTION
- Card spread props can now be overridden.
- Cardy no longer has extended padding in bottom.
- Update NavBarSearchField to work with TextInput CSS refactor.
- NavBarSearchField clear button only visible if it as entered text.

Pair programmed with Chris, so all design changes have been reviewed by him.

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/d866b2dd-3313-4f74-bd0b-9f77674292ea)

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/651431c3-971f-438a-a2d4-8893087467ab)
