### PR TITLE
Click on modal scrollbar no longer closes modal

### DIFF
--- a/packages/core/src/hooks/__tests__/UseMultiOnClickOutside.test.ts
+++ b/packages/core/src/hooks/__tests__/UseMultiOnClickOutside.test.ts
@@ -3,7 +3,7 @@ import { useRef } from "react";
 import { useMultiOnClickOutside } from "../UseMultiOnClickOutside";
 import { vi } from "vitest";
 
-describe("useOnClickOutside", () => {
+describe("useMultiOnClickOutside", () => {
   const options = {
     altKey: true,
     bubbles: true,

--- a/packages/modal/src/dialog/UseDialog.tsx
+++ b/packages/modal/src/dialog/UseDialog.tsx
@@ -60,7 +60,6 @@ export function useDialog<TProps, TPromiseResolve = void>(
           rejectRef.current = reject;
         }
       );
-      console.log("SHOW");
       setClosing(false);
       setContentVisible(true);
       forceRerender();

--- a/packages/modal/src/dialog/modal/ModalDialog.module.css
+++ b/packages/modal/src/dialog/modal/ModalDialog.module.css
@@ -10,6 +10,17 @@
 
   @media (min-width: 769px) {
     border-radius: var(--swui-border-radius-large);
+
+    &::-webkit-scrollbar-thumb {
+      background-color: var(--lhds-color-ui-400);
+      border: 4px solid transparent;
+      border-radius: 8px;
+      background-clip: padding-box;
+    }
+
+    &::-webkit-scrollbar {
+      width: 16px;
+    }
   }
 
   &:not([open]) {


### PR DESCRIPTION
- Fix typo.
- Click on scrollbars in modal was registered as click outside and closed the modal.
- Scrollbars in modal caused the side of the modal to lose round corners.

## Before

![image](https://github.com/user-attachments/assets/f17006f2-2def-478e-bff7-d68ef843c232)

## After

![image](https://github.com/user-attachments/assets/c03db21e-e43a-40be-a922-77492c6e5380)
