### PR TITLE
Add support for border variants in TextInput, just like LabelledTextInput

### DIFF
--- a/packages/forms/src/components/ui/text-input/TextInput.module.css
+++ b/packages/forms/src/components/ui/text-input/TextInput.module.css
@@ -8,6 +8,40 @@
   border-radius: var(--swui-field-border-radius);
   outline: none;
 
+  &&.onlyTop {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    border-bottom-color: transparent;
+    &:focus-within:not(.disabled) {
+      z-index: 1;
+    }
+  }
+
+  &&.onlyBottom {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    &:focus-within:not(.disabled) {
+      z-index: 1;
+    }
+  }
+
+  &&.onlyLeft {
+    border-bottom-right-radius: 0;
+    border-top-right-radius: 0;
+    border-right-color: transparent;
+    &:focus-within:not(.disabled) {
+      z-index: 1;
+    }
+  }
+
+  &&.onlyRight {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    &:focus-within:not(.disabled) {
+      z-index: 1;
+    }
+  }
+
   &&:focus-within:not(.disabled) {
     outline: var(--swui-focus-outline);
     border-color: transparent;

--- a/packages/forms/src/components/ui/text-input/TextInput.stories.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInput.stories.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { action } from "@storybook/addon-actions";
-import { Box, Text } from "@stenajs-webui/core";
+import { Box, Column, Heading, Row, Text } from "@stenajs-webui/core";
 import { TextInput, TextInputProps, TextInputVariant } from "./TextInput";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { disabledControl } from "../../../storybook-helpers/storybook-controls";
 import {
   stenaAnimals,
@@ -24,7 +24,7 @@ export default {
   },
 };
 
-export const Demo: Story<TextInputProps> = (props) => (
+export const Demo: StoryFn<TextInputProps> = (props) => (
   <TextInput {...props} placeholder={"Enter some text"} />
 );
 
@@ -245,4 +245,23 @@ export const TypeDate = () => (
   <Box width={"400px"}>
     <TextInput type={"date"} />
   </Box>
+);
+
+export const DualInput = () => (
+  <Column gap={4}>
+    <Column>
+      <Heading>Input row</Heading>
+      <Row width={"300px"}>
+        <TextInput borderRadiusVariant={"onlyLeft"} />
+        <TextInput borderRadiusVariant={"onlyRight"} />
+      </Row>
+    </Column>
+    <Column>
+      <Heading>Input column</Heading>
+      <Column width={"300px"}>
+        <TextInput borderRadiusVariant={"onlyTop"} />
+        <TextInput borderRadiusVariant={"onlyBottom"} />
+      </Column>
+    </Column>
+  </Column>
 );

--- a/packages/forms/src/components/ui/text-input/TextInput.tsx
+++ b/packages/forms/src/components/ui/text-input/TextInput.tsx
@@ -1,7 +1,10 @@
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { InputProps } from "@stenajs-webui/core";
-import { InputSpinner } from "@stenajs-webui/elements";
-import { stenaCheck, stenaExclamationTriangle } from "@stenajs-webui/elements";
+import {
+  InputSpinner,
+  stenaCheck,
+  stenaExclamationTriangle,
+} from "@stenajs-webui/elements";
 import cx from "classnames";
 import * as React from "react";
 import { ChangeEvent, CSSProperties, useRef } from "react";
@@ -10,6 +13,13 @@ import { useTextInput } from "../../../hooks/UseTextInput";
 import { FullOnChangeProps } from "../types";
 import styles from "./TextInput.module.css";
 import { TextInputIcon } from "./TextInputIcon";
+
+export type TextInputBorderVariant =
+  | "normalBorder"
+  | "onlyTop"
+  | "onlyBottom"
+  | "onlyLeft"
+  | "onlyRight";
 
 export type TextInputVariant =
   | "standard"
@@ -56,6 +66,7 @@ export interface TextInputProps
   autoFocus?: boolean;
   /** onMove callback, triggered when user tries to move outside of field using arrow keys, tab or shift+tab. */
   onMove?: (direction: MoveDirection) => void;
+  borderRadiusVariant?: TextInputBorderVariant;
 }
 
 export const TextInput: React.FC<TextInputProps> = (props) => {
@@ -88,6 +99,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
     hideBorder,
     onFocus,
     onBlur,
+    borderRadiusVariant = "normalBorder",
     ...inputProps
   } = props;
   const localRef = useRef<HTMLInputElement>(null);
@@ -122,6 +134,7 @@ export const TextInput: React.FC<TextInputProps> = (props) => {
       className={cx(
         styles.textInput,
         styles[variant],
+        styles[borderRadiusVariant],
         {
           [styles.disabled]: disabled,
         },


### PR DESCRIPTION
- This is in preparation for the new calendar, which is designed with visually connected inputs.

<img width="326" alt="image" src="https://github.com/user-attachments/assets/66b4d075-eaa5-4ae2-be3e-c23f31ab5d80">
