### PR TITLE
Fix tooltip never breaking row

### DIFF
--- a/packages/tooltip/src/components/tooltip/Tooltip.tsx
+++ b/packages/tooltip/src/components/tooltip/Tooltip.tsx
@@ -129,12 +129,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
 };
 
 const TooltipText: React.FC<{ label: string }> = ({ label }) => (
-  <Text
-    color={cssColor("--lhds-color-ui-50")}
-    size={"small"}
-    variant={"bold"}
-    whiteSpace={"nowrap"}
-  >
+  <Text color={cssColor("--lhds-color-ui-50")} size={"small"} variant={"bold"}>
     {label}
   </Text>
 );


### PR DESCRIPTION
## Before

<img width="550" alt="image" src="https://github.com/user-attachments/assets/d5ecdd1a-977e-4432-9ab7-30275d15a348">

## After

<img width="561" alt="image" src="https://github.com/user-attachments/assets/3e3e44d1-abb9-40b0-9279-53f556cb55f0">
