### PR TITLE
Fix invalid styling for Popover in StandardTable

### DIFF
--- a/examples/stories/boxes/NewBlockConfig.stories.tsx
+++ b/examples/stories/boxes/NewBlockConfig.stories.tsx
@@ -22,7 +22,6 @@ export const NewBlockConfig = () => (
     <Box
       shadow={"box"}
       background={"white"}
-      display={"inline-block"}
       spacing={2}
       gap={2}
     >
@@ -37,7 +36,7 @@ export const NewBlockConfig = () => (
 
       <SeparatorLine />
 
-      <Indent num={2}>
+      <Indent num={2} gap={2}>
         <Row>
           <Column>
             <Text>Customer</Text>

--- a/packages/grid/src/features/table-ui/components/table/TableHeadItem.tsx
+++ b/packages/grid/src/features/table-ui/components/table/TableHeadItem.tsx
@@ -148,8 +148,6 @@ export const TableHeadItem: React.FC<TableHeadProps> = React.memo(
               trigger={"click"}
               zIndex={1000}
               disablePadding
-              variant={"outlined"}
-              arrow={false}
             >
               <FlatButton leftIcon={stenaDotsVertical} size={"small"} />
             </Popover>

--- a/packages/grid/src/features/table-ui/stories/TableUi.stories.tsx
+++ b/packages/grid/src/features/table-ui/stories/TableUi.stories.tsx
@@ -7,7 +7,7 @@ import { TableHeadRow } from "../components/table/TableHeadRow";
 import { TableHeadItem } from "../components/table/TableHeadItem";
 import { TableCell } from "../components/table/TableCell";
 import { cssColor } from "@stenajs-webui/theme";
-import { ActionMenuItem } from "@stenajs-webui/elements";
+import { ActionMenu, ActionMenuItem } from "@stenajs-webui/elements";
 
 export default {
   title: "grid/TableUi",
@@ -34,11 +34,11 @@ export const Overview = () => {
           selected={selectedNr === 1}
           arrow={(selectedNr === 1 && "down") || undefined}
           popoverContent={
-            <Column>
+            <ActionMenu>
               <ActionMenuItem label={"Rename"} />
               <ActionMenuItem label={"Ban"} />
               <ActionMenuItem label={"Delete"} />
-            </Column>
+            </ActionMenu>
           }
           infoIconTooltipText={"This is the username."}
         />

--- a/packages/tooltip/src/components/popover/Popover.module.css
+++ b/packages/tooltip/src/components/popover/Popover.module.css
@@ -2,8 +2,21 @@
   padding: 0;
 }
 
+:global(.tippy-box) {
+  position: relative;
+  background-color: #333;
+  color: #fff;
+  border-radius: 8px;
+  font-size: 14px;
+  line-height: 1.5;
+  outline: 0;
+  transition-property: transform, visibility, opacity;
+}
+
 :global(.tippy-box[data-theme~="light"]) {
   box-shadow: var(--swui-shadow-popover);
+  color: #26323d;
+  background-color: #fff;
 }
 
 :global(.tippy-box[data-theme~="outlined"]) {


### PR DESCRIPTION
In some case, Popover styling is not loaded properly from Tippy.module.css. 
I'm not sure why this happens :( 
Moved the styling to Popover.module.css which is loaded correctly.

## Before

<img width="292" alt="image" src="https://github.com/StenaIT/stenajs-webui/assets/1266041/037752b9-af05-4b16-bdfc-18ae9dbc408b">

## After

<img width="312" alt="image" src="https://github.com/StenaIT/stenajs-webui/assets/1266041/9785a568-4cfd-42e1-bdfd-59e24da47cf3">
