### PR TITLE
Update imports of lodash to use default imports

### DIFF
--- a/packages/calendar/src/components/calendar/Calendar.tsx
+++ b/packages/calendar/src/components/calendar/Calendar.tsx
@@ -1,7 +1,7 @@
 import { Row, Space, Spacing } from "@stenajs-webui/core";
 import { getMonth, getYear, parse } from "date-fns";
 import { enGB } from "date-fns/locale";
-import { chunk } from "lodash";
+import chunk from "lodash/chunk";
 import * as React from "react";
 import { useMemo } from "react";
 import { useHighlightToday } from "../../features/today-state/UseHighlightToday";

--- a/packages/calendar/src/features/dual-text-input/DualTextInput.tsx
+++ b/packages/calendar/src/features/dual-text-input/DualTextInput.tsx
@@ -19,7 +19,7 @@ import {
   TextInputBoxProps,
   TextInputProps,
 } from "@stenajs-webui/forms";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import * as React from "react";
 import { FocusEventHandler, useCallback, useMemo, useRef } from "react";
 import { cssColor } from "@stenajs-webui/theme";

--- a/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
+++ b/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
@@ -1,4 +1,4 @@
-import { startCase } from "lodash";
+import startCase from "lodash/startCase";
 import * as React from "react";
 import { useMemo } from "react";
 import { Row } from "@stenajs-webui/core";

--- a/packages/calendar/src/features/time-picker/TimePicker.tsx
+++ b/packages/calendar/src/features/time-picker/TimePicker.tsx
@@ -1,6 +1,6 @@
 import { Indent, Row } from "@stenajs-webui/core";
 import { ValueAndOnValueChangeProps } from "@stenajs-webui/forms";
