### PR TITLE
Update padding, Chip and clear button in Select

### DIFF
--- a/packages/elements/src/components/ui/buttons/common/BaseButton.tsx
+++ b/packages/elements/src/components/ui/buttons/common/BaseButton.tsx
@@ -1,7 +1,7 @@
 import { ButtonElementProps } from "@stenajs-webui/core";
 import cx from "classnames";
 import * as React from "react";
-import { forwardRef } from "react";
+import { forwardRef, MouseEventHandler } from "react";
 import buttonBaseStyles from "./BaseButton.module.css";
 import { CommonButtonProps } from "./ButtonCommon";
 import { getButtonLabel } from "./ButtonLabelFactory";
@@ -66,10 +66,19 @@ export const BaseButton = forwardRef<HTMLButtonElement, BaseButtonProps>(
       loadingOnly ||
       successIconOnly;
 
+    const onClickHandler: MouseEventHandler<HTMLButtonElement> = (ev) => {
+      ev.stopPropagation();
+      ev.preventDefault();
+      if (disabled || success || loading) {
+        return;
+      }
+      onClick?.(ev);
+    };
+
     return (
       <button
         ref={ref}
-        onClick={disabled || success || loading ? undefined : onClick}
+        onClick={onClickHandler}
         className={cx(
           buttonBaseStyles.button,
           buttonBaseStyles[size],

--- a/packages/elements/src/components/ui/chip/Chip.tsx
+++ b/packages/elements/src/components/ui/chip/Chip.tsx
@@ -9,8 +9,8 @@ import { stenaTimesThick } from "../../../icons/generated/CommonIcons";
 export type ChipVariant = "primary" | "secondary";
 
 export interface ChipProps {
-  onClick?: () => void;
-  onClickRemove?: () => void;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  onClickRemove?: MouseEventHandler<HTMLButtonElement>;
   label?: string;
   variant?: ChipVariant;
   className?: string;
@@ -24,11 +24,11 @@ export const Chip: React.FC<ChipProps> = ({
   className,
   ...rest
 }) => {
-  const onClickHandler: MouseEventHandler<HTMLSpanElement> = (ev) => {
+  const onClickHandler: MouseEventHandler<HTMLButtonElement> = (ev) => {
     ev.stopPropagation();
     ev.preventDefault();
     if (onClick) {
-      onClick();
+      onClick(ev);
     }
   };
 

--- a/packages/elements/src/components/ui/chip/Chip.tsx
+++ b/packages/elements/src/components/ui/chip/Chip.tsx
@@ -27,9 +27,13 @@ export const Chip: React.FC<ChipProps> = ({
   const onClickHandler: MouseEventHandler<HTMLButtonElement> = (ev) => {
     ev.stopPropagation();
     ev.preventDefault();
-    if (onClick) {
-      onClick(ev);
-    }
+    onClick?.(ev);
+  };
+
+  const onClickRemoveHandler: MouseEventHandler<HTMLButtonElement> = (ev) => {
+    ev.stopPropagation();
+    ev.preventDefault();
+    onClickRemove?.(ev);
   };
 
   const removableStyle = onClickRemove ? styles.removable : undefined;
@@ -55,7 +59,7 @@ export const Chip: React.FC<ChipProps> = ({
       {onClickRemove && (
         <button
           className={cx(styles.chipCell, styles.close)}
-          onClick={onClickRemove}
+          onClick={onClickRemoveHandler}
         >
           <div className={styles.circle}>
             <Icon icon={stenaTimesThick} size={8} />

--- a/packages/elements/src/components/ui/icon/CircledIcon.tsx
+++ b/packages/elements/src/components/ui/icon/CircledIcon.tsx
@@ -64,7 +64,7 @@ const getBackgroundSize = (
     case "medium":
       return "40px";
     case "large":
-      return "96px";
+      return "64px";
     case "xl":
       return "160px";
     default:
@@ -81,7 +81,7 @@ const getIconSize = (
     case "medium":
       return 20;
     case "large":
-      return 48;
+      return 32;
     case "xl":
       return 80;
     default:

--- a/packages/forms/src/components/ui/text-input/TextInput.module.css
+++ b/packages/forms/src/components/ui/text-input/TextInput.module.css
@@ -1,6 +1,6 @@
 .textInput {
   display: flex;
-  height: 36px;
+  height: var(--swui-field-height);
   width: 100%;
   align-items: center;
   background: var(--swui-field-bg-enabled);

--- a/packages/modal/src/ready-made-modals/InfoAlert.stories.tsx
+++ b/packages/modal/src/ready-made-modals/InfoAlert.stories.tsx
@@ -1,12 +1,14 @@
 import * as React from "react";
 import { Row } from "@stenajs-webui/core";
 import type { Meta, StoryObj } from "@storybook/react";
-import { PrimaryButton } from "@stenajs-webui/elements";
+import {
+  PrimaryButton,
+  SecondaryButton,
+  stenaBell,
+} from "@stenajs-webui/elements";
 import { InfoAlert } from "./InfoAlert";
-import { stenaBell } from "@stenajs-webui/elements";
 import { useDialogPromise } from "../dialog/UseDialogPromise";
 import { useAlertDialog } from "../dialog/alert/UseAlertDialog";
-import { SecondaryButton } from "@stenajs-webui/elements";
 
 const meta: Meta<typeof InfoAlert> = {
   title: "modal/Ready-made modals/InfoAlert",
@@ -39,7 +41,7 @@ const OneButtonAlert: React.FC = () => {
       heading={heading}
       text={text}
       icon={stenaBell}
-      buttons={<PrimaryButton size={"larger"} label={"Restart"} />}
+      buttons={<PrimaryButton size={"large"} label={"Restart"} />}
     />
   );
 };
@@ -67,8 +69,8 @@ const TwoButtonsAlert: React.FC = () => {
       icon={stenaBell}
       buttons={
         <>
-          <SecondaryButton size={"larger"} label={"Cancel"} />
-          <PrimaryButton size={"larger"} label={"Restart"} />
+          <SecondaryButton size={"large"} label={"Cancel"} />
+          <PrimaryButton size={"large"} label={"Restart"} />
         </>
       }
     />

--- a/packages/select/src/SelectTheme.ts
+++ b/packages/select/src/SelectTheme.ts
@@ -116,7 +116,7 @@ export const defaultSelectTheme: SelectTheme = {
     boxShadowFocused: "none",
     fontFamily: "var(--swui-font-primary)",
     fontSize: "var(--swui-font-size-inputs)",
-    minHeight: "30px",
+    minHeight: "24px",
     placeholderColor: "var(--swui-field-text-color)",
     textColor: "var(--swui-field-text-color)",
     borderRadius: "var(--swui-field-border-radius)",
@@ -125,7 +125,7 @@ export const defaultSelectTheme: SelectTheme = {
     textColor: "var(--swui-field-text-color)",
   },
   groupHeading: {
-    fontSize: "var(--swui-font-size-smaller)",
+    fontSize: "var(--swui-font-size-small)",
     lineHeight: "var(--swui-line-height-smaller)",
     fontWeight: "var(--swui-font-weight-text-bold)",
     color: cssColor("--lhds-color-ui-600"),

--- a/packages/select/src/components/ui/ChipMultiSelect/ChipMultiSelect.tsx
+++ b/packages/select/src/components/ui/ChipMultiSelect/ChipMultiSelect.tsx
@@ -1,6 +1,10 @@
 import { ValueAndOnValueChangeProps } from "@stenajs-webui/forms";
 import * as React from "react";
-import { MultiSelect, MultiSelectProps } from "../MultiSelect";
+import {
+  MultiSelect,
+  MultiSelectOption,
+  MultiSelectProps,
+} from "../MultiSelect";
 import { ChipRow, ChipRowItem } from "./ChipRow";
 
 export interface ChipMultiSelectOption extends ChipRowItem {}
@@ -10,8 +14,9 @@ export interface ChipMultiSelectOption extends ChipRowItem {}
  */
 export type ChipMultiSelectValue = ChipMultiSelectOption;
 
-export interface ChipMultiSelectProps<TOption>
-  extends Omit<MultiSelectProps<TOption>, "value" | "onChange" | "isLoading">,
+export interface ChipMultiSelectProps<
+  TOption extends MultiSelectOption = MultiSelectOption
+> extends Omit<MultiSelectProps<TOption>, "value" | "onChange" | "isLoading">,
     ValueAndOnValueChangeProps<Array<TOption>> {
   loading?: boolean;
   inputValue?: string;

--- a/packages/select/src/components/ui/ChipMultiSelect/ChipRow.tsx
+++ b/packages/select/src/components/ui/ChipMultiSelect/ChipRow.tsx
@@ -3,11 +3,9 @@ import { Chip, FlatButton } from "@stenajs-webui/elements";
 import { ValueAndOnValueChangeProps } from "@stenajs-webui/forms";
 import * as React from "react";
 import { PropsWithChildren } from "react";
+import { MultiSelectOption } from "../MultiSelect";
 
-export interface ChipRowItem {
-  label: string;
-  value: string;
-}
+export interface ChipRowItem extends MultiSelectOption {}
 
 export interface ChipRowProps<TValue>
   extends ValueAndOnValueChangeProps<TValue> {

--- a/packages/select/src/components/ui/MultiSelect.tsx
+++ b/packages/select/src/components/ui/MultiSelect.tsx
@@ -4,6 +4,7 @@ import SelectComponent, {
   ClearIndicatorProps,
   GroupBase,
   mergeStyles,
+  MultiValueProps,
   Props,
   SelectComponentsConfig,
 } from "react-select";
@@ -11,10 +12,16 @@ import {
   createStylesFromVariant,
   SelectVariant,
 } from "../../util/StylesBuilder";
-import { CloseButton } from "@stenajs-webui/elements";
+import { Chip, stenaTimes, TextInputButton } from "@stenajs-webui/elements";
 
-export interface MultiSelectProps<TOption = { label: string; value: string }>
-  extends Props<TOption, true> {
+interface MultiSelectOption {
+  label: string;
+  value: string;
+}
+
+export interface MultiSelectProps<
+  TOption extends MultiSelectOption = MultiSelectOption
+> extends Props<TOption, true> {
   variant?: SelectVariant;
   isMulti?: true;
 }
@@ -25,7 +32,34 @@ export type MultiSelectComponentsConfig<TOption> = SelectComponentsConfig<
   GroupBase<TOption>
 >;
 
-export function MultiSelect<TOption>({
+const ClearIndicator = function <TOption>({
+  clearValue,
+}: ClearIndicatorProps<TOption, true, GroupBase<TOption>>) {
+  return (
+    <TextInputButton
+      aria-label={"Clear"}
+      onClick={clearValue}
+      icon={stenaTimes}
+      variant={"error"}
+    />
+  );
+};
+
+const MultiValue = function <TOption extends MultiSelectOption>({
+  removeProps,
+  data,
+}: MultiValueProps<TOption, true, GroupBase<TOption>>) {
+  return (
+    <Chip
+      onClickRemove={(ev) =>
+        removeProps.onClick?.(ev as unknown as React.MouseEvent<HTMLDivElement>)
+      }
+      label={data.label}
+    />
+  );
+};
+
+export function MultiSelect<TOption extends MultiSelectOption>({
   variant = "standard",
   styles,
   isMulti,
@@ -38,14 +72,10 @@ export function MultiSelect<TOption>({
     return styles ? mergeStyles(sourceStyles, styles) : sourceStyles;
   }, [variant, styles]);
 
-  const ClearIndicator = (
-    props: ClearIndicatorProps<TOption, true, GroupBase<TOption>>
-  ) => <CloseButton aria-label={"Clear"} onClick={props.clearValue} />;
-
   return (
     <SelectComponent
       styles={selectStyles}
-      components={{ ...components, ClearIndicator }}
+      components={{ ...components, ClearIndicator, MultiValue }}
       {...selectProps}
       isMulti={true}
     />

--- a/packages/select/src/components/ui/MultiSelect.tsx
+++ b/packages/select/src/components/ui/MultiSelect.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../util/StylesBuilder";
 import { Chip, stenaTimes, TextInputButton } from "@stenajs-webui/elements";
 
-interface MultiSelectOption {
+export interface MultiSelectOption {
   label: string;
   value: string;
 }

--- a/packages/select/src/components/ui/MultiSelect.tsx
+++ b/packages/select/src/components/ui/MultiSelect.tsx
@@ -36,12 +36,15 @@ const ClearIndicator = function <TOption>({
   clearValue,
 }: ClearIndicatorProps<TOption, true, GroupBase<TOption>>) {
   return (
-    <TextInputButton
-      aria-label={"Clear"}
-      onClick={clearValue}
-      icon={stenaTimes}
-      variant={"error"}
-    />
+    // stopPropagation is needed to prevent react-select from opening its menu when clicking on the button.
+    <div onMouseDown={(ev) => ev.stopPropagation()}>
+      <TextInputButton
+        aria-label={"Clear"}
+        onClick={clearValue}
+        icon={stenaTimes}
+        variant={"error"}
+      />
+    </div>
   );
 };
 
@@ -50,12 +53,17 @@ const MultiValue = function <TOption extends MultiSelectOption>({
   data,
 }: MultiValueProps<TOption, true, GroupBase<TOption>>) {
   return (
-    <Chip
-      onClickRemove={(ev) =>
-        removeProps.onClick?.(ev as unknown as React.MouseEvent<HTMLDivElement>)
-      }
-      label={data.label}
-    />
+    // stopPropagation is needed to prevent react-select from opening its menu when clicking on the button.
+    <div onMouseDown={(ev) => ev.stopPropagation()}>
+      <Chip
+        onClickRemove={(ev) =>
+          removeProps.onClick?.(
+            ev as unknown as React.MouseEvent<HTMLDivElement>
+          )
+        }
+        label={data.label}
+      />
+    </div>
   );
 };
 

--- a/packages/select/src/components/ui/OverflowingMultiSelect.tsx
+++ b/packages/select/src/components/ui/OverflowingMultiSelect.tsx
@@ -1,9 +1,15 @@
 import * as React from "react";
-import { MultiSelect, MultiSelectProps } from "./MultiSelect";
 import { memo, ReactElement } from "react";
+import {
+  MultiSelect,
+  MultiSelectOption,
+  MultiSelectProps,
+} from "./MultiSelect";
 import { components, ValueContainerProps } from "react-select";
 
-export function OverflowingMultiSelect<T>(props: MultiSelectProps<T>) {
+export function OverflowingMultiSelect<T extends MultiSelectOption>(
+  props: MultiSelectProps<T>
+) {
   return (
     <MultiSelect
       hideSelectedOptions={false}

--- a/packages/select/src/util/StylesBuilder.ts
+++ b/packages/select/src/util/StylesBuilder.ts
@@ -138,7 +138,7 @@ export const createStylesFromTheme = <
     // none of react-selects styles are passed to <View />
     fontFamily: input.fontFamily,
     fontSize: input.fontSize,
-    minHeight: "36px",
+    minHeight: "var(--swui-field-height)",
     backgroundColor: resolveInputBackgroundColor(
       input,
       isDisabled,
@@ -228,8 +228,8 @@ export const createStylesFromTheme = <
   }),
   valueContainer: (base) => ({
     ...base,
-    padding: "4px",
-    gap: "4px",
+    padding: "var(--swui-metrics-space-half)",
+    gap: "var(--swui-metrics-space-half)",
   }),
   dropdownIndicator: (base, { isFocused, isDisabled }) => ({
     ...base,
@@ -292,7 +292,7 @@ export const createStylesFromTheme = <
     fontSize: groupHeading.fontSize,
     alignItems: "center",
     margin: 0,
-    borderRadius: "4px",
+    borderRadius: "var(--swui-border-radius-small)",
     overflow: "hidden",
   }),
   loadingMessage: (base) => ({

--- a/packages/select/src/util/StylesBuilder.ts
+++ b/packages/select/src/util/StylesBuilder.ts
@@ -138,7 +138,7 @@ export const createStylesFromTheme = <
     // none of react-selects styles are passed to <View />
     fontFamily: input.fontFamily,
     fontSize: input.fontSize,
-    minHeight: input.minHeight,
+    minHeight: "36px",
     backgroundColor: resolveInputBackgroundColor(
       input,
       isDisabled,
@@ -181,6 +181,8 @@ export const createStylesFromTheme = <
   }),
   input: (base) => ({
     ...base,
+    padding: 0,
+    margin: 0,
     minHeight: input.minHeight,
     fontFamily: input.fontFamily,
     fontSize: input.fontSize,
@@ -226,7 +228,8 @@ export const createStylesFromTheme = <
   }),
   valueContainer: (base) => ({
     ...base,
-    padding: "0 8px",
+    padding: "4px",
+    gap: "4px",
   }),
   dropdownIndicator: (base, { isFocused, isDisabled }) => ({
     ...base,
@@ -289,7 +292,8 @@ export const createStylesFromTheme = <
     fontSize: groupHeading.fontSize,
     alignItems: "center",
     margin: 0,
-    marginRight: 2,
+    borderRadius: "4px",
+    overflow: "hidden",
   }),
   loadingMessage: (base) => ({
     ...base,

--- a/packages/theme/src/styles/default-theme.css
+++ b/packages/theme/src/styles/default-theme.css
@@ -71,6 +71,7 @@
   --swui-field-text-color-disabled: #0c0e10;
   --swui-field-letter-spacing: 0;
   --swui-field-text-line-height: var(--swui-line-height);
+  --swui-field-height: 36px;
   --swui-field-bg-enabled: var(--swui-white);
   --swui-field-bg-disabled: var(--lhds-color-ui-300);
   --swui-field-border-color: var(--lhds-color-ui-400);
@@ -106,6 +107,7 @@
   --swui-metrics-indent: 8px;
   --swui-metrics-spacing: 8px;
   --swui-metrics-space: 8px;
+  --swui-metrics-space-half: 4px;
 
   --swui-default-item-height: 40px;
 


### PR DESCRIPTION
- Update design av Select. Improved padding, selected items are no longer flush to the border when many items.
- Increased text size from smaller to small.
- Using Chip instead of built-in MultiValue component.
- Use TextInputButton as clear button in MultiSelect.
- MultiSelect options now required by types to be `{ label: string, value: string }`

## Before

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/1af109f9-d368-474c-8fe3-f8710e22f70c)

## After

![image](https://github.com/StenaIT/stenajs-webui/assets/1266041/e1511098-9057-4c3c-99f1-ef641462b4b2)
