### PR TITLE
Modal inner content is 100% height on mobile

### DIFF
--- a/packages/modal/src/dialog/UseDialog.tsx
+++ b/packages/modal/src/dialog/UseDialog.tsx
@@ -28,6 +28,7 @@ export interface DialogOptions {
   className: string;
   closingClassName: string;
   contentWrapperClassName: string;
+  contentWrapperStyle?: CSSProperties;
   dialogStyle?: CSSProperties;
   ref?: RefObject<HTMLDialogElement>;
   onResolve?: () => void;
@@ -62,14 +63,14 @@ export function useDialog<TProps, TPromiseResolve = void>(
       setContentVisible(true);
       forceRerender();
       modalComponentProps.current = props;
-      if (options?.modal) {
+      if (options.modal) {
         currentRef.current?.showModal();
       } else {
         currentRef.current?.show();
       }
       return promiseRef.current;
     },
-    [currentRef, options?.modal]
+    [currentRef, options.modal]
   );
 
   const resolve = useCallback<ResolveCommand<TPromiseResolve>>(
@@ -83,7 +84,7 @@ export function useDialog<TProps, TPromiseResolve = void>(
           currentRef.current?.close();
           resolveRef.current?.(value);
           modalComponentProps.current = undefined;
-          options?.onResolve?.();
+          options.onResolve?.();
         },
         { once: true }
       );
@@ -101,7 +102,7 @@ export function useDialog<TProps, TPromiseResolve = void>(
           setContentVisible(false);
           currentRef.current?.close();
           rejectRef.current?.(error);
-          options?.onReject?.();
+          options.onReject?.();
           modalComponentProps.current = undefined;
         },
         { once: true }
@@ -115,16 +116,13 @@ export function useDialog<TProps, TPromiseResolve = void>(
       <DialogContext.Provider value={{ resolve, reject }}>
         <dialog
           onClick={
-            options?.disableCloseOnClickOutside ? undefined : () => reject()
+            options.disableCloseOnClickOutside ? undefined : () => reject()
           }
           ref={currentRef}
-          className={cx(
-            options?.className,
-            closing && options?.closingClassName
-          )}
-          style={options?.dialogStyle}
+          className={cx(options.className, closing && options.closingClassName)}
+          style={options.dialogStyle}
         >
-          {options?.disableCloseOnClickOutside ? (
+          {options.disableCloseOnClickOutside ? (
             <>
               {contentVisible && (
                 <Comp {...(modalComponentProps.current as TProps)} key={key} />
@@ -132,9 +130,10 @@ export function useDialog<TProps, TPromiseResolve = void>(
             </>
           ) : (
             <div
-              className={options?.contentWrapperClassName}
+              style={options.contentWrapperStyle}
+              className={options.contentWrapperClassName}
               onClick={
-                options?.disableCloseOnClickOutside
+                options.disableCloseOnClickOutside
                   ? undefined
                   : (ev) => ev.stopPropagation()
               }
@@ -150,11 +149,12 @@ export function useDialog<TProps, TPromiseResolve = void>(
     [
       resolve,
       reject,
-      options?.disableCloseOnClickOutside,
-      options?.className,
-      options?.closingClassName,
-      options?.dialogStyle,
-      options?.contentWrapperClassName,
+      options.disableCloseOnClickOutside,
+      options.className,
+      options.closingClassName,
+      options.dialogStyle,
+      options.contentWrapperStyle,
+      options.contentWrapperClassName,
       currentRef,
       closing,
       contentVisible,

--- a/packages/modal/src/dialog/modal/ModalDialog.module.css
+++ b/packages/modal/src/dialog/modal/ModalDialog.module.css
@@ -85,3 +85,8 @@
     }
   }
 }
+
+.contentWrapper {
+  display: flex;
+  height: 100%;
+}

--- a/packages/modal/src/dialog/modal/ModalDialog.module.css
+++ b/packages/modal/src/dialog/modal/ModalDialog.module.css
@@ -87,7 +87,7 @@
 }
 
 .contentWrapper {
-  @media (min-width: 768px) {
+  @media (max-width: 768px) {
     display: flex;
     height: 100%;
   }

--- a/packages/modal/src/dialog/modal/ModalDialog.module.css
+++ b/packages/modal/src/dialog/modal/ModalDialog.module.css
@@ -87,6 +87,8 @@
 }
 
 .contentWrapper {
-  display: flex;
-  height: 100%;
+  @media (min-width: 768px) {
+    display: flex;
+    height: 100%;
+  }
 }

--- a/packages/modal/src/dialog/modal/ModalDialog.stories.tsx
+++ b/packages/modal/src/dialog/modal/ModalDialog.stories.tsx
@@ -8,6 +8,7 @@ import { useDialogPromise } from "../UseDialogPromise";
 import { useModalDialog } from "./UseModalDialog";
 import { cssColor } from "@stenajs-webui/theme";
 import { useAlertDialog } from "../alert/UseAlertDialog";
+import { ModalBody } from "../../building-blocks/ModalBody";
 
 export default {
   title: "modal/Dialog/ModalDialog",
@@ -17,12 +18,12 @@ const ModalContent: React.FC = () => {
   const { resolve } = useDialogPromise();
 
   return (
-    <Column spacing={2} indent={2} gap={2}>
+    <ModalBody>
       <Text>Some modal content</Text>
       <Row gap={2}>
         <PrimaryButton label={"Close"} onClick={() => resolve()} />
       </Row>
-    </Column>
+    </ModalBody>
   );
 };
 export const Overview: StoryFn = () => {


### PR DESCRIPTION
- Add display flex and height 100% to ModalDialog internal wrapper div. This ensures that it takes up the whole height of the dialog on mobile, so that inner elements can be positioned with fixed within the modal.

- Add contentWrapperStyle to useDialog options, complementing contentWrapperClassName.