### PR TITLE
 Click outside to close modal now only reacts to onMouseDown.

### DIFF
--- a/packages/modal/src/dialog/UseDialog.tsx
+++ b/packages/modal/src/dialog/UseDialog.tsx
@@ -115,7 +115,7 @@ export function useDialog<TProps, TPromiseResolve = void>(
     () => (
       <DialogContext.Provider value={{ resolve, reject }}>
         <dialog
-          onClick={
+          onMouseDown={
             options.disableCloseOnClickOutside ? undefined : () => reject()
           }
           ref={currentRef}
@@ -132,7 +132,7 @@ export function useDialog<TProps, TPromiseResolve = void>(
             <div
               style={options.contentWrapperStyle}
               className={options.contentWrapperClassName}
-              onClick={
+              onMouseDown={
                 options.disableCloseOnClickOutside
                   ? undefined
                   : (ev) => ev.stopPropagation()


### PR DESCRIPTION
# Use case

User presses mouse button inside modal, then moves pointer outside of modal and releases the mouse button. The click is registered as outside the modal and closes it. Not very nice!

Now it uses onMouseDown instead of onClick, which requires the mouse down event to come from outside of modal.