### PR TITLE
Fix MonthPicker having wrong locale

### DIFF
--- a/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.tsx
@@ -110,6 +110,7 @@ export const TravelDateCalendar: React.FC<TravelDateCalendarProps> = ({
           firstMonth={firstMonthInMonthPicker}
           numMonths={numMonthsInMonthPicker}
           value={visibleMonth}
+          localeCode={localeCode}
           size={size}
           onValueChange={(v) => {
             setVisibleMonth(v);

--- a/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.tsx
@@ -118,6 +118,7 @@ export const TravelDateRangeCalendar: React.FC<
           numMonths={numMonthsInMonthPicker}
           value={visibleMonth}
           size={size}
+          localeCode={localeCode}
           onValueChange={(v) => {
             setVisibleMonth(v);
             setVisiblePanel("calendar");

--- a/packages/calendar/src/components/input-types/date-input/DateInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-input/DateInput.stories.tsx
@@ -4,13 +4,13 @@ import * as React from "react";
 import { useState } from "react";
 import { setDayStateValue } from "../../../util/calendar/StateModifier";
 import { DateInput } from "./DateInput";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 
 export default {
   title: "calendar/Input/DateInput",
   component: DateInput,
   decorators: [
-    (TheStory: Story) => (
+    (TheStory: StoryFn) => (
       <div style={{ marginBottom: "400px" }}>
         <TheStory />
       </div>

--- a/packages/calendar/src/components/input-types/date-input/DateInput.tsx
+++ b/packages/calendar/src/components/input-types/date-input/DateInput.tsx
@@ -39,8 +39,10 @@ export interface DateInputProps<T = unknown>
    */
   placeholder?: string;
   /**
-   *  Portal target, HTML element. If not set, portal is not used.
+   *  Portal target, HTML element. If not set, window.body is used.
    */
+  portalTarget?: HTMLElement;
+  zIndex?: number;
   width?: string;
   /**
    * The calendar theme to use.
@@ -68,6 +70,8 @@ export const DateInput: React.FC<DateInputProps> = ({
   minDate,
   maxDate = defaultMaxDate,
   disabled,
+  portalTarget,
+  zIndex,
 }) => {
   const { hideCalendar, showingCalendar, onSelectDate, showCalendar } =
     useDateInput(onChange, onClose, openOnMount);
@@ -78,6 +82,8 @@ export const DateInput: React.FC<DateInputProps> = ({
         hideArrow
         open={showingCalendar}
         onRequestClose={hideCalendar}
+        appendTo={portalTarget}
+        zIndex={zIndex}
         renderTrigger={(props) => (
           <Box {...props}>
             <TextInput

--- a/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-range-dual-text-input/DateRangeDualTextInput.stories.tsx
@@ -1,5 +1,5 @@
 import { Column, Txt } from "@stenajs-webui/core";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { addDays, format } from "date-fns";
 import * as React from "react";
 import { useState } from "react";
@@ -11,7 +11,7 @@ export default {
   title: "calendar/Input/DateRangeDualTextInput",
   component: DateRangeDualTextInput,
   decorators: [
-    (TheStory: Story) => (
+    (TheStory: StoryFn) => (
       <div style={{ marginBottom: "400px" }}>
         <TheStory />
       </div>
@@ -118,24 +118,6 @@ export const RangeSelected = () => {
       <DateRangeDualTextInput
         value={value}
         onValueChange={setValue}
-        {...props}
-      />
-    </div>
-  );
-};
-
-export const WithHiddenYearPagination = () => {
-  const [value, setValue] = useState<DateRange | undefined>(undefined);
-  const props = useDateRangeCalendarState();
-
-  return (
-    <div style={{ display: "inline-block" }}>
-      <DateRangeDualTextInput
-        value={value}
-        onValueChange={setValue}
-        calendarProps={{
-          hideYearPagination: true,
-        }}
         {...props}
       />
     </div>

--- a/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.stories.tsx
@@ -1,5 +1,5 @@
 import { Column } from "@stenajs-webui/core";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import { addDays, format, subDays } from "date-fns";
 import * as React from "react";
 import { useState } from "react";
@@ -10,7 +10,7 @@ export default {
   title: "calendar/Input/DateRangeInput",
   component: DateRangeInput,
   decorators: [
-    (TheStory: Story) => (
+    (TheStory: StoryFn) => (
       <div style={{ marginBottom: "400px" }}>
         <TheStory />
       </div>

--- a/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
+++ b/packages/calendar/src/components/input-types/date-range-input/DateRangeInput.tsx
@@ -64,6 +64,12 @@ export interface DateRangeInputProps<T>
    * Disables the Popover and both TextInputs.
    */
   disabled?: boolean;
+
+  /**
+   *  Portal target, HTML element. If not set, window.body is used.
+   */
+  portalTarget?: HTMLElement;
+  zIndex?: number;
 }
 
 /**
@@ -81,6 +87,8 @@ export function DateRangeInput<T>({
   minDate,
   maxDate = defaultMaxDate,
   disabled,
+  portalTarget,
+  zIndex,
 }: DateRangeInputProps<T>): React.ReactElement<DateRangeInputProps<T>> {
   const [currentPanel, setCurrentPanel] =
     useState<CalendarPanelType>("calendar");
@@ -109,6 +117,8 @@ export function DateRangeInput<T>({
   return (
     <ControlledPopover
       hideArrow
+      appendTo={portalTarget}
+      zIndex={zIndex}
       renderTrigger={(props) => (
         <Row alignItems={"center"} {...props}>
           <TextInput

--- a/packages/calendar/src/components/input-types/date-text-input/DateTextInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-text-input/DateTextInput.stories.tsx
@@ -2,13 +2,13 @@ import { Column } from "@stenajs-webui/core";
 import { DateTextInput } from "./DateTextInput";
 import * as React from "react";
 import { useState } from "react";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 
 export default {
   title: "calendar/Input/DateTextInput",
   component: DateTextInput,
   decorators: [
-    (TheStory: Story) => (
+    (TheStory: StoryFn) => (
       <div style={{ marginBottom: "400px" }}>
         <TheStory />
       </div>

--- a/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
+++ b/packages/calendar/src/components/input-types/date-text-input/DateTextInput.tsx
@@ -40,6 +40,11 @@ export interface DateTextInputProps<T>
   placeholder?: string;
   /** The date text input theme to use. */
   calendarTheme?: CalendarTheme;
+  /**
+   *  Portal target for the popover, HTML element. If not set, window.body is used.
+   */
+  portalTarget?: HTMLElement;
+  zIndex?: number;
 }
 
 export const DateTextInput: React.FC<DateTextInputProps<unknown>> = ({
@@ -56,6 +61,8 @@ export const DateTextInput: React.FC<DateTextInputProps<unknown>> = ({
   minDate,
   maxDate = defaultMaxDate,
   variant,
+  portalTarget,
+  zIndex,
   ...props
 }) => {
   const [open, setOpen] = useState(false);
@@ -107,6 +114,8 @@ export const DateTextInput: React.FC<DateTextInputProps<unknown>> = ({
   return (
     <Box width={width}>
       <ControlledPopover
+        appendTo={portalTarget}
+        zIndex={zIndex}
         renderTrigger={(popoverProps) => (
           <TextInput
             {...props}

--- a/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/date-time-input/DateTimeInput.stories.tsx
@@ -1,6 +1,6 @@
 import { Column, Indent, Row } from "@stenajs-webui/core";
 import { FlatButton, stenaTrash } from "@stenajs-webui/elements";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import * as React from "react";
 import { useState } from "react";
 import { DateTimeInput } from "./DateTimeInput";
@@ -10,7 +10,7 @@ export default {
   title: "calendar/Input/DateTimeInput",
   component: DateTimeInput,
   decorators: [
-    (TheStory: Story) => (
+    (TheStory: StoryFn) => (
       <div style={{ marginBottom: "400px", display: "inline-block" }}>
         <TheStory />
       </div>

--- a/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.tsx
@@ -230,6 +230,7 @@ export const TravelDateInput: React.FC<TravelDateInputProps> = ({
                   numMonths={numMonthsInMonthPicker}
                   value={visibleMonth}
                   size={size}
+                  localeCode={localeCode}
                   onValueChange={(v) => {
                     setVisibleMonth(v);
                     setVisiblePanel("calendar");

--- a/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.tsx
@@ -235,6 +235,7 @@ export const TravelDateRangeInput: React.FC<TravelDateRangeInputProps> = ({
                   numMonths={numMonthsInMonthPicker}
                   value={visibleMonth}
                   size={size}
+                  localeCode={localeCode}
                   onValueChange={(v) => {
                     setVisibleMonth(v);
                     setVisiblePanel("calendar");

--- a/packages/calendar/src/features/calendar-with-month-year-pickers/CalendarWithMonthYearPickers.tsx
+++ b/packages/calendar/src/features/calendar-with-month-year-pickers/CalendarWithMonthYearPickers.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@stenajs-webui/core";
 import { PrimaryButton } from "@stenajs-webui/elements";
 import * as React from "react";
-import { ReactNode, useCallback } from "react";
+import { ReactNode, useCallback, useMemo } from "react";
 import { Calendar } from "../../components/calendar/Calendar";
 import {
   CalendarProps,
@@ -11,6 +11,7 @@ import { MonthPicker } from "../month-picker/MonthPicker";
 import { CalendarPreset } from "../preset-picker/CalendarPreset";
 import { PresetPicker } from "../preset-picker/PresetPicker";
 import { CalendarPanelType } from "./CalendarPanelType";
+import { getLocaleCodeForLocale } from "../localize-date-format/LocaleMapper";
 
 interface CalendarWithMonthYearPickersProps<T>
   extends Omit<CalendarProps<T>, "date" | "year" | "month"> {
@@ -32,6 +33,12 @@ export const CalendarWithMonthYearPickers =
     renderMonthPicker,
     ...props
   }: CalendarWithMonthYearPickersProps<T>) {
+    const localeCode = useMemo(
+      () =>
+        locale == null ? "en-GB" : (getLocaleCodeForLocale(locale) ?? "en-GB"),
+      [locale],
+    );
+
     const onChangeSelectedMonth = useCallback(
       (selectedMonth: Date) => {
         if (setDateInFocus) {
@@ -70,7 +77,7 @@ export const CalendarWithMonthYearPickers =
           <MonthPicker
             value={dateInFocus}
             onValueChange={onChangeSelectedMonth}
-            locale={locale}
+            localeCode={localeCode}
             firstMonth={new Date()}
             numMonths={24}
           />

--- a/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
+++ b/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
@@ -41,3 +41,18 @@ export const getLocaleForLocaleCode = (
 export const getDefaultLocaleForFormatting = (): Locale => {
   return locales["sv"];
 };
+
+/**
+ * This is only used by old calendar components, to pass localeCode to updated components.
+ * All updated calendar components just take localeCode, for example "en-GB", since that is what the browser provides,
+ * and is not library dependent.
+ */
+export const getLocaleCodeForLocale = (locale: Locale): string | undefined => {
+  const localeCodes = Object.keys(locales);
+  for (const localeCode of localeCodes) {
+    if (locales[localeCode].code === locale.code) {
+      return localeCode;
+    }
+  }
+  return undefined;
+};

--- a/packages/calendar/src/features/month-picker/MonthPicker.stories.tsx
+++ b/packages/calendar/src/features/month-picker/MonthPicker.stories.tsx
@@ -13,6 +13,7 @@ export const Standard = () => {
   return (
     <div style={{ display: "inline-block" }}>
       <MonthPicker
+        localeCode={"en-GB"}
         value={value}
         onValueChange={setValue}
         numMonths={24}

--- a/packages/calendar/src/features/month-picker/MonthPicker.tsx
+++ b/packages/calendar/src/features/month-picker/MonthPicker.tsx
@@ -1,4 +1,3 @@
-import { enGB } from "date-fns/locale";
 import * as React from "react";
 import {
   KeyboardEventHandler,
@@ -11,14 +10,14 @@ import {
 import { ValueAndOnValueChangeProps } from "@stenajs-webui/forms";
 import { Column, exhaustSwitchCase, Heading } from "@stenajs-webui/core";
 import { MonthPickerCell } from "./MonthPickerCell";
-import { addMonths, isSameMonth, Locale } from "date-fns";
+import { addMonths, isSameMonth } from "date-fns";
 import { createMonths } from "./MonthPickerDataFactory";
 import { useToday } from "../travel-calendar/util/UseToday";
 
 export type MonthPickerSizeVariant = "small" | "medium" | "large";
 
 export interface MonthPickerProps extends ValueAndOnValueChangeProps<Date> {
-  locale?: Locale;
+  localeCode: string;
   firstMonth: Date;
   numMonths: number;
   onCancel?: () => void;
@@ -28,8 +27,8 @@ export interface MonthPickerProps extends ValueAndOnValueChangeProps<Date> {
 export const MonthPicker: React.FC<MonthPickerProps> = ({
   value,
   onValueChange,
-  locale = enGB,
   firstMonth,
+  localeCode,
   numMonths,
   onCancel,
   size = "medium",
@@ -83,7 +82,7 @@ export const MonthPicker: React.FC<MonthPickerProps> = ({
                             month={month}
                             firstAvailableMonth={firstMonth}
                             lastAvailableMonth={lastMonth}
-                            locale={locale}
+                            localeCode={localeCode}
                             selected={value ? isSameMonth(value, month) : false}
                             autoFocus={inited}
                             onClick={() => onValueChange?.(month)}

--- a/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
+++ b/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
@@ -9,19 +9,20 @@ import {
 } from "react";
 import { Row } from "@stenajs-webui/core";
 import { FlatButton, PrimaryButton } from "@stenajs-webui/elements";
-import { format, Locale } from "date-fns";
+import { format } from "date-fns";
 import {
   getDomIdForKeyboardKey,
   getDomIdForMonth,
 } from "./MonthPickerKeyboardNavigation";
 import { Position } from "./Position";
 import { MonthPickerSizeVariant } from "./MonthPicker";
+import { getLocaleForLocaleCode } from "../localize-date-format/LocaleMapper";
 
 interface MonthPickerCellProps {
   month: Date;
   onClick: () => void;
   selected: boolean;
-  locale: Locale;
+  localeCode: string;
   autoFocus: boolean;
   monthPickerId: string;
   firstAvailableMonth: Date;
@@ -34,12 +35,17 @@ export const MonthPickerCell: React.FC<MonthPickerCellProps> = ({
   month,
   onClick,
   selected,
-  locale,
+  localeCode,
   autoFocus,
   monthPickerId,
   position,
   size,
 }) => {
+  const locale = useMemo(
+    () => getLocaleForLocaleCode(localeCode) ?? getLocaleForLocaleCode("en-GB"),
+    [localeCode],
+  );
+
   const label = useMemo(
     () => startCase(format(month, "MMM", { locale })),
     [locale, month],

--- a/packages/calendar/src/features/year-picker/YearPicker.stories.tsx
+++ b/packages/calendar/src/features/year-picker/YearPicker.stories.tsx
@@ -1,14 +1,14 @@
 import * as React from "react";
 import { useState } from "react";
 import { YearPicker, YearPickerProps } from "./YearPicker";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 
 export default {
   title: "calendar/Pickers/YearPicker",
   component: YearPicker,
 };
 
-export const Demo: Story<YearPickerProps> = (props) => {
+export const Demo: StoryFn<YearPickerProps> = (props) => {
   const [value, setValue] = useState<number | undefined>(undefined);
   return (
     <div style={{ display: "inline-block" }}>


### PR DESCRIPTION
- MonthPicker now takes localeCode from browser as prop, instead of locale from date-fns.
- This is consistent with new calendar, and the components do not have props that rely on dependency types.
- Add mapping from locale to localeCode, since it is needed in old calendars that use MonthPicker.
- Add portalTarget and zIndex props to some calendars that was missing them.
- Some fixes in stories, replace Story with StoryFn.