### PR TITLE
Fix invalid generic constraints in StandardTable

### DIFF
--- a/packages/calendar/src/types/CalendarTypes.tsx
+++ b/packages/calendar/src/types/CalendarTypes.tsx
@@ -8,14 +8,14 @@ import {
 import { MonthPickerValue } from "../features/month-picker/MonthPicker";
 import { Locale } from "date-fns";
 
-export interface CalendarDayProps<T = Record<string, never>>
+export interface CalendarDayProps<T = Record<string, unknown>>
   extends ExtraDayContentProps<T> {
   extraDayContent?: React.ComponentType<ExtraDayContentProps<T>>;
   onClickDay?: OnClickDay<T>;
   defaultHighlights?: Array<DayStateHighlight>;
 }
 
-export interface ExtraDayContentProps<T = Record<string, never>> {
+export interface ExtraDayContentProps<T = Record<string, unknown>> {
   month: MonthData;
   week: WeekData;
   day: DayData;

--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -42,7 +42,7 @@ import { StandardTableHeadRow } from "./StandardTableHeadRow";
 import { TableHeadProps } from "../../table-ui/components/table/TableHeadItem";
 
 export interface StandardTableProps<
-  TItem,
+  TItem extends Record<string, unknown>,
   TColumnKey extends string,
   TColumnGroupKey extends string
 > {
@@ -155,7 +155,7 @@ export type StandardTableVariant =
   | "compact";
 
 export const StandardTable = function StandardTable<
-  TItem extends Record<string, never>,
+  TItem extends Record<string, unknown>,
   TColumnKey extends string,
   TColumnGroupKey extends string
 >({

--- a/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableCell.tsx
@@ -22,7 +22,7 @@ import { StandardTableCellUi } from "./StandardTableCellUi";
 import { TextCell } from "./TextCell";
 import { DefaultStandardTableCellRenderer } from "../config/StandardTableColumnConfig";
 
-export interface StandardTableCellProps<TItem extends Record<string, never>> {
+export interface StandardTableCellProps<TItem extends Record<string, unknown>> {
   columnId: string;
   item: TItem;
   rowIndex: number;
@@ -38,7 +38,7 @@ const fallbackCellRenderer: DefaultStandardTableCellRenderer<unknown> = ({
 }) => <TextCell label={label} size={textSize} />;
 
 export const StandardTableCell = React.memo(function StandardTableCell<
-  TItem extends Record<string, never>
+  TItem extends Record<string, unknown>
 >({
   columnId,
   item,

--- a/packages/grid/src/features/standard-table/components/StandardTableContent.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableContent.tsx
@@ -7,7 +7,7 @@ import { StandardTableProps, StandardTableVariant } from "./StandardTable";
 import { StandardTableRowList } from "./StandardTableRowList";
 
 interface Props<
-  TItem extends object,
+  TItem extends Record<string, unknown>,
   TColumnKey extends string,
   TColumnGroupKey extends string
 > extends Omit<
@@ -18,7 +18,7 @@ interface Props<
 }
 
 export const StandardTableContent = React.memo(function StandardTableContent<
-  TItem extends Record<string, never>,
+  TItem extends Record<string, unknown>,
   TColumnKey extends string,
   TColumnGroupKey extends string
 >({

--- a/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRow.tsx
@@ -27,7 +27,7 @@ import { StandardTableCell } from "./StandardTableCell";
 import { StandardTableRowExpansion } from "./StandardTableRowExpansion";
 import { TrWithHoverBackground } from "./TrWithHoverBackground";
 
-export interface StandardTableRowProps<TItem extends Record<string, never>> {
+export interface StandardTableRowProps<TItem extends Record<string, unknown>> {
   item: TItem;
   idListForEnabledItems: Array<string>;
   rowIndex: number;
@@ -38,7 +38,7 @@ export interface StandardTableRowProps<TItem extends Record<string, never>> {
 }
 
 export const StandardTableRow = React.memo(function StandardTableRow<
-  TItem extends Record<string, never>
+  TItem extends Record<string, unknown>
 >({
   item,
   idListForEnabledItems,

--- a/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableRowList.tsx
@@ -14,7 +14,7 @@ import { StandardTableRow } from "./StandardTableRow";
 import { SummaryRowSwitcher } from "../features/summary-row/components/SummaryRowSwitcher";
 import { filterItemsOnEnabledCheckboxes } from "../util/FilterItemsOnEnabledCheckboxes";
 
-interface StandardTableContentProps<TItem extends Record<string, never>> {
+interface StandardTableContentProps<TItem extends Record<string, unknown>> {
   items?: Array<TItem>;
   colIndexOffset?: number;
   rowIndexOffset?: number;
@@ -22,7 +22,7 @@ interface StandardTableContentProps<TItem extends Record<string, never>> {
 }
 
 export const StandardTableRowList = React.memo(function StandardTableRowList<
-  TItem extends Record<string, never>
+  TItem extends Record<string, unknown>
 >({
   items,
   colIndexOffset = 0,

--- a/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
+++ b/packages/grid/src/features/standard-table/stories/StandardTableHorror.stories.tsx
@@ -23,7 +23,7 @@ export default {
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export interface SalesPerformanceTableRowItem {
+export interface SalesPerformanceTableRowItem extends Record<string, unknown> {
   info: any;
   pricingPath: any;
   automation?: any;


### PR DESCRIPTION
- Fix invalid type usage. Improperly declared "empty object" constraint in generics, which caused no objects to match the constraint.