### PR TITLE
Add large heading size variant to ModalHeading

### DIFF
--- a/packages/modal/src/building-blocks/ModalHeader.tsx
+++ b/packages/modal/src/building-blocks/ModalHeader.tsx
@@ -1,20 +1,28 @@
 import * as React from "react";
-import { Row } from "@stenajs-webui/core";
-import { ModalHeading } from "./ModalHeading";
+import { HeadingVariant, Row } from "@stenajs-webui/core";
+import { ModalHeading, ModalHeadingSizeVariant } from "./ModalHeading";
 import { CloseButton } from "@stenajs-webui/elements";
 
 export interface ModalHeaderProps {
   heading?: string;
+  headingSize?: ModalHeadingSizeVariant;
+  headingLevel?: HeadingVariant;
   onClickClose?: () => void;
 }
 
 export const ModalHeader: React.FC<ModalHeaderProps> = ({
   heading,
+  headingLevel,
+  headingSize,
   onClickClose,
 }) => {
   return (
     <Row justifyContent={"space-between"}>
-      {heading && <ModalHeading>{heading}</ModalHeading>}
+      {heading && (
+        <ModalHeading headingLevel={headingLevel} size={headingSize}>
+          {heading}
+        </ModalHeading>
+      )}
       <CloseButton onClick={onClickClose} />
     </Row>
   );

--- a/packages/modal/src/building-blocks/ModalHeading.tsx
+++ b/packages/modal/src/building-blocks/ModalHeading.tsx
@@ -1,13 +1,21 @@
 import * as React from "react";
-import { Heading } from "@stenajs-webui/core";
+import { Heading, HeadingVariant } from "@stenajs-webui/core";
+
+export type ModalHeadingSizeVariant = "medium" | "large";
 
 export interface ModalHeadingProps {
+  size?: ModalHeadingSizeVariant;
   children: string;
+  headingLevel?: HeadingVariant;
 }
 
-export const ModalHeading: React.FC<ModalHeadingProps> = ({ children }) => {
+export const ModalHeading: React.FC<ModalHeadingProps> = ({
+  headingLevel = "h2",
+  size = "medium",
+  children,
+}) => {
   return (
-    <Heading variant={"h3"} as={"h2"}>
+    <Heading variant={size === "medium" ? "h3" : "h1"} as={headingLevel}>
       {children}
     </Heading>
   );


### PR DESCRIPTION
- ModalHeader can specify what heading size to pass down to ModalHeading.
- Same with heading level (what DOM element to use, h1, h2, etc).