### PR TITLE
Fix rail menu hamburger button not visible when window is small

### DIFF
--- a/packages/elements/src/components/ui/buttons/menu-button/IconMenuButton.tsx
+++ b/packages/elements/src/components/ui/buttons/menu-button/IconMenuButton.tsx
@@ -26,6 +26,7 @@ export const IconMenuButton = forwardRef<
       width={"100%"}
       borderRadius={"99rem"}
       overflow={"hidden"}
+      flexShrink={0}
     >
       <button
         className={cx(

--- a/packages/panels/src/components/nav-bar/NavBar.stories.tsx
+++ b/packages/panels/src/components/nav-bar/NavBar.stories.tsx
@@ -45,7 +45,7 @@ import { SidebarMenu } from "../sidebar-menu/SidebarMenu";
 import { SidebarMenuHeading } from "../sidebar-menu/items/SidebarMenuHeading";
 import { SidebarMenuLink } from "../sidebar-menu/items/SidebarMenuLink";
 import { SidebarMenuCollapsible } from "../sidebar-menu/items/SidebarMenuCollapsible";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { NavBarHeading } from "./NavBarHeading";
 import { SidebarRailMenu } from "../sidebar-menu/rail/SidebarRailMenu";
 import { NavBarUserButton } from "./NavBarUserButton";
@@ -60,7 +60,7 @@ export default {
   subcomponents: { NavBarButton, NavBarMenuButton: NavBarPopoverButton },
 };
 
-export const Demo: Story<Pick<NavBarProps, "variant">> = ({ variant }) => {
+export const Demo: StoryFn<Pick<NavBarProps, "variant">> = ({ variant }) => {
   const [isOpen, open, close] = useBoolean(false);
   const [pinned, , unpin, togglePin] = useBoolean(false);
   const onClick = () => {};


### PR DESCRIPTION
- Hamburger menu is now always visible in rail menu, even when total menu height is larger than window height.

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/b601ae67-f80f-43c8-80e0-9aa11a4fb11d)
