### PR TITLE
Fix gap in Tag with icon but no label

### DIFF
--- a/packages/elements/src/components/ui/tag/Tag.tsx
+++ b/packages/elements/src/components/ui/tag/Tag.tsx
@@ -50,7 +50,7 @@ export const Tag: React.FC<TagProps> = ({
       {...getDataProps(rest)}
     >
       {icon && <FontAwesomeIcon icon={icon} className={styles.icon} />}
-      <span>{label}</span>
+      {label && <span>{label}</span>}
     </div>
   );
 };


### PR DESCRIPTION
When Tag has icon but no label, there should be no gap between icon and non-label.