### PR TITLE
Add setup function for declarative modals

### DIFF
--- a/packages/modal/src/declarative-modals/DeclarativeModalSetup.ts
+++ b/packages/modal/src/declarative-modals/DeclarativeModalSetup.ts
@@ -1,0 +1,5 @@
+import ReactModal from "react-modal";
+
+export const setupDeclarativeModals = (htmlElement: string | HTMLElement) => {
+  ReactModal.setAppElement(htmlElement);
+};

--- a/packages/modal/src/declarative-modals/DeclarativeModals.mdx
+++ b/packages/modal/src/declarative-modals/DeclarativeModals.mdx
@@ -17,6 +17,22 @@ you should use `useModalDialog` hooks instead.
 
 These modals are based on the `react-modal` library.
 
+# Setup
+
+To use declarative modals, you need to set up `react-modal`.
+
+Just call `setupDeclarativeModals(..)` with application root div as argument.
+
+```
+setupDeclarativeModals("root")
+```
+
+or
+
+```
+setupDeclarativeModals(document.getElementById("root")!)
+```
+
 # Minimal inherent visuals
 
 Visually, these are identical to dialog hooks API.

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./common-types";
+export * from "./declarative-modals/DeclarativeModalSetup";
 export * from "./declarative-modals/window/BaseWindow";
 export * from "./declarative-modals/drawer/Drawer";
 export * from "./declarative-modals/drawer/DrawerHeader";


### PR DESCRIPTION
- Add setup function for react-modal, so that applications do not have to add react-modal to package.json dependencies.