### PR TITLE
Improve type and run-time safety for locale codes

### DIFF
--- a/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.tsx
@@ -10,10 +10,11 @@ import {
 import { useTravelDateInput } from "../../../features/travel-calendar/hooks/UseTravelDateInput";
 import { TravelDateTextInputField } from "../../../features/travel-calendar/components/TravelDateTextInputField";
 import { DateTextInputVariant } from "../../../features/travel-calendar/types";
+import { SupportedLocaleCode } from "../../../features/localize-date-format/LocaleMapper";
 
 export interface TravelDateCalendarProps
   extends ValueAndOnValueChangeProps<string> {
-  localeCode?: string;
+  localeCode?: SupportedLocaleCode;
   initialMonthInFocus?: Date;
   label?: string;
   previousMonthButtonAriaLabel?: string;

--- a/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.tsx
@@ -13,10 +13,11 @@ import {
   DateTextInputVariant,
   TravelDateRangeInputValue,
 } from "../../../features/travel-calendar/types";
+import { SupportedLocaleCode } from "../../../features/localize-date-format/LocaleMapper";
 
 export interface TravelDateRangeCalendarProps
   extends ValueAndOnValueChangeProps<TravelDateRangeInputValue> {
-  localeCode?: string;
+  localeCode?: SupportedLocaleCode;
   initialMonthInFocus?: Date;
   startDateLabel?: string;
   endDateLabel?: string;

--- a/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.tsx
@@ -26,6 +26,7 @@ import cx from "classnames";
 import { TravelDateTextInputField } from "../../../features/travel-calendar/components/TravelDateTextInputField";
 import { useTravelDateInput } from "../../../features/travel-calendar/hooks/UseTravelDateInput";
 import { DateTextInputVariant } from "../../../features/travel-calendar/types";
+import { SupportedLocaleCode } from "../../../features/localize-date-format/LocaleMapper";
 
 export interface RenderBelowSingleDateCalendarArgs {
   hideCalendar: () => void;
@@ -33,7 +34,7 @@ export interface RenderBelowSingleDateCalendarArgs {
 
 export interface TravelDateInputProps
   extends ValueAndOnValueChangeProps<string> {
-  localeCode?: string;
+  localeCode?: SupportedLocaleCode;
   initialMonthInFocus?: Date;
   label?: string;
   previousMonthButtonAriaLabel?: string;

--- a/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.tsx
@@ -29,6 +29,7 @@ import {
 } from "../../../features/travel-calendar/types";
 import styles from "./TravelDateRangeInput.module.css";
 import cx from "classnames";
+import { SupportedLocaleCode } from "../../../features/localize-date-format/LocaleMapper";
 
 export interface RenderBelowCalendarArgs {
   hideCalendar: () => void;
@@ -36,7 +37,7 @@ export interface RenderBelowCalendarArgs {
 
 export interface TravelDateRangeInputProps
   extends ValueAndOnValueChangeProps<TravelDateRangeInputValue> {
-  localeCode?: string;
+  localeCode?: SupportedLocaleCode;
   initialMonthInFocus?: Date;
   startDateLabel?: string;
   endDateLabel?: string;

--- a/packages/calendar/src/features/calendar-with-month-year-pickers/CalendarWithMonthYearPickers.tsx
+++ b/packages/calendar/src/features/calendar-with-month-year-pickers/CalendarWithMonthYearPickers.tsx
@@ -11,7 +11,10 @@ import { MonthPicker } from "../month-picker/MonthPicker";
 import { CalendarPreset } from "../preset-picker/CalendarPreset";
 import { PresetPicker } from "../preset-picker/PresetPicker";
 import { CalendarPanelType } from "./CalendarPanelType";
-import { getLocaleCodeForLocale } from "../localize-date-format/LocaleMapper";
+import {
+  getLocaleCodeForLocale,
+  SupportedLocaleCode,
+} from "../localize-date-format/LocaleMapper";
 
 interface CalendarWithMonthYearPickersProps<T>
   extends Omit<CalendarProps<T>, "date" | "year" | "month"> {
@@ -33,7 +36,7 @@ export const CalendarWithMonthYearPickers =
     renderMonthPicker,
     ...props
   }: CalendarWithMonthYearPickersProps<T>) {
-    const localeCode = useMemo(
+    const localeCode = useMemo<SupportedLocaleCode>(
       () =>
         locale == null ? "en-GB" : (getLocaleCodeForLocale(locale) ?? "en-GB"),
       [locale],

--- a/packages/calendar/src/features/localize-date-format/DateFormatProvider.ts
+++ b/packages/calendar/src/features/localize-date-format/DateFormatProvider.ts
@@ -1,7 +1,11 @@
 // Define the supported locales
 
-export const getDateFormatForLocaleCode = (locale: string): string => {
-  const formatter = new Intl.DateTimeFormat(locale, { dateStyle: "short" });
+import { SupportedLocaleCode } from "./LocaleMapper";
+
+export const getDateFormatForLocaleCode = (
+  localeCode: SupportedLocaleCode,
+): string => {
+  const formatter = new Intl.DateTimeFormat(localeCode, { dateStyle: "short" });
   const parts = formatter.formatToParts(new Date());
   const formatMap: { [key: string]: string } = {
     year: "yyyy",

--- a/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
+++ b/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
@@ -17,6 +17,22 @@ type LocalesMap = {
   [key: string]: Locale;
 };
 
+export type SupportedLocaleCode =
+  | "en-US"
+  | "en-GB"
+  | "de-AT"
+  | "de-DE"
+  | "sv-SE"
+  | "da-DK"
+  | "fr"
+  | "de"
+  | "es"
+  | "sv"
+  | "pl"
+  | "da"
+  | "nl"
+  | "nb";
+
 const locales: LocalesMap = {
   "en-US": enUS,
   "en-GB": enGB,
@@ -34,34 +50,45 @@ const locales: LocalesMap = {
   nb,
 };
 
-export const getLocaleForLocaleCode = (
+export const fallbackLocaleCode: SupportedLocaleCode = "en-GB";
+export const fallbackLocaleCodeForFormatting: SupportedLocaleCode = "sv";
+
+export const getSupportedLocaleCode = (
   localeCode: string,
-): Locale | undefined => {
-  const exactMatch = locales[localeCode];
-  if (exactMatch != null) {
-    return exactMatch;
+  matchLanguage: boolean,
+  fallback: SupportedLocaleCode,
+): SupportedLocaleCode => {
+  if (locales[localeCode]) {
+    return localeCode as SupportedLocaleCode;
   }
-
-  const languageCode = getMappedLocaleCodeMatchingLanguage(localeCode);
-
-  if (languageCode != null) {
-    const languageMatch = locales[languageCode];
-    if (languageMatch != null) {
-      return languageMatch;
+  if (matchLanguage) {
+    const languageCode = getMappedLocaleCodeMatchingLanguage(localeCode);
+    if (languageCode) {
+      return languageCode;
     }
   }
+  return fallback;
+};
 
-  return undefined;
+export interface GetLocaleForLocaleCodeOptions {
+  matchLanguage?: boolean;
+  fallbackLocaleCode?: SupportedLocaleCode;
+}
+
+export const getLocaleForLocaleCode = (
+  localeCode: SupportedLocaleCode,
+): Locale => {
+  return locales[localeCode];
 };
 
 export const getMappedLocaleCodeMatchingLanguage = (
   localeCode: string,
-): string | undefined => {
+): SupportedLocaleCode | undefined => {
   const [lang] = localeCode.split("-");
   const localeCodes = Object.keys(locales);
   for (const l of localeCodes) {
     if (l.startsWith(lang)) {
-      return l;
+      return l as SupportedLocaleCode;
     }
   }
   return undefined;
@@ -76,11 +103,13 @@ export const getDefaultLocaleForFormatting = (): Locale => {
  * All updated calendar components just take localeCode, for example "en-GB", since that is what the browser provides,
  * and is not library dependent.
  */
-export const getLocaleCodeForLocale = (locale: Locale): string | undefined => {
+export const getLocaleCodeForLocale = (
+  locale: Locale,
+): SupportedLocaleCode | undefined => {
   const localeCodes = Object.keys(locales);
   for (const localeCode of localeCodes) {
     if (locales[localeCode].code === locale.code) {
-      return localeCode;
+      return localeCode as SupportedLocaleCode;
     }
   }
   return undefined;

--- a/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
+++ b/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
@@ -62,7 +62,7 @@ export const getSupportedLocaleCode = (
     return localeCode as SupportedLocaleCode;
   }
   if (matchLanguage) {
-    const languageCode = getMappedLocaleCodeMatchingLanguage(localeCode);
+    const languageCode = getSupportedLocaleCodeMatchingLanguage(localeCode);
     if (languageCode) {
       return languageCode;
     }
@@ -76,7 +76,7 @@ export const getLocaleForLocaleCode = (
   return locales[localeCode];
 };
 
-export const getMappedLocaleCodeMatchingLanguage = (
+export const getSupportedLocaleCodeMatchingLanguage = (
   localeCode: string,
 ): SupportedLocaleCode | undefined => {
   const [lang] = localeCode.split("-");

--- a/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
+++ b/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
@@ -70,11 +70,6 @@ export const getSupportedLocaleCode = (
   return fallback;
 };
 
-export interface GetLocaleForLocaleCodeOptions {
-  matchLanguage?: boolean;
-  fallbackLocaleCode?: SupportedLocaleCode;
-}
-
 export const getLocaleForLocaleCode = (
   localeCode: SupportedLocaleCode,
 ): Locale => {

--- a/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
+++ b/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
@@ -4,11 +4,14 @@ import {
   de,
   deAT,
   enGB,
+  enIE,
   enUS,
   es,
   fr,
+  lv,
   nb,
   nl,
+  nlBE,
   pl,
   sv,
 } from "date-fns/locale";
@@ -19,16 +22,20 @@ type LocalesMap = {
 
 export type SupportedLocaleCode =
   | "en-US"
+  | "en-IE"
   | "en-GB"
   | "de-AT"
   | "de-DE"
   | "sv-SE"
   | "da-DK"
+  | "nl-BE"
+  | "lv-LV"
   | "fr"
   | "de"
   | "es"
   | "sv"
   | "pl"
+  | "lv"
   | "da"
   | "nl"
   | "nb";
@@ -36,10 +43,13 @@ export type SupportedLocaleCode =
 const locales: LocalesMap = {
   "en-US": enUS,
   "en-GB": enGB,
+  "en-IE": enIE,
   "de-AT": deAT,
   "de-DE": de,
   "sv-SE": sv,
   "da-DK": da,
+  "nl-BE": nlBE,
+  "lv-LV": lv,
   fr,
   de,
   es,
@@ -47,6 +57,7 @@ const locales: LocalesMap = {
   pl,
   da,
   nl,
+  lv,
   nb,
 };
 

--- a/packages/calendar/src/features/localize-date-format/LocalizedDateFormatter.ts
+++ b/packages/calendar/src/features/localize-date-format/LocalizedDateFormatter.ts
@@ -1,8 +1,28 @@
 import { format } from "date-fns";
 import { getDateFormatForLocaleCode } from "./DateFormatProvider";
-import { getLocaleForLocaleCode } from "./LocaleMapper";
+import {
+  fallbackLocaleCode,
+  getLocaleForLocaleCode,
+  getSupportedLocaleCode,
+  SupportedLocaleCode,
+} from "./LocaleMapper";
 
-export const formatLocalizedDate = (date: Date, localeCode: string): string =>
-  format(date, getDateFormatForLocaleCode(localeCode), {
-    locale: getLocaleForLocaleCode(localeCode),
+export interface FormatLocalizedDateOptions {
+  matchLanguage?: boolean;
+  fallbackLocaleCode?: SupportedLocaleCode;
+}
+
+export const formatLocalizedDate = (
+  date: Date,
+  localeCode: string,
+  options?: FormatLocalizedDateOptions,
+): string => {
+  const l = getSupportedLocaleCode(
+    localeCode,
+    options?.matchLanguage ?? false,
+    options?.fallbackLocaleCode ?? fallbackLocaleCode,
+  );
+  return format(date, getDateFormatForLocaleCode(l), {
+    locale: getLocaleForLocaleCode(l),
   });
+};

--- a/packages/calendar/src/features/localize-date-format/LocalizedDateParser.ts
+++ b/packages/calendar/src/features/localize-date-format/LocalizedDateParser.ts
@@ -1,13 +1,30 @@
 import { parse } from "date-fns";
 import { getDateFormatForLocaleCode } from "./DateFormatProvider";
-import { getLocaleForLocaleCode } from "./LocaleMapper";
+import {
+  fallbackLocaleCode,
+  getLocaleForLocaleCode,
+  getSupportedLocaleCode,
+  SupportedLocaleCode,
+} from "./LocaleMapper";
+
+interface ParseLocalizedDateStringOptions {
+  matchLanguage?: boolean;
+  fallbackLocaleCode?: SupportedLocaleCode;
+  referenceDate?: Date;
+}
 
 export const parseLocalizedDateString = (
   dateString: string,
   localeCode: string,
-  referenceDate?: Date,
+  options?: ParseLocalizedDateStringOptions,
 ): Date | undefined => {
-  const locale = getLocaleForLocaleCode(localeCode);
+  const supportedLocaleCode = getSupportedLocaleCode(
+    localeCode,
+    options?.matchLanguage ?? false,
+    options?.fallbackLocaleCode ?? fallbackLocaleCode,
+  );
+
+  const locale = getLocaleForLocaleCode(supportedLocaleCode);
 
   if (locale == null) {
     return undefined;
@@ -15,8 +32,8 @@ export const parseLocalizedDateString = (
 
   const date = parse(
     dateString,
-    getDateFormatForLocaleCode(localeCode),
-    referenceDate ?? new Date(),
+    getDateFormatForLocaleCode(supportedLocaleCode),
+    options?.referenceDate ?? new Date(),
     {
       locale: locale,
     },

--- a/packages/calendar/src/features/localize-date-format/__tests__/LocaleMapper.test.ts
+++ b/packages/calendar/src/features/localize-date-format/__tests__/LocaleMapper.test.ts
@@ -1,6 +1,6 @@
 import {
   getLocaleForLocaleCode,
-  getMappedLocaleCodeMatchingLanguage,
+  getSupportedLocaleCodeMatchingLanguage,
   getSupportedLocaleCode,
 } from "../LocaleMapper";
 import { enUS, sv } from "date-fns/locale";
@@ -19,7 +19,7 @@ describe("LocaleMapper", () => {
   describe("getMappedLocaleCodeMatchingLanguage", () => {
     describe("when locale with same language exists", () => {
       it("returns that locale code", () => {
-        expect(getMappedLocaleCodeMatchingLanguage("sv-FI")).toBe("sv-SE");
+        expect(getSupportedLocaleCodeMatchingLanguage("sv-FI")).toBe("sv-SE");
       });
     });
   });

--- a/packages/calendar/src/features/localize-date-format/__tests__/LocaleMapper.test.ts
+++ b/packages/calendar/src/features/localize-date-format/__tests__/LocaleMapper.test.ts
@@ -1,31 +1,60 @@
 import {
   getLocaleForLocaleCode,
   getMappedLocaleCodeMatchingLanguage,
+  getSupportedLocaleCode,
 } from "../LocaleMapper";
 import { enUS, sv } from "date-fns/locale";
 
 describe("LocaleMapper", () => {
   describe("getLocaleForLocaleCode", () => {
-    describe("when locale exists, en-US", () => {
-      it("returns that locale", () => {
-        expect(getLocaleForLocaleCode("en-US")).toBe(enUS);
-      });
+    it("returns that locale", () => {
+      expect(getLocaleForLocaleCode("en-US")).toBe(enUS);
     });
-    describe("when locale exists, sv-SE", () => {
-      it("returns that locale", () => {
-        expect(getLocaleForLocaleCode("sv-SE")).toBe(sv);
-      });
-    });
-    describe("when match for language exists, sv-FI", () => {
-      it("returns that locale", () => {
-        expect(getLocaleForLocaleCode("sv-FI")).toBe(sv);
-      });
+  });
+  describe("when locale exists, sv-SE", () => {
+    it("returns that locale", () => {
+      expect(getLocaleForLocaleCode("sv-SE")).toBe(sv);
     });
   });
   describe("getMappedLocaleCodeMatchingLanguage", () => {
     describe("when locale with same language exists", () => {
       it("returns that locale code", () => {
         expect(getMappedLocaleCodeMatchingLanguage("sv-FI")).toBe("sv-SE");
+      });
+    });
+  });
+  describe("getSupportedLocaleCode", () => {
+    describe("when exact match exists, sv-SE", () => {
+      it("returns that locale", () => {
+        expect(getSupportedLocaleCode("sv-SE", true, "en-GB")).toBe("sv-SE");
+      });
+    });
+    describe("when language matching is disabled", () => {
+      describe("when language match exists", () => {
+        it("returns the fallback", () => {
+          expect(getSupportedLocaleCode("sv-FI", false, "en-GB")).toBe("en-GB");
+        });
+      });
+      describe("when no match", () => {
+        it("returns the fallback", () => {
+          expect(getSupportedLocaleCode("abcdabcd", false, "en-GB")).toBe(
+            "en-GB",
+          );
+        });
+      });
+    });
+    describe("when language matching is enabled", () => {
+      describe("when language match exists", () => {
+        it("returns the matched code", () => {
+          expect(getSupportedLocaleCode("sv-FI", true, "en-GB")).toBe("sv-SE");
+        });
+      });
+      describe("when no match", () => {
+        it("returns the fallback", () => {
+          expect(getSupportedLocaleCode("abcdabcd", false, "en-GB")).toBe(
+            "en-GB",
+          );
+        });
       });
     });
   });

--- a/packages/calendar/src/features/month-picker/MonthPicker.tsx
+++ b/packages/calendar/src/features/month-picker/MonthPicker.tsx
@@ -13,11 +13,12 @@ import { MonthPickerCell } from "./MonthPickerCell";
 import { addMonths, isSameMonth } from "date-fns";
 import { createMonths } from "./MonthPickerDataFactory";
 import { useToday } from "../travel-calendar/util/UseToday";
+import { SupportedLocaleCode } from "../localize-date-format/LocaleMapper";
 
 export type MonthPickerSizeVariant = "small" | "medium" | "large";
 
 export interface MonthPickerProps extends ValueAndOnValueChangeProps<Date> {
-  localeCode: string;
+  localeCode: SupportedLocaleCode;
   firstMonth: Date;
   numMonths: number;
   onCancel?: () => void;

--- a/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
+++ b/packages/calendar/src/features/month-picker/MonthPickerCell.tsx
@@ -16,13 +16,16 @@ import {
 } from "./MonthPickerKeyboardNavigation";
 import { Position } from "./Position";
 import { MonthPickerSizeVariant } from "./MonthPicker";
-import { getLocaleForLocaleCode } from "../localize-date-format/LocaleMapper";
+import {
+  getLocaleForLocaleCode,
+  SupportedLocaleCode,
+} from "../localize-date-format/LocaleMapper";
 
 interface MonthPickerCellProps {
   month: Date;
   onClick: () => void;
   selected: boolean;
-  localeCode: string;
+  localeCode: SupportedLocaleCode;
   autoFocus: boolean;
   monthPickerId: string;
   firstAvailableMonth: Date;

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateRangeTextInputFields.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateRangeTextInputFields.tsx
@@ -7,13 +7,14 @@ import { getDateFormatForLocaleCode } from "../../localize-date-format/DateForma
 import { reformatLocalizedDateString } from "../../localize-date-format/LocalizedDateReformatter";
 import { DateTextInputVariant, TravelDateRangeInputValue } from "../types";
 import { TravelCalendarSizeVariant } from "./TravelCalendar";
+import { SupportedLocaleCode } from "../../localize-date-format/LocaleMapper";
 
 export interface TravelDateRangeTextInputFieldsProps {
   value: TravelDateRangeInputValue | undefined;
   onValueChange:
     | ((value: Partial<TravelDateRangeInputValue>) => void)
     | undefined;
-  localeCode: string;
+  localeCode: SupportedLocaleCode;
   startDateLabel?: string;
   endDateLabel?: string;
   onFocus?: () => void;

--- a/packages/calendar/src/features/travel-calendar/components/TravelDateTextInputField.tsx
+++ b/packages/calendar/src/features/travel-calendar/components/TravelDateTextInputField.tsx
@@ -7,11 +7,12 @@ import { getDateFormatForLocaleCode } from "../../localize-date-format/DateForma
 import { reformatLocalizedDateString } from "../../localize-date-format/LocalizedDateReformatter";
 import { TravelCalendarSizeVariant } from "./TravelCalendar";
 import { DateTextInputVariant } from "../types";
+import { SupportedLocaleCode } from "../../localize-date-format/LocaleMapper";
 
 export interface TravelDateTextInputFieldProps {
   value: string | undefined;
   onValueChange: ((value: string) => void) | undefined;
-  localeCode: string;
+  localeCode: SupportedLocaleCode;
   label?: string;
   onFocus?: () => void;
   calendarSize: TravelCalendarSizeVariant;

--- a/packages/calendar/src/features/travel-calendar/hooks/UseTravelDateInput.ts
+++ b/packages/calendar/src/features/travel-calendar/hooks/UseTravelDateInput.ts
@@ -1,6 +1,6 @@
 import {
-  getDefaultLocaleForFormatting,
   getLocaleForLocaleCode,
+  SupportedLocaleCode,
 } from "../../localize-date-format/LocaleMapper";
 import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { useToday } from "../util/UseToday";
@@ -16,11 +16,10 @@ import { formatDateDescription } from "../util/DateDescriptionFormatter";
 export const useTravelDateInput = (
   value: string | undefined,
   onValueChange: ((value: string) => void) | undefined,
-  localeCode: string,
+  localeCode: SupportedLocaleCode,
   initialMonthInFocus: Date | undefined,
 ) => {
-  const locale =
-    getLocaleForLocaleCode(localeCode) ?? getDefaultLocaleForFormatting();
+  const locale = getLocaleForLocaleCode(localeCode);
 
   const calendarId = useId();
   const today = useToday();

--- a/packages/calendar/src/features/travel-calendar/hooks/UseTravelDateRangeInput.ts
+++ b/packages/calendar/src/features/travel-calendar/hooks/UseTravelDateRangeInput.ts
@@ -1,6 +1,6 @@
 import {
-  getDefaultLocaleForFormatting,
   getLocaleForLocaleCode,
+  SupportedLocaleCode,
 } from "../../localize-date-format/LocaleMapper";
 import { useCallback, useId, useMemo, useRef, useState } from "react";
 import { useToday } from "../util/UseToday";
@@ -16,11 +16,10 @@ import { formatDateDescription } from "../util/DateDescriptionFormatter";
 export const useTravelDateRangeInput = (
   value: TravelDateRangeInputValue | undefined,
   onValueChange: ((value: TravelDateRangeInputValue) => void) | undefined,
-  localeCode: string,
+  localeCode: SupportedLocaleCode,
   initialMonthInFocus: Date | undefined,
 ) => {
-  const locale =
-    getLocaleForLocaleCode(localeCode) ?? getDefaultLocaleForFormatting();
+  const locale = getLocaleForLocaleCode(localeCode);
 
   const calendarId = useId();
   const today = useToday();


### PR DESCRIPTION
- Locale code props are now typed, with only supported locale codes.
- Add getSupportedLocaleCode() which helps resolve supported locale type from any string.