### PR TITLE
Add gap between content and arrow in Collapsible

### DIFF
--- a/packages/elements/src/components/ui/buttons/menu-button/MenuButton.module.css
+++ b/packages/elements/src/components/ui/buttons/menu-button/MenuButton.module.css
@@ -56,6 +56,7 @@
     align-items: center;
     justify-content: space-between;
 
+    gap: 8px;
     border: 0;
     cursor: pointer;
     border-radius: var(--swui-max-border-radius);


### PR DESCRIPTION
- Add gap between right content and expandable arrow in MenuButton. This fixes no gap visual bug in Collapsible.


## Before

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/1f4d9af8-d55e-41c1-ac2c-d143e9f2eea7)

## After

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/8effd027-969e-4fe9-b0ce-45ada048489e)