-import { range } from "lodash";
+import range from "lodash/range";
 import * as React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {

--- a/packages/calendar/src/features/time-picker/TimePickerCell.tsx
+++ b/packages/calendar/src/features/time-picker/TimePickerCell.tsx
@@ -2,7 +2,7 @@ import { Row } from "@stenajs-webui/core";
 import { FlatButton, PrimaryButton } from "@stenajs-webui/elements";
 import * as React from "react";
 import { MutableRefObject, RefObject, useEffect, useRef } from "react";
-import { padStart } from "lodash";
+import padStart from "lodash/padStart";
 
 export interface TimePickerCellProps {
   item: number;

--- a/packages/calendar/src/features/year-picker/YearPicker.tsx
+++ b/packages/calendar/src/features/year-picker/YearPicker.tsx
@@ -8,7 +8,8 @@ import {
   stenaArrowLeft,
   stenaArrowRight,
 } from "@stenajs-webui/elements";
-import { chunk, range } from "lodash";
+import chunk from "lodash/chunk";
+import range from "lodash/range";
 
 export interface YearPickerProps extends ValueAndOnValueChangeProps<number> {
   initialLastYear?: number;

--- a/packages/calendar/src/util/calendar/CalendarDataFactory.ts
+++ b/packages/calendar/src/util/calendar/CalendarDataFactory.ts
@@ -14,7 +14,7 @@ import {
   startOfMonth,
   startOfWeek,
 } from "date-fns";
-import { startCase } from "lodash";
+import startCase from "lodash/startCase";
 import { DateFormats } from "../date/DateFormats";
 
 export enum Month {

--- a/packages/calendar/src/util/calendar/StateModifier.ts
+++ b/packages/calendar/src/util/calendar/StateModifier.ts
@@ -12,7 +12,7 @@ import {
   startOfMonth,
   subDays,
 } from "date-fns";
-import { last } from "lodash";
+import last from "lodash/last";
 import {
   CalendarState,
   CalendarUserData,

--- a/packages/core/src/hooks/UseOnNoMouseInput.ts
+++ b/packages/core/src/hooks/UseOnNoMouseInput.ts
@@ -1,4 +1,4 @@
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { useEffect, useRef } from "react";
 
 const events = ["mousemove", "mousedown", "keydown", "touchstart", "scroll"];

--- a/packages/core/src/utils/PropsForwarder.ts
+++ b/packages/core/src/utils/PropsForwarder.ts
@@ -1,4 +1,4 @@
-import { pickBy } from "lodash";
+import pickBy from "lodash/pickBy";
 
 export const getDataProps = <T extends Record<string, unknown>>(
   props: Record<string, unknown> | {}

--- a/packages/filter/src/features/search-filter/components/SearchFilterSection.tsx
+++ b/packages/filter/src/features/search-filter/components/SearchFilterSection.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { PropsWithChildren, useCallback } from "react";
 import { Row, Space } from "@stenajs-webui/core";
-import { lowerCase, upperFirst } from "lodash";
+import lowerCase from "lodash/lowerCase";
+import upperFirst from "lodash/upperFirst";
 import {
   Banner,
   FlatButton,

--- a/packages/forms/src/utils/NumberComparator.ts
+++ b/packages/forms/src/utils/NumberComparator.ts
@@ -1,4 +1,4 @@
-import { isNil } from "lodash";
+import isNil from "lodash/isNil";
 import { parseFloatElseUndefined } from "@stenajs-webui/core";
 
 export const isMinReached = (

--- a/packages/grid-export/src/features/grid-copy-to-clipboard/transformers/HeaderTransformer.ts
+++ b/packages/grid-export/src/features/grid-copy-to-clipboard/transformers/HeaderTransformer.ts
@@ -3,7 +3,7 @@ import {
   StandardTableColumnGroupConfig,
   StandardTableConfig,
 } from "@stenajs-webui/grid";
-import { flatten } from "lodash";
+import flatten from "lodash/flatten";
 import { transformJustifyContentToTextAlign } from "./AlignmentTransformer";
 
 export const transformTableHeaders = <

--- a/packages/grid-export/src/features/grid-copy-to-clipboard/transformers/RowTransformer.ts
+++ b/packages/grid-export/src/features/grid-copy-to-clipboard/transformers/RowTransformer.ts
@@ -2,7 +2,7 @@ import {
   StandardTableColumnGroupConfig,
   StandardTableConfig,
 } from "@stenajs-webui/grid";
-import { flatten } from "lodash";
+import flatten from "lodash/flatten";
 import { transformItemToCell } from "./CellTransformer";
 import { CustomCellFormatters } from "../../../common/CellFormatters";
 

--- a/packages/grid-export/src/features/grid-excel-export/transformers/HeaderTransformer.ts
+++ b/packages/grid-export/src/features/grid-excel-export/transformers/HeaderTransformer.ts
@@ -2,7 +2,7 @@ import {
   formatColumnIdToHeaderCellLabel,
   StandardTableConfig,
 } from "@stenajs-webui/grid";
-import { flatten } from "lodash";
+import flatten from "lodash/flatten";
 import { ZipCelXRow } from "zipcelx";
 import { StandardTableColumnGroupConfig } from "@stenajs-webui/grid";
 

--- a/packages/grid-export/src/features/grid-excel-export/transformers/RowTransformer.ts
+++ b/packages/grid-export/src/features/grid-excel-export/transformers/RowTransformer.ts
@@ -2,7 +2,7 @@ import {
   StandardTableColumnGroupConfig,
   StandardTableConfig,
 } from "@stenajs-webui/grid";
-import { flatten } from "lodash";
+import flatten from "lodash/flatten";
 import { ZipCelXCell, ZipCelXRow } from "zipcelx";
 import { transformItemToCell } from "./CellTransformer";
 import { CustomCellFormatters } from "../../../common/CellFormatters";

--- a/packages/grid/src/features/standard-table/features/column-groups/ColumnGroupFactory.ts
+++ b/packages/grid/src/features/standard-table/features/column-groups/ColumnGroupFactory.ts
@@ -1,4 +1,4 @@
-import { compact } from "lodash";
+import compact from "lodash/compact";
 import { StandardTableColumnGroupConfig } from "../../config/StandardTableColumnGroupConfig";
 import {
   StandardTableConfigWithGroups,

--- a/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTable.stories.tsx
@@ -24,7 +24,8 @@ import {
   standardTableConfigForStories,
   useListState,
 } from "./StandardTableStoryHelper";
-import { sortBy, sumBy } from "lodash";
+import sortBy from "lodash/sortBy";
+import sumBy from "lodash/sumBy";
 import { Tag } from "@stenajs-webui/elements";
 import { createColumnConfig } from "../config/StandardTableColumnConfig";
 

--- a/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
@@ -11,7 +11,7 @@ import {
 import { cssColor } from "@stenajs-webui/theme";
 import { Popover } from "@stenajs-webui/tooltip";
 import { format, parseISO } from "date-fns";
-import { round } from "lodash";
+import round from "lodash/round";
 import * as React from "react";
 import { StandardTable } from "../components/StandardTable";
 import { createColumnConfig } from "../config/StandardTableColumnConfig";

--- a/packages/grid/src/features/standard-table/util/LabelFormatter.ts
+++ b/packages/grid/src/features/standard-table/util/LabelFormatter.ts
@@ -1,4 +1,5 @@
-import { lowerCase, upperFirst } from "lodash";
+import lowerCase from "lodash/lowerCase";
+import upperFirst from "lodash/upperFirst";
 
 export const formatValueLabel = <T>(itemValue: T) => {
   if (itemValue == null) {

--- a/packages/select/src/util/multiDropdownUtils.ts
+++ b/packages/select/src/util/multiDropdownUtils.ts
@@ -1,4 +1,7 @@
-import { differenceWith, intersectionWith, isEqual, uniqWith } from "lodash";
+import differenceWith from "lodash/differenceWith";
+import intersectionWith from "lodash/intersectionWith";
+import isEqual from "lodash/isEqual";
+import uniqWith from "lodash/uniqWith";
 import { ActionMeta, GroupBase, OnChangeValue, Options } from "react-select";
 import { OnChange } from "../components/ui/GroupedMultiSelect";
 import { DropdownOption } from "../components/ui/GroupedMultiSelectTypes";


### PR DESCRIPTION
- Update imports of lodash to use default imports, since named imports are not 100% compatible with ESM.

This should this errors in some projects:

```
Named export 'debounce' not found. The requested module 'lodash' is a CommonJS module, which may not support all module.exports as named exports. 
```


More info:

https://nodejs.org/dist/latest-v14.x/docs/api/esm.html#esm_commonjs_namespaces
https://simonplend.com/node-js-now-supports-named-imports-from-commonjs-modules-but-what-does-that-mean/