### PR TITLE
Add ability to have custom row in top and/or bottom of StandardTable

### DIFF
--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -146,6 +146,22 @@ export interface StandardTableProps<
    * This is triggered when user clicks on the table headers, even if using external sorting.
    */
   onSortOrderChange?: StandardTableOnSortOrderChange<TColumnKey>;
+
+  /**
+   * If set, this will always show below <th> and above first <tr>.
+   * This row is 100% custom, and inherits no design or functionality from StandardTable.
+   * You must make sure that extraHeaderRow root is a <tr> and contains <td> elements.
+   * You must also make sure that it has correct number of cells, with correct padding, etc.
+   */
+  renderExtraRowTop?: () => ReactNode;
+
+  /**
+   * If set, this will always show below last <tr>.
+   * This row is 100% custom, and inherits no design or functionality from StandardTable.
+   * You must make sure that extraHeaderRow root is a <tr> and contains <td> elements.
+   * You must also make sure that it has correct number of cells, with correct padding, etc.
+   */
+  renderExtraRowBottom?: () => ReactNode;
 }
 
 export type StandardTableVariant =

--- a/packages/grid/src/features/standard-table/components/StandardTableContent.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTableContent.tsx
@@ -34,6 +34,8 @@ export const StandardTableContent = React.memo(function StandardTableContent<
   rowIndexOffset,
   variant,
   errorLabel,
+  renderExtraRowTop,
+  renderExtraRowBottom,
 }: Props<TItem, TColumnKey, TColumnGroupKey>) {
   const totalNumColumns = useTotalNumColumns();
 
@@ -111,12 +113,14 @@ export const StandardTableContent = React.memo(function StandardTableContent<
 
   return (
     <tbody>
+      {renderExtraRowTop?.()}
       <StandardTableRowList
         variant={variant}
         items={items}
         colIndexOffset={colIndexOffset}
         rowIndexOffset={rowIndexOffset}
       />
+      {renderExtraRowBottom?.()}
     </tbody>
   );
 });


### PR DESCRIPTION
Add ability to have custom row in top and/or bottom of StandardTable. This contains no functionality or design, it is simply just an opening for the teams that need custom rows that don't fit into StandardTable, without adding more complexity into StandardTable.