### PR TITLE
Some sizes updates to travel calendar.

### DIFF
--- a/packages/calendar/src/features/travel-calendar/components/MonthHeader.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/MonthHeader.tsx
@@ -50,7 +50,7 @@ export const MonthHeader: React.FC<MonthHeaderProps> = ({
           )
         }
         ref={monthPickerButtonRef}
-        size={calendarSize === "large" ? "large" : "medium"}
+        size={calendarSize === "small" ? "medium" : "large"}
       />
       <Row alignItems={"center"} gap={2}>
         <SecondaryButton
@@ -58,13 +58,13 @@ export const MonthHeader: React.FC<MonthHeaderProps> = ({
           onClick={() => setVisibleMonth(subMonths(visibleMonth, 1))}
           disabled={prevMonthDisabled}
           aria-label={previousMonthButtonAriaLabel}
-          size={calendarSize === "large" ? "large" : "medium"}
+          size={calendarSize === "small" ? "medium" : "large"}
         />
         <SecondaryButton
           leftIcon={stenaArrowRight}
           onClick={() => setVisibleMonth(addMonths(visibleMonth, 1))}
           aria-label={nextMonthButtonAriaLabel}
-          size={calendarSize === "large" ? "large" : "medium"}
+          size={calendarSize === "small" ? "medium" : "large"}
         />
       </Row>
     </Row>

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateCell.module.css
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateCell.module.css
@@ -12,8 +12,8 @@
   }
 
   &.large {
-    width: 64px;
-    height: 64px;
+    width: 56px;
+    height: 28px;
   }
 
   border-radius: var(--swui-max-border-radius);

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateCellBackground.module.css
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateCellBackground.module.css
@@ -10,7 +10,7 @@
   }
 
   &.large {
-    width: 32px;
-    height: 64px;
+    width: 28px;
+    height: 56px;
   }
 }


### PR DESCRIPTION
- Size large is now 56x56px.
- For size medium, buttons and dates are now 48px, instead of 40px.