### PR TITLE
Locale mapping falls back to language match only

### DIFF
--- a/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
+++ b/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
@@ -22,6 +22,8 @@ const locales: LocalesMap = {
   "en-GB": enGB,
   "de-AT": deAT,
   "de-DE": de,
+  "sv-SE": sv,
+  "da-DK": da,
   fr,
   de,
   es,
@@ -35,7 +37,34 @@ const locales: LocalesMap = {
 export const getLocaleForLocaleCode = (
   localeCode: string,
 ): Locale | undefined => {
-  return locales[localeCode];
+  const exactMatch = locales[localeCode];
+  if (exactMatch != null) {
+    return exactMatch;
+  }
+
+  const languageCode = getMappedLocaleCodeMatchingLanguage(localeCode);
+
+  if (languageCode != null) {
+    const languageMatch = locales[languageCode];
+    if (languageMatch != null) {
+      return languageMatch;
+    }
+  }
+
+  return undefined;
+};
+
+export const getMappedLocaleCodeMatchingLanguage = (
+  localeCode: string,
+): string | undefined => {
+  const [lang] = localeCode.split("-");
+  const localeCodes = Object.keys(locales);
+  for (const l of localeCodes) {
+    if (l.startsWith(lang)) {
+      return l;
+    }
+  }
+  return undefined;
 };
 
 export const getDefaultLocaleForFormatting = (): Locale => {

--- a/packages/calendar/src/features/localize-date-format/__tests__/LocaleMapper.test.ts
+++ b/packages/calendar/src/features/localize-date-format/__tests__/LocaleMapper.test.ts
@@ -1,0 +1,32 @@
+import {
+  getLocaleForLocaleCode,
+  getMappedLocaleCodeMatchingLanguage,
+} from "../LocaleMapper";
+import { enUS, sv } from "date-fns/locale";
+
+describe("LocaleMapper", () => {
+  describe("getLocaleForLocaleCode", () => {
+    describe("when locale exists, en-US", () => {
+      it("returns that locale", () => {
+        expect(getLocaleForLocaleCode("en-US")).toBe(enUS);
+      });
+    });
+    describe("when locale exists, sv-SE", () => {
+      it("returns that locale", () => {
+        expect(getLocaleForLocaleCode("sv-SE")).toBe(sv);
+      });
+    });
+    describe("when match for language exists, sv-FI", () => {
+      it("returns that locale", () => {
+        expect(getLocaleForLocaleCode("sv-FI")).toBe(sv);
+      });
+    });
+  });
+  describe("getMappedLocaleCodeMatchingLanguage", () => {
+    describe("when locale with same language exists", () => {
+      it("returns that locale code", () => {
+        expect(getMappedLocaleCodeMatchingLanguage("sv-FI")).toBe("sv-SE");
+      });
+    });
+  });
+});


### PR DESCRIPTION
- When locale code mapping fails, it tries to map it by language only, ignoring region.