### PR TITLE
Add renderExtraHeadRows prop to StandardTable, allows one or severa…

### DIFF
--- a/packages/grid/src/features/standard-table/components/StandardTable.tsx
+++ b/packages/grid/src/features/standard-table/components/StandardTable.tsx
@@ -141,17 +141,25 @@ export interface StandardTableProps<
   onSortOrderChange?: StandardTableOnSortOrderChange<TColumnKey>;
 
   /**
-   * If set, this will always show below <th> and above first <tr>.
-   * This row is 100% custom, and inherits no design or functionality from StandardTable.
-   * You must make sure that extraHeaderRow root is a <tr> and contains <td> elements.
+   * If set, this will always show inside <thead>, below last <th>.
+   * This row is 100% custom, shown as is, and inherits no design or functionality from StandardTable.
+   * You must make sure that renderExtraHeadRows root is one or several <th> elements.
+   * You must also make sure that it has correct number of cells, with correct padding, etc.
+   */
+  renderExtraHeadRows?: () => ReactNode;
+
+  /**
+   * If set, this will always show inside <tbody>, above first <tr>.
+   * This row is 100% custom, shown as is, and inherits no design or functionality from StandardTable.
+   * You must make sure that extraHeaderRow root is a <tr>.
    * You must also make sure that it has correct number of cells, with correct padding, etc.
    */
   renderExtraRowTop?: () => ReactNode;
 
   /**
    * If set, this will always show below last <tr>.
-   * This row is 100% custom, and inherits no design or functionality from StandardTable.
-   * You must make sure that extraHeaderRow root is a <tr> and contains <td> elements.
+   * This row is 100% custom, shown as is, and inherits no design or functionality from StandardTable.
+   * You must make sure that extraHeaderRow root is a <tr>.
    * You must also make sure that it has correct number of cells, with correct padding, etc.
    */
   renderExtraRowBottom?: () => ReactNode;
@@ -175,6 +183,7 @@ export const StandardTable = function StandardTable<
   variant = "standard",
   onKeyDown,
   onSortOrderChange,
+  renderExtraHeadRows,
   ...props
 }: StandardTableProps<TItem, TColumnKey, TColumnGroupKey>) {
   const generatedTableId = useId();
@@ -313,6 +322,7 @@ export const StandardTable = function StandardTable<
                                     items={props.items}
                                     height={"var(--current-row-height)"}
                                   />
+                                  {renderExtraHeadRows?.()}
                                 </thead>
                                 <StandardTableContent
                                   variant={variant}


### PR DESCRIPTION
Add renderExtraHeadRows prop to StandardTable, allows one or several extra custom th rows in header, below ordinary header.