### PR TITLE
Fix bug where contentRight was incorrectly required

### DIFF
--- a/packages/forms/src/components/ui/radio/RadioButtonBox.tsx
+++ b/packages/forms/src/components/ui/radio/RadioButtonBox.tsx
@@ -32,14 +32,14 @@ export interface RadioButtonBoxNoRightProps extends RadioButtonBoxCommonProps {
 }
 
 export interface RadioButtonBoxIconProps extends RadioButtonBoxCommonProps {
-  icon: IconDefinition;
+  icon?: IconDefinition;
   contentRight?: never;
 }
 
 export interface RadioButtonBoxContentRightProps
   extends RadioButtonBoxCommonProps {
   icon?: never;
-  contentRight: ReactNode;
+  contentRight?: ReactNode;
 }
 
 export const RadioButtonBox: React.FC<RadioButtonBoxProps> = ({


### PR DESCRIPTION
- Fix bug where contentRight was required in booking funnel app, even though icon was provided. This is working properly in webui Storybook, but not in the app.