### PR TITLE
Add size variants to travel calendar

### DIFF
--- a/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.stories.tsx
@@ -95,7 +95,7 @@ export const Sizes = () => {
   const [value, setValue] = useState<string>("");
 
   return (
-    <Column gap={4}>
+    <Column gap={4} indent={4}>
       {(["small", "medium", "large"] as const).map((size) => (
         <Column gap={2}>
           <Heading>{size}</Heading>

--- a/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.stories.tsx
@@ -2,7 +2,7 @@ import { StoryFn } from "@storybook/react";
 import * as React from "react";
 import { useState } from "react";
 import { TravelDateCalendar } from "./TravelDateCalendar";
-import { Column, Row, Spacing } from "@stenajs-webui/core";
+import { Column, Heading, Row, Spacing } from "@stenajs-webui/core";
 import { Banner, Label } from "@stenajs-webui/elements";
 import { parseLocalizedDateString } from "../../../features/localize-date-format/LocalizedDateParser";
 
@@ -87,6 +87,28 @@ const LocaleDemo = ({ localeCode }: { localeCode: string }) => {
           localeCode={localeCode}
         />
       </Row>
+    </Column>
+  );
+};
+
+export const Sizes = () => {
+  const [value, setValue] = useState<string>("");
+
+  return (
+    <Column gap={4}>
+      {(["small", "medium", "large"] as const).map((size) => (
+        <Column gap={2}>
+          <Heading>{size}</Heading>
+          <Row>
+            <TravelDateCalendar
+              value={value}
+              onValueChange={setValue}
+              localeCode={"sv"}
+              size={size}
+            />
+          </Row>
+        </Column>
+      ))}
     </Column>
   );
 };

--- a/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.tsx
@@ -3,7 +3,10 @@ import { Column, Heading, HeadingVariant } from "@stenajs-webui/core";
 import { ValueAndOnValueChangeProps } from "@stenajs-webui/forms";
 import { MonthPicker } from "../../../features/month-picker/MonthPicker";
 import { MonthHeader } from "../../../features/travel-calendar/components/MonthHeader";
-import { TravelCalendar } from "../../../features/travel-calendar/components/TravelCalendar";
+import {
+  TravelCalendar,
+  TravelCalendarSizeVariant,
+} from "../../../features/travel-calendar/components/TravelCalendar";
 import { useTravelDateInput } from "../../../features/travel-calendar/hooks/UseTravelDateInput";
 import { TravelDateSingleTextInputField } from "../../../features/travel-calendar/components/TravelDateSingleTextInputField";
 
@@ -18,6 +21,7 @@ export interface TravelDateCalendarProps
   headingLevel?: HeadingVariant;
   firstMonthInMonthPicker?: Date;
   numMonthsInMonthPicker?: number;
+  size?: TravelCalendarSizeVariant;
 }
 
 export const TravelDateCalendar: React.FC<TravelDateCalendarProps> = ({
@@ -32,6 +36,7 @@ export const TravelDateCalendar: React.FC<TravelDateCalendarProps> = ({
   headingLevel,
   numMonthsInMonthPicker = 12,
   firstMonthInMonthPicker = new Date(),
+  size = "medium",
 }) => {
   const inputProps = useTravelDateInput(
     value,
@@ -62,17 +67,20 @@ export const TravelDateCalendar: React.FC<TravelDateCalendarProps> = ({
         onValueChange={onValueChangeByInputs}
         localeCode={localeCode}
         label={label}
+        calendarSize={size}
       />
 
       <MonthHeader
         {...inputProps}
         previousMonthButtonAriaLabel={previousMonthButtonAriaLabel}
         nextMonthButtonAriaLabel={nextMonthButtonAriaLabel}
+        calendarSize={size}
       />
 
       {visiblePanel === "calendar" && (
         <TravelCalendar
           {...inputProps}
+          size={size}
           selectedStartDate={selectedDate}
           selectedEndDate={selectedDate}
           isValidDateRange={Boolean(selectedDate)}
@@ -84,6 +92,7 @@ export const TravelDateCalendar: React.FC<TravelDateCalendarProps> = ({
           firstMonth={firstMonthInMonthPicker}
           numMonths={numMonthsInMonthPicker}
           value={visibleMonth}
+          size={size}
           onValueChange={(v) => {
             setVisibleMonth(v);
             setVisiblePanel("calendar");

--- a/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.stories.tsx
@@ -104,7 +104,7 @@ export const Sizes = () => {
   );
 
   return (
-    <Column gap={4}>
+    <Column gap={4} indent={4}>
       {(["small", "medium", "large"] as const).map((size) => (
         <Column gap={2}>
           <Heading>{size}</Heading>

--- a/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.stories.tsx
@@ -2,7 +2,7 @@ import { StoryFn } from "@storybook/react";
 import * as React from "react";
 import { useState } from "react";
 import { TravelDateRangeCalendar } from "./TravelDateRangeCalendar";
-import { Column, Row, Spacing } from "@stenajs-webui/core";
+import { Column, Heading, Row, Spacing } from "@stenajs-webui/core";
 import { Banner, Label } from "@stenajs-webui/elements";
 import { TravelDateRangeInputValue } from "../../../features/travel-calendar/types";
 import { parseLocalizedDateString } from "../../../features/localize-date-format/LocalizedDateParser";
@@ -94,6 +94,30 @@ const LocaleDemo = ({ localeCode }: { localeCode: string }) => {
           localeCode={localeCode}
         />
       </Row>
+    </Column>
+  );
+};
+
+export const Sizes = () => {
+  const [value, setValue] = useState<TravelDateRangeInputValue | undefined>(
+    undefined
+  );
+
+  return (
+    <Column gap={4}>
+      {(["small", "medium", "large"] as const).map((size) => (
+        <Column gap={2}>
+          <Heading>{size}</Heading>
+          <Row>
+            <TravelDateRangeCalendar
+              value={value}
+              onValueChange={setValue}
+              localeCode={"sv"}
+              size={size}
+            />
+          </Row>
+        </Column>
+      ))}
     </Column>
   );
 };

--- a/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.tsx
@@ -5,7 +5,10 @@ import { TravelDateTextInputFields } from "../../../features/travel-calendar/com
 import { MonthPicker } from "../../../features/month-picker/MonthPicker";
 import { useTravelDateRangeInput } from "../../../features/travel-calendar/hooks/UseTravelDateRangeInput";
 import { MonthHeader } from "../../../features/travel-calendar/components/MonthHeader";
-import { TravelCalendar } from "../../../features/travel-calendar/components/TravelCalendar";
+import {
+  TravelCalendar,
+  TravelCalendarSizeVariant,
+} from "../../../features/travel-calendar/components/TravelCalendar";
 import { TravelDateRangeInputValue } from "../../../features/travel-calendar/types";
 
 export interface TravelDateRangeCalendarProps
@@ -20,6 +23,7 @@ export interface TravelDateRangeCalendarProps
   headingLevel?: HeadingVariant;
   firstMonthInMonthPicker?: Date;
   numMonthsInMonthPicker?: number;
+  size?: TravelCalendarSizeVariant;
 }
 
 export const TravelDateRangeCalendar: React.FC<
@@ -37,6 +41,7 @@ export const TravelDateRangeCalendar: React.FC<
   headingLevel,
   numMonthsInMonthPicker = 12,
   firstMonthInMonthPicker = new Date(),
+  size = "medium",
 }) => {
   const inputProps = useTravelDateRangeInput(
     value,
@@ -67,21 +72,26 @@ export const TravelDateRangeCalendar: React.FC<
         localeCode={localeCode}
         startDateLabel={startDateLabel}
         endDateLabel={endDateLabel}
+        calendarSize={size}
       />
 
       <MonthHeader
         {...inputProps}
         previousMonthButtonAriaLabel={previousMonthButtonAriaLabel}
         nextMonthButtonAriaLabel={nextMonthButtonAriaLabel}
+        calendarSize={size}
       />
 
-      {visiblePanel === "calendar" && <TravelCalendar {...inputProps} />}
+      {visiblePanel === "calendar" && (
+        <TravelCalendar {...inputProps} size={size} />
+      )}
 
       {visiblePanel === "month-picker" && (
         <MonthPicker
           firstMonth={firstMonthInMonthPicker}
           numMonths={numMonthsInMonthPicker}
           value={visibleMonth}
+          size={size}
           onValueChange={(v) => {
             setVisibleMonth(v);
             setVisiblePanel("calendar");

--- a/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.stories.tsx
@@ -2,7 +2,7 @@ import { StoryFn } from "@storybook/react";
 import * as React from "react";
 import { useState } from "react";
 import { TravelDateInput } from "./TravelDateInput";
-import { Column, Row, Spacing } from "@stenajs-webui/core";
+import { Column, Heading, Row, Spacing } from "@stenajs-webui/core";
 import {
   Banner,
   Label,
@@ -51,6 +51,28 @@ export const WithHeading = () => {
         heading={"Select date"}
       />
     </div>
+  );
+};
+
+export const Sizes = () => {
+  const [value, setValue] = useState<string>("");
+
+  return (
+    <Column gap={4}>
+      {(["small", "medium", "large"] as const).map((size) => (
+        <Column gap={2}>
+          <Heading>{size}</Heading>
+          <Row>
+            <TravelDateInput
+              value={value}
+              onValueChange={setValue}
+              localeCode={"sv"}
+              size={size}
+            />
+          </Row>
+        </Column>
+      ))}
+    </Column>
   );
 };
 

--- a/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.stories.tsx
@@ -58,7 +58,7 @@ export const Sizes = () => {
   const [value, setValue] = useState<string>("");
 
   return (
-    <Column gap={4}>
+    <Column gap={4} indent={4}>
       {(["small", "medium", "large"] as const).map((size) => (
         <Column gap={2}>
           <Heading>{size}</Heading>

--- a/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.tsx
@@ -17,7 +17,10 @@ import { ValueAndOnValueChangeProps } from "@stenajs-webui/forms";
 import { CardBody } from "@stenajs-webui/elements";
 import { MonthPicker } from "../../../features/month-picker/MonthPicker";
 import { MonthHeader } from "../../../features/travel-calendar/components/MonthHeader";
-import { TravelCalendar } from "../../../features/travel-calendar/components/TravelCalendar";
+import {
+  TravelCalendar,
+  TravelCalendarSizeVariant,
+} from "../../../features/travel-calendar/components/TravelCalendar";
 import styles from "./TravelDateInput.module.css";
 import cx from "classnames";
 import { TravelDateSingleTextInputField } from "../../../features/travel-calendar/components/TravelDateSingleTextInputField";
@@ -42,6 +45,7 @@ export interface TravelDateInputProps
   zIndexWhenClosed?: number;
   onHideCalendar?: () => void;
   renderBelowCalendar?: (args: RenderBelowSingleDateCalendarArgs) => ReactNode;
+  size?: TravelCalendarSizeVariant;
 }
 
 export const TravelDateInput: React.FC<TravelDateInputProps> = ({
@@ -60,10 +64,11 @@ export const TravelDateInput: React.FC<TravelDateInputProps> = ({
   zIndexWhenClosed,
   onHideCalendar,
   renderBelowCalendar,
+  size = "medium",
 }) => {
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [calendarInDom, setCalendarInDom] = useState(false);
-  const [size, setSize] = useState<{ height: number; width: number }>({
+  const [boxSize, setBoxSize] = useState<{ height: number; width: number }>({
     // Sane defaults, this will be updated with actual data from DOM.
     width: 336,
     height: 66,
@@ -104,11 +109,11 @@ export const TravelDateInput: React.FC<TravelDateInputProps> = ({
     const width = sizeSourceRef.current?.offsetWidth;
     const height = sizeSourceRef.current?.offsetHeight;
     if (width != null && height != null) {
-      if (size.height !== height || size.width !== width) {
-        setSize({ width, height });
+      if (boxSize.height !== height || boxSize.width !== width) {
+        setBoxSize({ width, height });
       }
     }
-  }, [size.height, size.width]);
+  }, [boxSize.height, boxSize.width]);
 
   const inputProps = useTravelDateInput(
     value,
@@ -142,8 +147,8 @@ export const TravelDateInput: React.FC<TravelDateInputProps> = ({
       className={styles.travelDateInput}
       ref={ref}
       onKeyDown={onKeyDown}
-      height={size.height}
-      width={size.width}
+      height={boxSize.height}
+      width={boxSize.width}
     >
       <Box
         position={"absolute"}
@@ -156,6 +161,7 @@ export const TravelDateInput: React.FC<TravelDateInputProps> = ({
           localeCode={localeCode}
           label={label}
           onFocus={showCalendar}
+          calendarSize={size}
         />
       </Box>
 
@@ -183,11 +189,13 @@ export const TravelDateInput: React.FC<TravelDateInputProps> = ({
                 {...inputProps}
                 previousMonthButtonAriaLabel={previousMonthButtonAriaLabel}
                 nextMonthButtonAriaLabel={nextMonthButtonAriaLabel}
+                calendarSize={size}
               />
 
               {visiblePanel === "calendar" && (
                 <TravelCalendar
                   {...inputProps}
+                  size={size}
                   isValidDateRange={Boolean(selectedDate)}
                   selectedStartDate={selectedDate}
                   selectedEndDate={selectedDate}
@@ -199,6 +207,7 @@ export const TravelDateInput: React.FC<TravelDateInputProps> = ({
                   firstMonth={firstMonthInMonthPicker}
                   numMonths={numMonthsInMonthPicker}
                   value={visibleMonth}
+                  size={size}
                   onValueChange={(v) => {
                     setVisibleMonth(v);
                     setVisiblePanel("calendar");

--- a/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.stories.tsx
@@ -2,7 +2,7 @@ import { StoryFn } from "@storybook/react";
 import * as React from "react";
 import { useState } from "react";
 import { TravelDateRangeInput } from "./TravelDateRangeInput";
-import { Column, Row, Spacing } from "@stenajs-webui/core";
+import { Column, Heading, Row, Spacing } from "@stenajs-webui/core";
 import {
   Banner,
   Label,
@@ -56,6 +56,30 @@ export const WithHeading = () => {
         heading={"Select dates"}
       />
     </div>
+  );
+};
+
+export const Sizes = () => {
+  const [value, setValue] = useState<TravelDateRangeInputValue | undefined>(
+    undefined
+  );
+
+  return (
+    <Column gap={4}>
+      {(["small", "medium", "large"] as const).map((size) => (
+        <Column gap={2}>
+          <Heading>{size}</Heading>
+          <Row>
+            <TravelDateRangeInput
+              value={value}
+              onValueChange={setValue}
+              localeCode={"sv"}
+              size={size}
+            />
+          </Row>
+        </Column>
+      ))}
+    </Column>
   );
 };
 

--- a/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.stories.tsx
@@ -65,7 +65,7 @@ export const Sizes = () => {
   );
 
   return (
-    <Column gap={4}>
+    <Column gap={4} indent={4}>
       {(["small", "medium", "large"] as const).map((size) => (
         <Column gap={2}>
           <Heading>{size}</Heading>

--- a/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.tsx
@@ -19,7 +19,10 @@ import { CardBody } from "@stenajs-webui/elements";
 import { MonthPicker } from "../../../features/month-picker/MonthPicker";
 import { useTravelDateRangeInput } from "../../../features/travel-calendar/hooks/UseTravelDateRangeInput";
 import { MonthHeader } from "../../../features/travel-calendar/components/MonthHeader";
-import { TravelCalendar } from "../../../features/travel-calendar/components/TravelCalendar";
+import {
+  TravelCalendar,
+  TravelCalendarSizeVariant,
+} from "../../../features/travel-calendar/components/TravelCalendar";
 import { TravelDateRangeInputValue } from "../../../features/travel-calendar/types";
 import styles from "./TravelDateRangeInput.module.css";
 import cx from "classnames";
@@ -44,6 +47,7 @@ export interface TravelDateRangeInputProps
   zIndexWhenClosed?: number;
   onHideCalendar?: () => void;
   renderBelowCalendar?: (args: RenderBelowCalendarArgs) => ReactNode;
+  size?: TravelCalendarSizeVariant;
 }
 
 export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
@@ -63,10 +67,11 @@ export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
   zIndexWhenClosed,
   onHideCalendar,
   renderBelowCalendar,
+  size = "medium",
 }) => {
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [calendarInDom, setCalendarInDom] = useState(false);
-  const [size, setSize] = useState<{ height: number; width: number }>({
+  const [boxSize, setBoxSize] = useState<{ height: number; width: number }>({
     // Sane defaults, this will be updated with actual data from DOM.
     width: 336,
     height: 66,
@@ -107,11 +112,11 @@ export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
     const width = sizeSourceRef.current?.offsetWidth;
     const height = sizeSourceRef.current?.offsetHeight;
     if (width != null && height != null) {
-      if (size.height !== height || size.width !== width) {
-        setSize({ width, height });
+      if (boxSize.height !== height || boxSize.width !== width) {
+        setBoxSize({ width, height });
       }
     }
-  }, [size.height, size.width]);
+  }, [boxSize.height, boxSize.width]);
 
   const inputProps = useTravelDateRangeInput(
     value,
@@ -144,8 +149,8 @@ export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
       className={styles.travelDateRangeInput}
       ref={ref}
       onKeyDown={onKeyDown}
-      height={size.height}
-      width={size.width}
+      height={boxSize.height}
+      width={boxSize.width}
     >
       <Box
         position={"absolute"}
@@ -159,6 +164,7 @@ export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
           startDateLabel={startDateLabel}
           endDateLabel={endDateLabel}
           onFocus={showCalendar}
+          calendarSize={size}
         />
       </Box>
 
@@ -186,10 +192,11 @@ export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
                 {...inputProps}
                 previousMonthButtonAriaLabel={previousMonthButtonAriaLabel}
                 nextMonthButtonAriaLabel={nextMonthButtonAriaLabel}
+                calendarSize={size}
               />
 
               {visiblePanel === "calendar" && (
-                <TravelCalendar {...inputProps} />
+                <TravelCalendar {...inputProps} size={size} />
               )}
 
               {visiblePanel === "month-picker" && (
@@ -197,6 +204,7 @@ export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
                   firstMonth={firstMonthInMonthPicker}
                   numMonths={numMonthsInMonthPicker}
                   value={visibleMonth}
+                  size={size}
                   onValueChange={(v) => {
                     setVisibleMonth(v);
                     setVisiblePanel("calendar");

--- a/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.tsx
@@ -77,6 +77,8 @@ export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
     height: 66,
   });
 
+  const inputFieldsHeight = size === "large" ? "8.8rem" : "6.6rem";
+
   const calendarOpenRef = useRef(false);
 
   const showCalendar = useCallback(() => {
@@ -187,7 +189,9 @@ export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
                   {heading}
                 </Heading>
               )}
-              <Box height={"6.8rem"} />
+
+              <Box height={inputFieldsHeight} />
+
               <MonthHeader
                 {...inputProps}
                 previousMonthButtonAriaLabel={previousMonthButtonAriaLabel}

--- a/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
+++ b/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
@@ -15,6 +15,7 @@ import {
   getDomIdForMonth,
 } from "./MonthPickerKeyboardNavigation";
 import { Position } from "./Position";
+import { MonthPickerSizeVariant } from "./MonthPicker";
 
 interface MonthPickerCellProps {
   month: Date;
@@ -26,6 +27,7 @@ interface MonthPickerCellProps {
   firstAvailableMonth: Date;
   lastAvailableMonth: Date;
   position: Position;
+  size: MonthPickerSizeVariant;
 }
 
 export const MonthPickerCell: React.FC<MonthPickerCellProps> = ({
@@ -36,6 +38,7 @@ export const MonthPickerCell: React.FC<MonthPickerCellProps> = ({
   autoFocus,
   monthPickerId,
   position,
+  size,
 }) => {
   const label = useMemo(
     () => startCase(format(month, "MMM", { locale })),
@@ -50,6 +53,7 @@ export const MonthPickerCell: React.FC<MonthPickerCellProps> = ({
   const ref = useRef<HTMLButtonElement>(null);
 
   const domId = getDomIdForMonth(position, monthPickerId);
+  const tabIndex = selected ? 0 : -1;
 
   useEffect(() => {
     ref.current?.focus();
@@ -81,6 +85,8 @@ export const MonthPickerCell: React.FC<MonthPickerCellProps> = ({
           aria-selected={true}
           autoFocus={autoFocus}
           ref={ref}
+          size={size === "large" ? "large" : "medium"}
+          tabIndex={tabIndex}
         />
       ) : (
         <FlatButton
@@ -88,6 +94,8 @@ export const MonthPickerCell: React.FC<MonthPickerCellProps> = ({
           label={label}
           aria-label={abbr}
           onClick={onClick}
+          size={size === "large" ? "large" : "medium"}
+          tabIndex={tabIndex}
         />
       )}
     </Row>

--- a/packages/calendar/src/features/travel-calendar/components/MonthHeader.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/MonthHeader.tsx
@@ -11,6 +11,7 @@ import {
 import { Row } from "@stenajs-webui/core";
 import { addMonths, subMonths } from "date-fns";
 import { VisiblePanel } from "../types";
+import { TravelCalendarSizeVariant } from "./TravelCalendar";
 
 export interface MonthHeaderProps {
   monthPickerButtonLabel: string;
@@ -22,6 +23,7 @@ export interface MonthHeaderProps {
   visibleMonth: Date;
   setVisibleMonth: (date: Date) => void;
   prevMonthDisabled: boolean;
+  calendarSize: TravelCalendarSizeVariant;
 }
 
 export const MonthHeader: React.FC<MonthHeaderProps> = ({
@@ -34,6 +36,7 @@ export const MonthHeader: React.FC<MonthHeaderProps> = ({
   setVisibleMonth,
   visibleMonth,
   prevMonthDisabled,
+  calendarSize,
 }) => {
   return (
     <Row alignSelf={"center"} justifyContent={"space-between"} width={"100%"}>
@@ -47,6 +50,7 @@ export const MonthHeader: React.FC<MonthHeaderProps> = ({
           )
         }
         ref={monthPickerButtonRef}
+        size={calendarSize === "large" ? "large" : "medium"}
       />
       <Row alignItems={"center"} gap={2}>
         <SecondaryButton
@@ -54,11 +58,13 @@ export const MonthHeader: React.FC<MonthHeaderProps> = ({
           onClick={() => setVisibleMonth(subMonths(visibleMonth, 1))}
           disabled={prevMonthDisabled}
           aria-label={previousMonthButtonAriaLabel}
+          size={calendarSize === "large" ? "large" : "medium"}
         />
         <SecondaryButton
           leftIcon={stenaArrowRight}
           onClick={() => setVisibleMonth(addMonths(visibleMonth, 1))}
           aria-label={nextMonthButtonAriaLabel}
+          size={calendarSize === "large" ? "large" : "medium"}
         />
       </Row>
     </Row>

--- a/packages/calendar/src/features/travel-calendar/components/TravelCalendar.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/TravelCalendar.tsx
@@ -10,6 +10,8 @@ import { isSameDay } from "date-fns";
 import { Dispatch, SetStateAction } from "react";
 import styles from "./TravelCalendar.module.css";
 
+export type TravelCalendarSizeVariant = "small" | "medium" | "large";
+
 export interface TravelCalendarProps {
   visibleMonthData: MonthData;
   onClickDate: (date: Date) => void;
@@ -24,6 +26,7 @@ export interface TravelCalendarProps {
   isDateDisabled: (date: Date) => boolean;
   calendarId: string;
   todayIsInVisibleMonth: boolean;
+  size?: TravelCalendarSizeVariant;
 }
 
 export const TravelCalendar: React.FC<TravelCalendarProps> = ({
@@ -40,6 +43,7 @@ export const TravelCalendar: React.FC<TravelCalendarProps> = ({
   calendarId,
   isDateDisabled,
   todayIsInVisibleMonth,
+  size = "medium",
 }) => {
   return (
     <table className={styles.travelCalendar}>
@@ -56,6 +60,7 @@ export const TravelCalendar: React.FC<TravelCalendarProps> = ({
             <tr key={week.weekNumber}>
               {week.days.map((day) => (
                 <TravelDateCell
+                  size={size}
                   onClick={(d) => onClickDate(d)}
                   key={day.dateString}
                   visibleMonth={visibleMonth}

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateCell.module.css
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateCell.module.css
@@ -1,7 +1,20 @@
 .travelDateCell {
   position: relative;
-  width: 48px;
-  height: 48px;
+
+  &.small {
+    width: 40px;
+    height: 40px;
+  }
+
+  &.medium {
+    width: 48px;
+    height: 48px;
+  }
+
+  &.large {
+    width: 64px;
+    height: 64px;
+  }
 
   border-radius: var(--swui-max-border-radius);
 

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateCell.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateCell.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { KeyboardEventHandler, useCallback } from "react";
-import { Box, Row, Text } from "@stenajs-webui/core";
+import { Text } from "@stenajs-webui/core";
 import { DayData } from "../../../util/calendar/CalendarDataFactory";
 import styles from "./TravelDateCell.module.css";
 import cx from "classnames";
@@ -9,6 +9,8 @@ import { getCellBackgroundColors } from "../util/CellBgColors";
 import { getDateToFocusOn } from "../util/KeyboardNavigation";
 import { createDayId } from "../util/DayIdGenerator";
 import { cssColor } from "@stenajs-webui/theme";
+import { TravelCalendarSizeVariant } from "./TravelCalendar";
+import { TravelDateCellBackground } from "./TravelDateCellBackground";
 
 export interface TravelDateCellProps {
   onClick: (date: Date) => void;
@@ -25,6 +27,7 @@ export interface TravelDateCellProps {
   todayIsInVisibleMonth: boolean;
   calendarId: string;
   isDateDisabled: (date: Date) => boolean;
+  size: TravelCalendarSizeVariant;
 }
 
 export const TravelDateCell: React.FC<TravelDateCellProps> = ({
@@ -42,6 +45,7 @@ export const TravelDateCell: React.FC<TravelDateCellProps> = ({
   todayIsInVisibleMonth,
   calendarId,
   isDateDisabled,
+  size,
 }) => {
   const onKeyDown = useCallback<KeyboardEventHandler<HTMLTableDataCellElement>>(
     async (e) => {
@@ -97,7 +101,7 @@ export const TravelDateCell: React.FC<TravelDateCellProps> = ({
 
   return (
     <td
-      className={styles.travelDateCell}
+      className={cx(styles.travelDateCell, styles[size])}
       onClick={disabled ? undefined : () => onClick(day.date)}
       onMouseOver={
         disabled ? undefined : () => dayIsInMonth && onStartHover(day.date)
@@ -122,10 +126,11 @@ export const TravelDateCell: React.FC<TravelDateCellProps> = ({
     >
       <div className={styles.outline} />
 
-      <Row>
-        <Box height={"48px"} width={"24px"} background={bgColors.left}></Box>
-        <Box height={"48px"} width={"24px"} background={bgColors.right}></Box>
-      </Row>
+      <TravelDateCellBackground
+        calendarSize={size}
+        bgColorLeft={bgColors.left}
+        bgColorRight={bgColors.right}
+      />
 
       {dayIsInMonth && (
         <div

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateCellBackground.module.css
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateCellBackground.module.css
@@ -1,0 +1,16 @@
+.travelDateCellBackground {
+  &.small {
+    width: 20px;
+    height: 40px;
+  }
+
+  &.medium {
+    width: 24px;
+    height: 48px;
+  }
+
+  &.large {
+    width: 32px;
+    height: 64px;
+  }
+}

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateCellBackground.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateCellBackground.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { Box, Row } from "@stenajs-webui/core";
+import { TravelCalendarSizeVariant } from "./TravelCalendar";
+import styles from "./TravelDateCellBackground.module.css";
+import cx from "classnames";
+
+export interface TravelDateCellBackgroundProps {
+  calendarSize: TravelCalendarSizeVariant;
+  bgColorLeft: string;
+  bgColorRight: string;
+}
+
+export const TravelDateCellBackground: React.FC<
+  TravelDateCellBackgroundProps
+> = ({ calendarSize, bgColorLeft, bgColorRight }) => {
+  return (
+    <Row>
+      <Box
+        className={cx(styles.travelDateCellBackground, styles[calendarSize])}
+        background={bgColorLeft}
+      />
+      <Box
+        className={cx(styles.travelDateCellBackground, styles[calendarSize])}
+        background={bgColorRight}
+      />
+    </Row>
+  );
+};

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateSingleTextInputField.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateSingleTextInputField.tsx
@@ -5,6 +5,7 @@ import { TravelDateTextInput } from "./TravelDateTextInput";
 import { createInputMaskForDateFormat } from "../../localize-date-format/InputMaskProvider";
 import { getDateFormatForLocaleCode } from "../../localize-date-format/DateFormatProvider";
 import { reformatLocalizedDateString } from "../../localize-date-format/LocalizedDateReformatter";
+import { TravelCalendarSizeVariant } from "./TravelCalendar";
 
 export interface TravelDateSingleTextInputFieldProps {
   value: string | undefined;
@@ -12,11 +13,19 @@ export interface TravelDateSingleTextInputFieldProps {
   localeCode: string;
   label?: string;
   onFocus?: () => void;
+  calendarSize: TravelCalendarSizeVariant;
 }
 
 export const TravelDateSingleTextInputField: React.FC<
   TravelDateSingleTextInputFieldProps
-> = ({ value, onValueChange, label = "Date", localeCode, onFocus }) => {
+> = ({
+  value,
+  onValueChange,
+  label = "Date",
+  localeCode,
+  onFocus,
+  calendarSize,
+}) => {
   const { mask, placeholder } = useMemo(() => {
     const dateFormatForLocaleCode = getDateFormatForLocaleCode(localeCode);
     return {
@@ -40,6 +49,7 @@ export const TravelDateSingleTextInputField: React.FC<
         onFocus={onFocus}
         label={label}
         placeholder={placeholder}
+        calendarSize={calendarSize}
       />
     </Row>
   );

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateTextInput.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateTextInput.tsx
@@ -10,6 +10,8 @@ import {
   InputMaskProvider,
   useMaskedInput,
 } from "@stenajs-webui/input-mask";
+import { TravelCalendarSizeVariant } from "./TravelCalendar";
+import { exhaustSwitchCase } from "@stenajs-webui/core";
 
 export interface TravelDateTextInputProps extends LabelledTextInputProps {
   mask: InputMask | InputMaskProvider;
@@ -18,6 +20,7 @@ export interface TravelDateTextInputProps extends LabelledTextInputProps {
   keepCharPositions?: boolean;
   placeholderChar?: string;
   showMask?: boolean;
+  calendarSize: TravelCalendarSizeVariant;
 }
 
 export const TravelDateTextInput: React.FC<TravelDateTextInputProps> = ({
@@ -30,6 +33,7 @@ export const TravelDateTextInput: React.FC<TravelDateTextInputProps> = ({
   keepCharPositions,
   placeholderChar,
   showMask,
+  calendarSize,
   ...inputProps
 }) => {
   const inputRef = useRef(null);
@@ -51,7 +55,22 @@ export const TravelDateTextInput: React.FC<TravelDateTextInputProps> = ({
       {...inputProps}
       ref={inputRef}
       onChange={maskedOnChange}
-      width={"168px"}
+      width={getWidth(calendarSize)}
+      size={calendarSize === "large" ? "large" : "medium"}
     />
   );
+};
+
+const getWidth = (calenderSize: TravelCalendarSizeVariant) => {
+  // For cell size = 48px, (48*7)/2 = 168px
+  switch (calenderSize) {
+    case "small":
+      return "140px";
+    case "medium":
+      return "168px";
+    case "large":
+      return "224px";
+    default:
+      return exhaustSwitchCase(calenderSize, "168px");
+  }
 };

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateTextInputFields.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateTextInputFields.tsx
@@ -6,6 +6,7 @@ import { createInputMaskForDateFormat } from "../../localize-date-format/InputMa
 import { getDateFormatForLocaleCode } from "../../localize-date-format/DateFormatProvider";
 import { reformatLocalizedDateString } from "../../localize-date-format/LocalizedDateReformatter";
 import { TravelDateRangeInputValue } from "../types";
+import { TravelCalendarSizeVariant } from "./TravelCalendar";
 
 export interface TravelDateTextInputFieldsProps {
   value: TravelDateRangeInputValue | undefined;
@@ -16,6 +17,7 @@ export interface TravelDateTextInputFieldsProps {
   startDateLabel?: string;
   endDateLabel?: string;
   onFocus?: () => void;
+  calendarSize: TravelCalendarSizeVariant;
 }
 
 export const TravelDateTextInputFields: React.FC<
@@ -27,6 +29,7 @@ export const TravelDateTextInputFields: React.FC<
   startDateLabel = "From",
   endDateLabel = "To",
   onFocus,
+  calendarSize,
 }) => {
   const { mask, placeholder } = useMemo(() => {
     const dateFormatForLocaleCode = getDateFormatForLocaleCode(localeCode);
@@ -57,6 +60,7 @@ export const TravelDateTextInputFields: React.FC<
         label={startDateLabel}
         borderRadiusVariant={"onlyLeft"}
         placeholder={placeholder}
+        calendarSize={calendarSize}
       />
       <TravelDateTextInput
         mask={mask}
@@ -75,6 +79,7 @@ export const TravelDateTextInputFields: React.FC<
         label={endDateLabel}
         borderRadiusVariant={"onlyRight"}
         placeholder={placeholder}
+        calendarSize={calendarSize}
       />
     </Row>
   );


### PR DESCRIPTION
- Travel calendar now has three size variants; small, medium and large.
- Refactor month picker to be a table, and set correct tab index.