### PR TITLE
Add support for more locales

### DIFF
--- a/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-calendar/TravelDateCalendar.stories.tsx
@@ -6,6 +6,7 @@ import { Column, Heading, Row, Spacing } from "@stenajs-webui/core";
 import { Banner, Label } from "@stenajs-webui/elements";
 import { parseLocalizedDateString } from "../../../features/localize-date-format/LocalizedDateParser";
 import { isToday } from "date-fns";
+import { SupportedLocaleCode } from "../../../features/localize-date-format/LocaleMapper";
 
 export default {
   title: "calendar/Calendar/TravelDateCalendar",
@@ -92,19 +93,26 @@ export const WithTestIds = () => {
 };
 
 export const Locales = () => {
-  const locales = [
-    "sv",
-    "da",
-    "en-GB",
-    "pl",
-    "nl",
+  const locales: Array<SupportedLocaleCode> = [
     "en-US",
+    "en-GB",
+    "en-IE",
     "de-AT",
+    "nl-BE",
+    "nl-NL",
     "de-DE",
-    "fr",
-    "de",
-    "es",
-    "nb",
+    "nb-NO",
+    "sv-SE",
+    "da-DK",
+    "lv-LV",
+    "lt-LT",
+    "it-IT",
+    "et-EE",
+    "fi-FI",
+    "cs-CZ",
+    "es-ES",
+    "fr-FR",
+    "pl-PL",
   ];
 
   return (
@@ -116,7 +124,7 @@ export const Locales = () => {
   );
 };
 
-const LocaleDemo = ({ localeCode }: { localeCode: string }) => {
+const LocaleDemo = ({ localeCode }: { localeCode: SupportedLocaleCode }) => {
   const [value, setValue] = useState<string>("");
 
   return (

--- a/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.stories.tsx
+++ b/packages/calendar/src/components/calendar-types/travel-date-range-calendar/TravelDateRangeCalendar.stories.tsx
@@ -7,6 +7,7 @@ import { Banner, Label } from "@stenajs-webui/elements";
 import { TravelDateRangeInputValue } from "../../../features/travel-calendar/types";
 import { parseLocalizedDateString } from "../../../features/localize-date-format/LocalizedDateParser";
 import { isToday } from "date-fns";
+import { SupportedLocaleCode } from "../../../features/localize-date-format/LocaleMapper";
 
 export default {
   title: "calendar/Calendar/TravelDateRangeCalendar",
@@ -100,19 +101,26 @@ export const WithTestIds = () => {
 };
 
 export const Locales = () => {
-  const locales = [
-    "sv",
-    "da",
-    "en-GB",
-    "pl",
-    "nl",
+  const locales: Array<SupportedLocaleCode> = [
     "en-US",
+    "en-GB",
+    "en-IE",
     "de-AT",
+    "nl-BE",
+    "nl-NL",
     "de-DE",
-    "fr",
-    "de",
-    "es",
-    "nb",
+    "nb-NO",
+    "sv-SE",
+    "da-DK",
+    "lv-LV",
+    "lt-LT",
+    "it-IT",
+    "et-EE",
+    "fi-FI",
+    "cs-CZ",
+    "es-ES",
+    "fr-FR",
+    "pl-PL",
   ];
 
   return (
@@ -124,7 +132,7 @@ export const Locales = () => {
   );
 };
 
-const LocaleDemo = ({ localeCode }: { localeCode: string }) => {
+const LocaleDemo = ({ localeCode }: { localeCode: SupportedLocaleCode }) => {
   const [value, setValue] = useState<TravelDateRangeInputValue | undefined>(
     undefined,
   );

--- a/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-input/TravelDateInput.stories.tsx
@@ -12,6 +12,7 @@ import {
 import { parseLocalizedDateString } from "../../../features/localize-date-format/LocalizedDateParser";
 import { formatLocalizedDate } from "../../../features/localize-date-format/LocalizedDateFormatter";
 import { addDays, isToday } from "date-fns";
+import { SupportedLocaleCode } from "../../../features/localize-date-format/LocaleMapper";
 
 export default {
   title: "calendar/Input/TravelDateInput",
@@ -160,19 +161,26 @@ export const ParseDate = () => {
 };
 
 export const Locales = () => {
-  const locales = [
-    "sv",
-    "da",
-    "en-GB",
-    "pl",
-    "nl",
+  const locales: Array<SupportedLocaleCode> = [
     "en-US",
+    "en-GB",
+    "en-IE",
     "de-AT",
+    "nl-BE",
+    "nl-NL",
     "de-DE",
-    "fr",
-    "de",
-    "es",
-    "nb",
+    "nb-NO",
+    "sv-SE",
+    "da-DK",
+    "lv-LV",
+    "lt-LT",
+    "it-IT",
+    "et-EE",
+    "fi-FI",
+    "cs-CZ",
+    "es-ES",
+    "fr-FR",
+    "pl-PL",
   ];
 
   return (
@@ -184,7 +192,7 @@ export const Locales = () => {
   );
 };
 
-const LocaleDemo = ({ localeCode }: { localeCode: string }) => {
+const LocaleDemo = ({ localeCode }: { localeCode: SupportedLocaleCode }) => {
   const [value, setValue] = useState<string>("");
 
   return (

--- a/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.stories.tsx
+++ b/packages/calendar/src/components/input-types/travel-date-range-input/TravelDateRangeInput.stories.tsx
@@ -13,6 +13,7 @@ import { TravelDateRangeInputValue } from "../../../features/travel-calendar/typ
 import { parseLocalizedDateString } from "../../../features/localize-date-format/LocalizedDateParser";
 import { formatLocalizedDate } from "../../../features/localize-date-format/LocalizedDateFormatter";
 import { addWeeks, isToday } from "date-fns";
+import { SupportedLocaleCode } from "../../../features/localize-date-format/LocaleMapper";
 
 export default {
   title: "calendar/Input/TravelDateRangeInput",
@@ -171,19 +172,26 @@ export const ParseDate = () => {
 };
 
 export const Locales = () => {
-  const locales = [
-    "sv",
-    "da",
-    "en-GB",
-    "pl",
-    "nl",
+  const locales: Array<SupportedLocaleCode> = [
     "en-US",
+    "en-GB",
+    "en-IE",
     "de-AT",
+    "nl-BE",
+    "nl-NL",
     "de-DE",
-    "fr",
-    "de",
-    "es",
-    "nb",
+    "nb-NO",
+    "sv-SE",
+    "da-DK",
+    "lv-LV",
+    "lt-LT",
+    "it-IT",
+    "et-EE",
+    "fi-FI",
+    "cs-CZ",
+    "es-ES",
+    "fr-FR",
+    "pl-PL",
   ];
 
   return (
@@ -195,7 +203,7 @@ export const Locales = () => {
   );
 };
 
-const LocaleDemo = ({ localeCode }: { localeCode: string }) => {
+const LocaleDemo = ({ localeCode }: { localeCode: SupportedLocaleCode }) => {
   const [value, setValue] = useState<TravelDateRangeInputValue | undefined>(
     undefined,
   );

--- a/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
+++ b/packages/calendar/src/features/localize-date-format/LocaleMapper.ts
@@ -7,12 +7,17 @@ import {
   enIE,
   enUS,
   es,
+  cs,
+  it,
+  fi,
   fr,
   lv,
   nb,
   nl,
+  et,
   nlBE,
   pl,
+  lt,
   sv,
 } from "date-fns/locale";
 
@@ -21,44 +26,76 @@ type LocalesMap = {
 };
 
 export type SupportedLocaleCode =
+  | "en"
   | "en-US"
-  | "en-IE"
   | "en-GB"
+  | "en-IE"
   | "de-AT"
+  | "nl-BE"
+  | "nl-NL"
   | "de-DE"
+  | "nb-NO"
   | "sv-SE"
   | "da-DK"
-  | "nl-BE"
   | "lv-LV"
-  | "fr"
-  | "de"
-  | "es"
-  | "sv"
-  | "pl"
-  | "lv"
-  | "da"
+  | "lt-LT"
+  | "it-IT"
+  | "et-EE"
+  | "fi-FI"
+  | "cs-CZ"
+  | "es-ES"
+  | "fr-FR"
+  | "pl-PL"
   | "nl"
-  | "nb";
+  | "de"
+  | "nb"
+  | "sv"
+  | "da"
+  | "lv"
+  | "lt"
+  | "it"
+  | "et"
+  | "fi"
+  | "cs"
+  | "es"
+  | "fr"
+  | "pl";
 
 const locales: LocalesMap = {
+  en: enGB,
   "en-US": enUS,
   "en-GB": enGB,
   "en-IE": enIE,
   "de-AT": deAT,
+  "nl-BE": nlBE,
+  "nl-NL": nl,
   "de-DE": de,
+  "nb-NO": nb,
   "sv-SE": sv,
   "da-DK": da,
-  "nl-BE": nlBE,
   "lv-LV": lv,
-  fr,
-  de,
-  es,
-  sv,
-  pl,
-  da,
+  "lt-LT": lt,
+  "it-IT": it,
+  "et-EE": et,
+  "fi-FI": fi,
+  "cs-CZ": cs,
+  "es-ES": es,
+  "fr-FR": fr,
+  "pl-PL": pl,
   nl,
-  lv,
+  de,
   nb,
+  sv,
+  da,
+  lv,
+  lt,
+  it,
+  et,
+  fi,
+  cs,
+  es,
+  fr,
+  pl,
 };
 
 export const fallbackLocaleCode: SupportedLocaleCode = "en-GB";

--- a/packages/modal/src/dialog/Dialog.mdx
+++ b/packages/modal/src/dialog/Dialog.mdx
@@ -83,6 +83,11 @@ Under the hood, this will use the ordinary `<Modal>` component, but wrapped with
 The only caveats are that you will lose the animations that are applied to the dialog elements,
 and you might have to deal with stacking contexts (z-index) manually, depending on your application.
 
+### This is for modal only
+
+Since `divInsteadOfDialog` will use `<Modal>`, it will get the behaviour and design of `<Modal>`.
+If you need for example `<Alert>`, just use `<Alert>`. Do not use `useAlertDialog` with `divInsteadOfDialog` set to true.
+
 ## Usage
 
 ### show()


### PR DESCRIPTION
- Update locale mapping, with support for all locales used by Stena websites.
- Add doc explaining that divInsteadOfDialog only works with modals, not alerts or drawers.