### PR TITLE
Fix asymmetric padding in Tag when there is no label.

### DIFF
--- a/packages/elements/src/components/ui/tag/Tag.module.css
+++ b/packages/elements/src/components/ui/tag/Tag.module.css
@@ -22,6 +22,10 @@
   &.medium {
     &.withIcon {
       padding-left: var(--swui-metrics-indent);
+
+      &.noLabel {
+        padding-right: var(--swui-metrics-indent);
+      }
     }
   }
 

--- a/packages/elements/src/components/ui/tag/Tag.stories.tsx
+++ b/packages/elements/src/components/ui/tag/Tag.stories.tsx
@@ -1,5 +1,5 @@
 import { Column, Indent, Row, Space, Text } from "@stenajs-webui/core";
-import { Story } from "@storybook/react";
+import { StoryFn } from "@storybook/react";
 import * as React from "react";
 import { CSSProperties } from "react";
 import { disabledControl } from "../../../storybook-helpers/storybook-controls";
@@ -49,6 +49,12 @@ export const Overview = () => (
                     label={"Default"}
                     icon={stenaSailingOnQuay}
                   />
+                  <Indent />
+                  <Tag
+                    size={size}
+                    variant={variant}
+                    icon={stenaSailingOnQuay}
+                  />
                 </Row>
               ))}
 
@@ -61,7 +67,7 @@ export const Overview = () => (
   </>
 );
 
-export const CustomTheme: Story<TagProps> = () => (
+export const CustomTheme: StoryFn<TagProps> = () => (
   <Tag
     style={
       {

--- a/packages/elements/src/components/ui/tag/Tag.tsx
+++ b/packages/elements/src/components/ui/tag/Tag.tsx
@@ -44,6 +44,7 @@ export const Tag: React.FC<TagProps> = ({
         styles[variant],
         styles[size],
         icon && styles.withIcon,
+        !label && styles.noLabel,
         className,
       )}
       style={style}


### PR DESCRIPTION
- Update stories to also show Tag with no label.

<img width="351" alt="image" src="https://github.com/user-attachments/assets/fd48aa11-8ab7-490d-ae4e-165d78a18cc3">
