### PR TITLE
Use a ref between draggable and the child div

### DIFF
--- a/packages/modal/src/declarative-modals/window/BaseWindow.tsx
+++ b/packages/modal/src/declarative-modals/window/BaseWindow.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useRef } from "react";
 import ReactModal from "react-modal";
 import Draggable from "react-draggable";
 import cx from "classnames";
@@ -21,6 +22,7 @@ export const BaseWindow: React.FC<BaseWindowProps> = ({
   children,
   ...reactModalProps
 }) => {
+  const nodRef = useRef(null);
   return (
     <ReactModal
       overlayClassName={styles.overlay}
@@ -32,6 +34,7 @@ export const BaseWindow: React.FC<BaseWindowProps> = ({
         cancel={`.${DRAGGABLE_CANCEL_CLASSNAME}, button, [role="tooltip"]`}
         bounds=".ReactModal__Overlay"
         disabled={!draggable}
+        nodeRef={nodRef}
       >
         <div
           style={{
@@ -41,6 +44,7 @@ export const BaseWindow: React.FC<BaseWindowProps> = ({
           className={cx(styles.content, {
             [styles.isDraggable]: draggable,
           })}
+          ref={nodRef}
         >
           {children}
         </div>

--- a/packages/modal/src/declarative-modals/window/BaseWindow.tsx
+++ b/packages/modal/src/declarative-modals/window/BaseWindow.tsx
@@ -22,7 +22,7 @@ export const BaseWindow: React.FC<BaseWindowProps> = ({
   children,
   ...reactModalProps
 }) => {
-  const nodRef = useRef(null);
+  const nodeRef = useRef(null);
   return (
     <ReactModal
       overlayClassName={styles.overlay}
@@ -34,7 +34,7 @@ export const BaseWindow: React.FC<BaseWindowProps> = ({
         cancel={`.${DRAGGABLE_CANCEL_CLASSNAME}, button, [role="tooltip"]`}
         bounds=".ReactModal__Overlay"
         disabled={!draggable}
-        nodeRef={nodRef}
+        nodeRef={nodeRef}
       >
         <div
           style={{
@@ -44,7 +44,7 @@ export const BaseWindow: React.FC<BaseWindowProps> = ({
           className={cx(styles.content, {
             [styles.isDraggable]: draggable,
           })}
-          ref={nodRef}
+          ref={nodeRef}
         >
           {children}
         </div>


### PR DESCRIPTION
The current implementation causes errors when used with React.StrictMode as react-draggable uses findDOMNode which is not recommended. See https://react.dev/reference/react-dom/findDOMNode#alternatives.

This change to use a ref instead of letting Draggable rely on unstable apis to get hold of the domNode as per react-draggable change log https://github.com/react-grid-layout/react-draggable/blob/master/CHANGELOG.md#440-may-12-2020